### PR TITLE
Fix missing ClipboardEntry type reference

### DIFF
--- a/PdfEditor/Models/ClipboardEntry.cs
+++ b/PdfEditor/Models/ClipboardEntry.cs
@@ -1,0 +1,29 @@
+using System;
+using ReactiveUI;
+
+namespace PdfEditor.Models;
+
+public class ClipboardEntry : ReactiveObject
+{
+    private string _text = string.Empty;
+    private DateTime _timestamp;
+    private int _pageNumber;
+
+    public string Text
+    {
+        get => _text;
+        set => this.RaiseAndSetIfChanged(ref _text, value);
+    }
+
+    public DateTime Timestamp
+    {
+        get => _timestamp;
+        set => this.RaiseAndSetIfChanged(ref _timestamp, value);
+    }
+
+    public int PageNumber
+    {
+        get => _pageNumber;
+        set => this.RaiseAndSetIfChanged(ref _pageNumber, value);
+    }
+}


### PR DESCRIPTION
The MainWindowViewModel was referencing a ClipboardEntry type that didn't exist, causing a compilation error. Created the ClipboardEntry model class with the required properties (Text, Timestamp, PageNumber) following the existing code patterns used in PageThumbnail.cs.