### PR TITLE
Fix NuGet package version conflicts in demo

### DIFF
--- a/PdfEditor.Demo/PdfEditor.Demo.csproj
+++ b/PdfEditor.Demo/PdfEditor.Demo.csproj
@@ -12,11 +12,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="PdfSharp" Version="1.50.5147" />
-    <PackageReference Include="PdfSharpCore" Version="1.3.65" />
+    <PackageReference Include="PDFsharp" Version="6.2.2" />
     <PackageReference Include="PdfPig" Version="0.1.11" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Updated package references to match main PdfEditor project:
- PDFsharp: 1.50.5147 → 6.2.2 (fixed casing and version)
- Microsoft.Extensions.Logging: 8.0.0 → 8.0.1
- Microsoft.Extensions.Logging.Console: 8.0.0 → 8.0.1
- Removed PdfSharpCore (inherited from PdfEditor reference)

Resolves package downgrade errors that prevented demo build.