### PR TITLE
Install .NET 8 SDK and run tests

### DIFF
--- a/PdfEditor.Tests/Integration/BlindRedactionVerificationTests.cs
+++ b/PdfEditor.Tests/Integration/BlindRedactionVerificationTests.cs
@@ -315,7 +315,7 @@ public class BlindRedactionVerificationTests : IDisposable
     {
         var textItems = new List<GridTextItem>();
 
-        var document = new PdfDocument();
+        var document = new PdfSharp.Pdf.PdfDocument();
         var page = document.AddPage();
         page.Width = XUnit.FromPoint(612);  // Letter size
         page.Height = XUnit.FromPoint(792);
@@ -344,7 +344,7 @@ public class BlindRedactionVerificationTests : IDisposable
 
     private void CreateSmallGridPdf(string outputPath, int rows, int cols)
     {
-        var document = new PdfDocument();
+        var document = new PdfSharp.Pdf.PdfDocument();
         var page = document.AddPage();
 
         using var gfx = XGraphics.FromPdfPage(page);
@@ -366,7 +366,7 @@ public class BlindRedactionVerificationTests : IDisposable
 
     private void CreateSimpleGridPdf(string outputPath, string text, double x, double y)
     {
-        var document = new PdfDocument();
+        var document = new PdfSharp.Pdf.PdfDocument();
         var page = document.AddPage();
 
         using var gfx = XGraphics.FromPdfPage(page);
@@ -482,12 +482,15 @@ public class BlindRedactionVerificationTests : IDisposable
         if (page.Contents.Elements.Count > 0)
         {
             var content = page.Contents.Elements.GetObject(0);
-            if (content is PdfSharp.Pdf.Advanced.PdfDictionary dict)
+            // Use reflection or direct stream access based on content type
+            var streamProp = content?.GetType().GetProperty("Stream");
+            if (streamProp != null)
             {
-                var stream = dict.Stream;
-                if (stream != null)
+                var stream = streamProp.GetValue(content);
+                var valueProp = stream?.GetType().GetProperty("Value");
+                if (valueProp != null)
                 {
-                    return stream.Value;
+                    return valueProp.GetValue(stream) as byte[] ?? Array.Empty<byte>();
                 }
             }
         }

--- a/PdfEditor.Tests/Integration/ExportFunctionalityTests.cs
+++ b/PdfEditor.Tests/Integration/ExportFunctionalityTests.cs
@@ -27,7 +27,7 @@ public class ExportFunctionalityTests : IDisposable
 
         // Create a test PDF with 3 pages
         _testPdfPath = Path.Combine(_testOutputDir, "export_test.pdf");
-        TestPdfGenerator.CreateSimplePdf(_testPdfPath, pageCount: 3);
+        TestPdfGenerator.CreateSimpleTextPdf(_testPdfPath, pageCount: 3);
     }
 
     [Fact]
@@ -128,7 +128,7 @@ public class ExportFunctionalityTests : IDisposable
         Directory.CreateDirectory(exportDir);
 
         var multiPagePdf = Path.Combine(_testOutputDir, "multi_page.pdf");
-        TestPdfGenerator.CreateSimplePdf(multiPagePdf, pageCount: 10);
+        TestPdfGenerator.CreateSimpleTextPdf(multiPagePdf, pageCount: 10);
 
         _documentService.LoadDocument(multiPagePdf);
 

--- a/PdfEditor.Tests/Integration/FileOperationsTests.cs
+++ b/PdfEditor.Tests/Integration/FileOperationsTests.cs
@@ -29,7 +29,7 @@ public class FileOperationsTests : IDisposable
         var sourcePdf = Path.Combine(_testOutputDir, "source.pdf");
         var destinationPdf = Path.Combine(_testOutputDir, "destination.pdf");
 
-        TestPdfGenerator.CreateSimplePdf(sourcePdf, pageCount: 3);
+        TestPdfGenerator.CreateSimpleTextPdf(sourcePdf, pageCount: 3);
         _documentService.LoadDocument(sourcePdf);
 
         // Act
@@ -49,7 +49,7 @@ public class FileOperationsTests : IDisposable
         var sourcePdf = Path.Combine(_testOutputDir, "source_mod.pdf");
         var destinationPdf = Path.Combine(_testOutputDir, "destination_mod.pdf");
 
-        TestPdfGenerator.CreateSimplePdf(sourcePdf, pageCount: 5);
+        TestPdfGenerator.CreateSimpleTextPdf(sourcePdf, pageCount: 5);
         _documentService.LoadDocument(sourcePdf);
 
         // Act - Modify and save
@@ -68,7 +68,7 @@ public class FileOperationsTests : IDisposable
     {
         // Arrange
         var pdfPath = Path.Combine(_testOutputDir, "close_test.pdf");
-        TestPdfGenerator.CreateSimplePdf(pdfPath, pageCount: 2);
+        TestPdfGenerator.CreateSimpleTextPdf(pdfPath, pageCount: 2);
         _documentService.LoadDocument(pdfPath);
 
         _documentService.IsDocumentLoaded.Should().BeTrue();
@@ -88,8 +88,8 @@ public class FileOperationsTests : IDisposable
         var pdf1 = Path.Combine(_testOutputDir, "doc1.pdf");
         var pdf2 = Path.Combine(_testOutputDir, "doc2.pdf");
 
-        TestPdfGenerator.CreateSimplePdf(pdf1, pageCount: 2);
-        TestPdfGenerator.CreateSimplePdf(pdf2, pageCount: 3);
+        TestPdfGenerator.CreateSimpleTextPdf(pdf1, pageCount: 2);
+        TestPdfGenerator.CreateSimpleTextPdf(pdf2, pageCount: 3);
 
         // Act
         _documentService.LoadDocument(pdf1);
@@ -109,7 +109,7 @@ public class FileOperationsTests : IDisposable
     {
         // Arrange
         var pdfPath = Path.Combine(_testOutputDir, "overwrite.pdf");
-        TestPdfGenerator.CreateSimplePdf(pdfPath, pageCount: 5);
+        TestPdfGenerator.CreateSimpleTextPdf(pdfPath, pageCount: 5);
 
         _documentService.LoadDocument(pdfPath);
 
@@ -132,8 +132,8 @@ public class FileOperationsTests : IDisposable
         var pdf2 = Path.Combine(_testOutputDir, "add_pages_from.pdf");
         var resultPdf = Path.Combine(_testOutputDir, "add_result.pdf");
 
-        TestPdfGenerator.CreateSimplePdf(pdf1, pageCount: 2);
-        TestPdfGenerator.CreateSimplePdf(pdf2, pageCount: 3);
+        TestPdfGenerator.CreateSimpleTextPdf(pdf1, pageCount: 2);
+        TestPdfGenerator.CreateSimpleTextPdf(pdf2, pageCount: 3);
 
         _documentService.LoadDocument(pdf1);
 

--- a/PdfEditor.Tests/Integration/PdfConformanceTests.cs
+++ b/PdfEditor.Tests/Integration/PdfConformanceTests.cs
@@ -44,7 +44,7 @@ public class PdfConformanceTests : IDisposable
     {
         // Arrange
         var pdfPath = Path.Combine(_testOutputDir, "basic.pdf");
-        TestPdfGenerator.CreateSimplePdf(pdfPath, pageCount: 1);
+        TestPdfGenerator.CreateSimpleTextPdf(pdfPath, pageCount: 1);
 
         // Act
         _documentService.LoadDocument(pdfPath);
@@ -59,7 +59,7 @@ public class PdfConformanceTests : IDisposable
     {
         // Arrange
         var pdfPath = Path.Combine(_testOutputDir, "render.pdf");
-        TestPdfGenerator.CreateSimplePdf(pdfPath, pageCount: 2);
+        TestPdfGenerator.CreateSimpleTextPdf(pdfPath, pageCount: 2);
 
         // Act
         var bitmap = await _renderService.RenderPageAsync(pdfPath, 0);
@@ -104,7 +104,7 @@ public class PdfConformanceTests : IDisposable
     {
         // Arrange
         var pdfPath = Path.Combine(_testOutputDir, "modify.pdf");
-        TestPdfGenerator.CreateSimplePdf(pdfPath, pageCount: 3);
+        TestPdfGenerator.CreateSimpleTextPdf(pdfPath, pageCount: 3);
 
         _documentService.LoadDocument(pdfPath);
         var originalCount = _documentService.PageCount;
@@ -123,8 +123,8 @@ public class PdfConformanceTests : IDisposable
         var pdf1 = Path.Combine(_testOutputDir, "add1.pdf");
         var pdf2 = Path.Combine(_testOutputDir, "add2.pdf");
 
-        TestPdfGenerator.CreateSimplePdf(pdf1, pageCount: 2);
-        TestPdfGenerator.CreateSimplePdf(pdf2, pageCount: 3);
+        TestPdfGenerator.CreateSimpleTextPdf(pdf1, pageCount: 2);
+        TestPdfGenerator.CreateSimpleTextPdf(pdf2, pageCount: 3);
 
         _documentService.LoadDocument(pdf1);
         var originalCount = _documentService.PageCount;
@@ -143,7 +143,7 @@ public class PdfConformanceTests : IDisposable
         var pdfPath = Path.Combine(_testOutputDir, "save_mod.pdf");
         var savePath = Path.Combine(_testOutputDir, "save_mod_result.pdf");
 
-        TestPdfGenerator.CreateSimplePdf(pdfPath, pageCount: 5);
+        TestPdfGenerator.CreateSimpleTextPdf(pdfPath, pageCount: 5);
         _documentService.LoadDocument(pdfPath);
 
         // Act
@@ -166,7 +166,7 @@ public class PdfConformanceTests : IDisposable
         var pdfPath = Path.Combine(_testOutputDir, "rotate.pdf");
         var savePath = Path.Combine(_testOutputDir, "rotate_result.pdf");
 
-        TestPdfGenerator.CreateSimplePdf(pdfPath, pageCount: 1);
+        TestPdfGenerator.CreateSimpleTextPdf(pdfPath, pageCount: 1);
         _documentService.LoadDocument(pdfPath);
 
         // Act
@@ -185,7 +185,7 @@ public class PdfConformanceTests : IDisposable
         var pdfPath = Path.Combine(_testOutputDir, "rotate_persist.pdf");
         var savePath = Path.Combine(_testOutputDir, "rotate_persist_result.pdf");
 
-        TestPdfGenerator.CreateSimplePdf(pdfPath, pageCount: 1);
+        TestPdfGenerator.CreateSimpleTextPdf(pdfPath, pageCount: 1);
         _documentService.LoadDocument(pdfPath);
 
         // Act
@@ -217,18 +217,21 @@ public class PdfConformanceTests : IDisposable
         _documentService.LoadDocument(pdfPath);
 
         var logger = new Mock<ILogger<RedactionService>>().Object;
-        var redactionService = new RedactionService(logger);
+        var loggerFactory = new Mock<ILoggerFactory>().Object;
+        var redactionService = new RedactionService(logger, loggerFactory);
 
         var doc = _documentService.GetCurrentDocument();
         var page = doc!.Pages[0];
 
         // Get a text location
-        var targetText = contentMap.First().Value.First();
+        var targetEntry = contentMap.contentMap.First();
+        var targetText = targetEntry.Key;  // The actual text string
+        var targetPos = targetEntry.Value;  // The position tuple
         var redactArea = new Avalonia.Rect(
-            targetText.X,
-            targetText.Y,
-            targetText.Width,
-            targetText.Height
+            targetPos.x,
+            targetPos.y,
+            targetPos.width,
+            targetPos.height
         );
 
         // Act
@@ -237,7 +240,7 @@ public class PdfConformanceTests : IDisposable
 
         // Assert - Text should be removed
         var textAfter = _textService.ExtractTextFromPage(savePath, 0);
-        textAfter.Should().NotContain(targetText.Text);
+        textAfter.Should().NotContain(targetText);
     }
 
     #endregion
@@ -249,7 +252,7 @@ public class PdfConformanceTests : IDisposable
     {
         // Arrange
         var pdfPath = Path.Combine(_testOutputDir, "multi.pdf");
-        TestPdfGenerator.CreateSimplePdf(pdfPath, pageCount: 10);
+        TestPdfGenerator.CreateSimpleTextPdf(pdfPath, pageCount: 10);
 
         // Act & Assert - Can load
         _documentService.LoadDocument(pdfPath);
@@ -280,7 +283,7 @@ public class PdfConformanceTests : IDisposable
         var exportDir = Path.Combine(_testOutputDir, "export_imgs");
         Directory.CreateDirectory(exportDir);
 
-        TestPdfGenerator.CreateSimplePdf(pdfPath, pageCount: 3);
+        TestPdfGenerator.CreateSimpleTextPdf(pdfPath, pageCount: 3);
 
         // Act
         for (int i = 0; i < 3; i++)
@@ -310,7 +313,7 @@ public class PdfConformanceTests : IDisposable
     {
         // Arrange
         var pdfPath = Path.Combine(_testOutputDir, "invalid_idx.pdf");
-        TestPdfGenerator.CreateSimplePdf(pdfPath, pageCount: 2);
+        TestPdfGenerator.CreateSimpleTextPdf(pdfPath, pageCount: 2);
         _documentService.LoadDocument(pdfPath);
 
         // Act & Assert

--- a/PdfEditor.Tests/PdfEditor.Tests.csproj
+++ b/PdfEditor.Tests/PdfEditor.Tests.csproj
@@ -13,6 +13,7 @@
     <!-- Testing Framework -->
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.5.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
 

--- a/PdfEditor.Tests/Unit/PageRotationTests.cs
+++ b/PdfEditor.Tests/Unit/PageRotationTests.cs
@@ -25,7 +25,7 @@ public class PageRotationTests : IDisposable
 
         // Create a test PDF
         _testPdfPath = Path.Combine(_testOutputDir, "rotation_test.pdf");
-        TestPdfGenerator.CreateSimplePdf(_testPdfPath, pageCount: 3);
+        TestPdfGenerator.CreateSimpleTextPdf(_testPdfPath, pageCount: 3);
     }
 
     [Fact]

--- a/PdfEditor.Tests/Unit/PdfSearchServiceTests.cs
+++ b/PdfEditor.Tests/Unit/PdfSearchServiceTests.cs
@@ -39,7 +39,7 @@ public class PdfSearchServiceTests : IDisposable
 
         // Assert
         results.Should().NotBeEmpty();
-        results.Should().Contain(m => m.Text.Contains("Hello"));
+        results.Should().Contain(m => m.MatchedText.Contains("Hello"));
         results.First().PageIndex.Should().Be(0);
     }
 

--- a/PdfEditor.Tests/Utilities/TestPdfGenerator.cs
+++ b/PdfEditor.Tests/Utilities/TestPdfGenerator.cs
@@ -30,6 +30,51 @@ public static class TestPdfGenerator
     }
 
     /// <summary>
+    /// Creates a simple multi-page PDF with text at known positions
+    /// Overload with pageCount parameter for backwards compatibility
+    /// </summary>
+    public static string CreateSimpleTextPdf(string outputPath, int pageCount)
+    {
+        return CreateMultiPagePdf(outputPath, pageCount);
+    }
+
+    /// <summary>
+    /// Creates a PDF with ONLY text, with custom content
+    /// Overload with text parameter for backwards compatibility
+    /// </summary>
+    public static string CreateTextOnlyPdf(string outputPath, string text)
+    {
+        return CreateSimpleTextPdf(outputPath, text);
+    }
+
+    /// <summary>
+    /// Creates a PDF with multiple lines of text
+    /// Overload with string array for backwards compatibility
+    /// </summary>
+    public static string CreateTextOnlyPdf(string outputPath, string[] lines)
+    {
+        var document = new PdfDocument();
+        var page = document.AddPage();
+        page.Width = XUnit.FromPoint(600);
+        page.Height = XUnit.FromPoint(800);
+
+        using var gfx = XGraphics.FromPdfPage(page);
+        var font = new XFont("Arial", 12);
+
+        double y = 50;
+        foreach (var line in lines)
+        {
+            gfx.DrawString(line, font, XBrushes.Black, new XPoint(100, y));
+            y += 30;
+        }
+
+        document.Save(outputPath);
+        document.Dispose();
+
+        return outputPath;
+    }
+
+    /// <summary>
     /// Creates a PDF with multiple text blocks at known positions
     /// </summary>
     public static string CreateMultiTextPdf(string outputPath)


### PR DESCRIPTION
- Add Moq package reference for mocking in tests
- Add TestPdfGenerator overloads for API compatibility
- Fix PdfDocument ambiguous references with explicit namespaces
- Fix RedactionService constructor calls with loggerFactory parameter
- Fix tuple member access in PdfConformanceTests
- Update PdfDictionary access using reflection for PdfSharpCore compatibility

Test results: 98 passed, 54 failed (failures mostly due to PDF rendering/PDFium issues in headless environment)