### PR TITLE
Add comprehensive redaction verification tests

### DIFF
--- a/PdfEditor.Tests/Integration/PreciseRedactionTests.cs
+++ b/PdfEditor.Tests/Integration/PreciseRedactionTests.cs
@@ -1,0 +1,427 @@
+using Xunit;
+using FluentAssertions;
+using PdfEditor.Services;
+using PdfEditor.Tests.Utilities;
+using PdfSharp.Pdf;
+using PdfSharp.Pdf.IO;
+using PdfSharp.Drawing;
+using Avalonia;
+using System.IO;
+using System.Text;
+using Xunit.Abstractions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace PdfEditor.Tests.Integration;
+
+/// <summary>
+/// Tests that verify precise redaction behavior:
+/// 1. Content beneath black box is REMOVED
+/// 2. Content outside black box is PRESERVED
+/// 3. No false positives (content incorrectly removed)
+/// 4. No false negatives (content that should be removed but isn't)
+/// </summary>
+public class PreciseRedactionTests : IDisposable
+{
+    private readonly ITestOutputHelper _output;
+    private readonly List<string> _tempFiles = new();
+    private readonly RedactionService _redactionService;
+
+    public PreciseRedactionTests(ITestOutputHelper output)
+    {
+        _output = output;
+        var loggerFactory = NullLoggerFactory.Instance;
+        var logger = NullLogger<RedactionService>.Instance;
+        _redactionService = new RedactionService(logger, loggerFactory);
+    }
+
+    #region Core "Beneath the Black Box" Tests
+
+    /// <summary>
+    /// PRIMARY TEST: Verify that ONLY content visually blocked by the black box is removed.
+    /// Creates a grid of text items and redacts specific cells, verifying:
+    /// - All text in redacted cells is removed
+    /// - All text outside redacted cells is preserved
+    /// </summary>
+    [Fact]
+    public void RedactArea_ShouldOnlyRemoveContentBeneathBlackBox()
+    {
+        _output.WriteLine("=== TEST: RedactArea_ShouldOnlyRemoveContentBeneathBlackBox ===");
+
+        // Arrange - Create PDF with text at known grid positions
+        var testPdf = CreateTempPath("grid_test.pdf");
+        var contentMap = CreateGridTestPdf(testPdf);
+        _tempFiles.Add(testPdf);
+
+        _output.WriteLine("Created PDF with content at positions:");
+        foreach (var item in contentMap)
+        {
+            _output.WriteLine($"  '{item.Key}' at ({item.Value.x}, {item.Value.y})");
+        }
+
+        // Verify all content exists before redaction
+        var textBefore = PdfTestHelpers.ExtractAllText(testPdf);
+        foreach (var item in contentMap)
+        {
+            textBefore.Should().Contain(item.Key, $"'{item.Key}' should exist before redaction");
+        }
+
+        // Act - Redact specific area (Row 2, covering "Row2_A" and "Row2_B")
+        var document = PdfReader.Open(testPdf, PdfDocumentOpenMode.Modify);
+        var page = document.Pages[0];
+
+        // Redaction area covers Row2 items
+        var redactionArea = new Rect(90, 190, 300, 30);
+        _output.WriteLine($"\nApplying redaction at: ({redactionArea.X}, {redactionArea.Y}, {redactionArea.Width}x{redactionArea.Height})");
+
+        _redactionService.RedactArea(page, redactionArea);
+
+        var redactedPdf = CreateTempPath("grid_test_redacted.pdf");
+        _tempFiles.Add(redactedPdf);
+        document.Save(redactedPdf);
+        document.Dispose();
+
+        // Assert - Check what was removed and what was preserved
+        var textAfter = PdfTestHelpers.ExtractAllText(testPdf);
+        _output.WriteLine("\nVerification results:");
+
+        // Items that SHOULD be removed (beneath black box)
+        var shouldBeRemoved = new[] { "Row2_A", "Row2_B" };
+        foreach (var item in shouldBeRemoved)
+        {
+            var wasRemoved = !textAfter.Contains(item);
+            _output.WriteLine($"  '{item}' removed: {wasRemoved}");
+            textAfter.Should().NotContain(item,
+                $"'{item}' is beneath black box and must be REMOVED");
+        }
+
+        // Items that SHOULD be preserved (outside black box)
+        var shouldBePreserved = new[] { "Row1_A", "Row1_B", "Row3_A", "Row3_B" };
+        foreach (var item in shouldBePreserved)
+        {
+            var wasPreserved = textAfter.Contains(item);
+            _output.WriteLine($"  '{item}' preserved: {wasPreserved}");
+            textAfter.Should().Contain(item,
+                $"'{item}' is outside black box and must be PRESERVED");
+        }
+
+        _output.WriteLine("\n=== PASSED: Only content beneath black box was removed ===");
+    }
+
+    /// <summary>
+    /// Test that verifies NO false positives - content near but outside redaction is preserved
+    /// </summary>
+    [Fact]
+    public void RedactArea_ShouldNotRemoveContentOutsideArea()
+    {
+        _output.WriteLine("=== TEST: RedactArea_ShouldNotRemoveContentOutsideArea ===");
+
+        // Arrange - Create PDF with text very close to redaction boundaries
+        var testPdf = CreateTempPath("boundary_precision_test.pdf");
+        CreateBoundaryTestPdf(testPdf);
+        _tempFiles.Add(testPdf);
+
+        // Act - Redact the center area only
+        var document = PdfReader.Open(testPdf, PdfDocumentOpenMode.Modify);
+        var page = document.Pages[0];
+
+        // Very precise redaction in the center
+        var redactionArea = new Rect(200, 200, 100, 50);
+        _redactionService.RedactArea(page, redactionArea);
+
+        var redactedPdf = CreateTempPath("boundary_precision_redacted.pdf");
+        _tempFiles.Add(redactedPdf);
+        document.Save(redactedPdf);
+        document.Dispose();
+
+        // Assert
+        var textAfter = PdfTestHelpers.ExtractAllText(redactedPdf);
+
+        // Center content should be removed
+        textAfter.Should().NotContain("CENTER_TARGET",
+            "Content in redaction area must be removed");
+
+        // Boundary content should be preserved
+        textAfter.Should().Contain("TOP_OUTSIDE",
+            "Content above redaction must be preserved");
+        textAfter.Should().Contain("BOTTOM_OUTSIDE",
+            "Content below redaction must be preserved");
+        textAfter.Should().Contain("LEFT_OUTSIDE",
+            "Content left of redaction must be preserved");
+        textAfter.Should().Contain("RIGHT_OUTSIDE",
+            "Content right of redaction must be preserved");
+
+        _output.WriteLine("=== PASSED: No false positives ===");
+    }
+
+    /// <summary>
+    /// Test that content partially overlapping with redaction area IS removed
+    /// (any overlap = removal, not just complete containment)
+    /// </summary>
+    [Fact]
+    public void RedactArea_ShouldRemovePartiallyOverlappingContent()
+    {
+        _output.WriteLine("=== TEST: RedactArea_ShouldRemovePartiallyOverlappingContent ===");
+
+        // Arrange
+        var testPdf = CreateTempPath("partial_overlap_test.pdf");
+        CreateOverlapTestPdf(testPdf);
+        _tempFiles.Add(testPdf);
+
+        // Act - Redact area that partially overlaps with text
+        var document = PdfReader.Open(testPdf, PdfDocumentOpenMode.Modify);
+        var page = document.Pages[0];
+
+        // This area partially overlaps with "PARTIALLY_COVERED"
+        var redactionArea = new Rect(150, 95, 100, 30);
+        _redactionService.RedactArea(page, redactionArea);
+
+        var redactedPdf = CreateTempPath("partial_overlap_redacted.pdf");
+        _tempFiles.Add(redactedPdf);
+        document.Save(redactedPdf);
+        document.Dispose();
+
+        // Assert - Partially overlapping content should be removed
+        var textAfter = PdfTestHelpers.ExtractAllText(redactedPdf);
+
+        textAfter.Should().NotContain("PARTIALLY_COVERED",
+            "Partially overlapping content must be removed for security");
+
+        _output.WriteLine("=== PASSED: Partially overlapping content removed ===");
+    }
+
+    #endregion
+
+    #region Multi-Page Tests
+
+    /// <summary>
+    /// Verify redaction on one page doesn't affect other pages
+    /// </summary>
+    [Fact]
+    public void RedactOnPage_ShouldNotAffectOtherPages()
+    {
+        _output.WriteLine("=== TEST: RedactOnPage_ShouldNotAffectOtherPages ===");
+
+        // Arrange - Create multi-page PDF
+        var testPdf = CreateTempPath("multipage_test.pdf");
+        TestPdfGenerator.CreateMultiPagePdf(testPdf, pageCount: 3);
+        _tempFiles.Add(testPdf);
+
+        // Verify content on all pages before
+        for (int i = 0; i < 3; i++)
+        {
+            var pageText = PdfTestHelpers.ExtractTextFromPage(testPdf, i);
+            pageText.Should().Contain($"Page {i + 1} Content");
+        }
+
+        // Act - Redact only on page 2
+        var document = PdfReader.Open(testPdf, PdfDocumentOpenMode.Modify);
+        var page2 = document.Pages[1];
+        _redactionService.RedactArea(page2, new Rect(90, 90, 200, 30));
+
+        var redactedPdf = CreateTempPath("multipage_redacted.pdf");
+        _tempFiles.Add(redactedPdf);
+        document.Save(redactedPdf);
+        document.Dispose();
+
+        // Assert - Only page 2 should be affected
+        var page1Text = PdfTestHelpers.ExtractTextFromPage(redactedPdf, 0);
+        var page2Text = PdfTestHelpers.ExtractTextFromPage(redactedPdf, 1);
+        var page3Text = PdfTestHelpers.ExtractTextFromPage(redactedPdf, 2);
+
+        page1Text.Should().Contain("Page 1 Content",
+            "Page 1 should be unaffected");
+        page2Text.Should().NotContain("Page 2 Content",
+            "Page 2 content should be redacted");
+        page3Text.Should().Contain("Page 3 Content",
+            "Page 3 should be unaffected");
+
+        _output.WriteLine("=== PASSED: Other pages unaffected ===");
+    }
+
+    #endregion
+
+    #region Edge Case Tests
+
+    /// <summary>
+    /// Redacting empty area should not corrupt PDF
+    /// </summary>
+    [Fact]
+    public void RedactEmptyArea_ShouldNotCorruptPdf()
+    {
+        // Arrange
+        var testPdf = CreateTempPath("empty_area_test.pdf");
+        TestPdfGenerator.CreateSimpleTextPdf(testPdf, "PRESERVE_THIS");
+        _tempFiles.Add(testPdf);
+
+        // Act - Redact area with no content
+        var document = PdfReader.Open(testPdf, PdfDocumentOpenMode.Modify);
+        var page = document.Pages[0];
+        _redactionService.RedactArea(page, new Rect(400, 400, 100, 50));
+
+        var redactedPdf = CreateTempPath("empty_area_redacted.pdf");
+        _tempFiles.Add(redactedPdf);
+        document.Save(redactedPdf);
+        document.Dispose();
+
+        // Assert
+        PdfTestHelpers.IsValidPdf(redactedPdf).Should().BeTrue();
+        var textAfter = PdfTestHelpers.ExtractAllText(redactedPdf);
+        textAfter.Should().Contain("PRESERVE_THIS",
+            "Content outside empty redaction area must be preserved");
+    }
+
+    /// <summary>
+    /// Very small redaction area should still work
+    /// </summary>
+    [Fact]
+    public void RedactSmallArea_ShouldStillRemoveContent()
+    {
+        // Arrange
+        var testPdf = CreateTempPath("small_area_test.pdf");
+        TestPdfGenerator.CreateSimpleTextPdf(testPdf, "TINY");
+        _tempFiles.Add(testPdf);
+
+        // Act - Very small redaction
+        var document = PdfReader.Open(testPdf, PdfDocumentOpenMode.Modify);
+        var page = document.Pages[0];
+        _redactionService.RedactArea(page, new Rect(98, 98, 30, 15)); // Small area
+
+        var redactedPdf = CreateTempPath("small_area_redacted.pdf");
+        _tempFiles.Add(redactedPdf);
+        document.Save(redactedPdf);
+        document.Dispose();
+
+        // Assert
+        var textAfter = PdfTestHelpers.ExtractAllText(redactedPdf);
+        textAfter.Should().NotContain("TINY",
+            "Even small redaction areas should remove content");
+    }
+
+    /// <summary>
+    /// Large redaction area (covering most of page) should work
+    /// </summary>
+    [Fact]
+    public void RedactLargeArea_ShouldRemoveAllContent()
+    {
+        // Arrange
+        var testPdf = CreateTempPath("large_area_test.pdf");
+        TestPdfGenerator.CreateMultiTextPdf(testPdf);
+        _tempFiles.Add(testPdf);
+
+        // Act - Large redaction covering most of page
+        var document = PdfReader.Open(testPdf, PdfDocumentOpenMode.Modify);
+        var page = document.Pages[0];
+        _redactionService.RedactArea(page, new Rect(0, 0, 600, 500));
+
+        var redactedPdf = CreateTempPath("large_area_redacted.pdf");
+        _tempFiles.Add(redactedPdf);
+        document.Save(redactedPdf);
+        document.Dispose();
+
+        // Assert
+        PdfTestHelpers.IsValidPdf(redactedPdf).Should().BeTrue();
+        var textAfter = PdfTestHelpers.ExtractAllText(redactedPdf);
+
+        textAfter.Should().NotContain("CONFIDENTIAL");
+        textAfter.Should().NotContain("Public Information");
+        textAfter.Should().NotContain("Secret Data");
+        textAfter.Should().NotContain("Normal Text");
+    }
+
+    #endregion
+
+    #region Helper Methods - PDF Generation
+
+    private Dictionary<string, (double x, double y)> CreateGridTestPdf(string outputPath)
+    {
+        var document = new PdfDocument();
+        var page = document.AddPage();
+        page.Width = XUnit.FromPoint(612);
+        page.Height = XUnit.FromPoint(792);
+
+        using var gfx = XGraphics.FromPdfPage(page);
+        var font = new XFont("Arial", 12);
+
+        var contentMap = new Dictionary<string, (double, double)>();
+
+        // Row 1 - y = 100
+        contentMap["Row1_A"] = (100, 100);
+        contentMap["Row1_B"] = (250, 100);
+
+        // Row 2 - y = 200 (this row will be redacted)
+        contentMap["Row2_A"] = (100, 200);
+        contentMap["Row2_B"] = (250, 200);
+
+        // Row 3 - y = 300
+        contentMap["Row3_A"] = (100, 300);
+        contentMap["Row3_B"] = (250, 300);
+
+        foreach (var item in contentMap)
+        {
+            gfx.DrawString(item.Key, font, XBrushes.Black,
+                new XPoint(item.Value.x, item.Value.y));
+        }
+
+        document.Save(outputPath);
+        document.Dispose();
+
+        return contentMap;
+    }
+
+    private void CreateBoundaryTestPdf(string outputPath)
+    {
+        var document = new PdfDocument();
+        var page = document.AddPage();
+
+        using var gfx = XGraphics.FromPdfPage(page);
+        var font = new XFont("Arial", 10);
+
+        // Center target (will be redacted)
+        gfx.DrawString("CENTER_TARGET", font, XBrushes.Black, new XPoint(210, 220));
+
+        // Surrounding content (should be preserved)
+        gfx.DrawString("TOP_OUTSIDE", font, XBrushes.Black, new XPoint(210, 180));
+        gfx.DrawString("BOTTOM_OUTSIDE", font, XBrushes.Black, new XPoint(210, 270));
+        gfx.DrawString("LEFT_OUTSIDE", font, XBrushes.Black, new XPoint(100, 220));
+        gfx.DrawString("RIGHT_OUTSIDE", font, XBrushes.Black, new XPoint(320, 220));
+
+        document.Save(outputPath);
+        document.Dispose();
+    }
+
+    private void CreateOverlapTestPdf(string outputPath)
+    {
+        var document = new PdfDocument();
+        var page = document.AddPage();
+
+        using var gfx = XGraphics.FromPdfPage(page);
+        var font = new XFont("Arial", 12);
+
+        // Text that will be partially covered by redaction
+        gfx.DrawString("PARTIALLY_COVERED", font, XBrushes.Black, new XPoint(100, 100));
+
+        // Text that won't be covered
+        gfx.DrawString("NOT_COVERED", font, XBrushes.Black, new XPoint(100, 200));
+
+        document.Save(outputPath);
+        document.Dispose();
+    }
+
+    private string CreateTempPath(string filename)
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "PreciseRedactionTests");
+        Directory.CreateDirectory(tempDir);
+        return Path.Combine(tempDir, filename);
+    }
+
+    public void Dispose()
+    {
+        foreach (var file in _tempFiles)
+        {
+            TestPdfGenerator.CleanupTestFile(file);
+        }
+    }
+
+    #endregion
+}

--- a/PdfEditor.Tests/Security/ContentRemovalVerificationTests.cs
+++ b/PdfEditor.Tests/Security/ContentRemovalVerificationTests.cs
@@ -1,0 +1,450 @@
+using Xunit;
+using FluentAssertions;
+using PdfEditor.Services;
+using PdfEditor.Tests.Utilities;
+using PdfSharp.Pdf.IO;
+using Avalonia;
+using System.IO;
+using System.Text;
+using Xunit.Abstractions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using UglyToad.PdfPig;
+
+namespace PdfEditor.Tests.Security;
+
+/// <summary>
+/// Security verification tests for redaction.
+/// These tests verify that content is TRULY REMOVED from PDF structure,
+/// not just visually hidden. This is critical for security.
+/// </summary>
+public class ContentRemovalVerificationTests : IDisposable
+{
+    private readonly ITestOutputHelper _output;
+    private readonly List<string> _tempFiles = new();
+    private readonly RedactionService _redactionService;
+
+    public ContentRemovalVerificationTests(ITestOutputHelper output)
+    {
+        _output = output;
+        var loggerFactory = NullLoggerFactory.Instance;
+        var logger = NullLogger<RedactionService>.Instance;
+        _redactionService = new RedactionService(logger, loggerFactory);
+    }
+
+    #region Core Content Removal Tests
+
+    /// <summary>
+    /// CRITICAL TEST: Text extraction using PdfPig must fail for redacted content.
+    /// This verifies TRUE glyph-level removal.
+    /// </summary>
+    [Fact]
+    public void RedactedText_ShouldNotBeExtractableWithPdfPig()
+    {
+        // Arrange
+        _output.WriteLine("=== TEST: RedactedText_ShouldNotBeExtractableWithPdfPig ===");
+
+        var testPdf = CreateTempPath("pdfpig_extraction_test.pdf");
+        TestPdfGenerator.CreateSimpleTextPdf(testPdf, "SUPER_SECRET_DATA");
+        _tempFiles.Add(testPdf);
+
+        // Verify text exists before
+        var textBefore = ExtractWithPdfPig(testPdf);
+        _output.WriteLine($"Text before redaction: '{textBefore}'");
+        textBefore.Should().Contain("SUPER_SECRET_DATA");
+
+        // Act - Apply redaction
+        var document = PdfReader.Open(testPdf, PdfDocumentOpenMode.Modify);
+        var page = document.Pages[0];
+        var redactionArea = new Rect(90, 90, 200, 30);
+        _redactionService.RedactArea(page, redactionArea);
+
+        var redactedPdf = CreateTempPath("pdfpig_extraction_redacted.pdf");
+        _tempFiles.Add(redactedPdf);
+        document.Save(redactedPdf);
+        document.Dispose();
+
+        // Assert - Extract with PdfPig (independent library)
+        var textAfter = ExtractWithPdfPig(redactedPdf);
+        _output.WriteLine($"Text after redaction: '{textAfter}'");
+
+        textAfter.Should().NotContain("SUPER_SECRET_DATA",
+            "CRITICAL: Text must be REMOVED from PDF structure, not just visually hidden. " +
+            "PdfPig extraction should not find the redacted text.");
+
+        _output.WriteLine("=== PASSED: Text not extractable with PdfPig ===");
+    }
+
+    /// <summary>
+    /// Verify content stream is actually modified (not just black box added)
+    /// </summary>
+    [Fact]
+    public void RedactedPdf_ContentStreamShouldBeModified()
+    {
+        // Arrange
+        _output.WriteLine("=== TEST: RedactedPdf_ContentStreamShouldBeModified ===");
+
+        var testPdf = CreateTempPath("content_stream_test.pdf");
+        TestPdfGenerator.CreateSimpleTextPdf(testPdf, "MODIFY_TEST_DATA");
+        _tempFiles.Add(testPdf);
+
+        // Get content stream before
+        var contentBefore = PdfTestHelpers.GetPageContentStream(testPdf);
+        _output.WriteLine($"Content stream size before: {contentBefore.Length} bytes");
+
+        // Act
+        var document = PdfReader.Open(testPdf, PdfDocumentOpenMode.Modify);
+        var page = document.Pages[0];
+        _redactionService.RedactArea(page, new Rect(90, 90, 200, 30));
+
+        var redactedPdf = CreateTempPath("content_stream_redacted.pdf");
+        _tempFiles.Add(redactedPdf);
+        document.Save(redactedPdf);
+        document.Dispose();
+
+        // Assert
+        var contentAfter = PdfTestHelpers.GetPageContentStream(redactedPdf);
+        _output.WriteLine($"Content stream size after: {contentAfter.Length} bytes");
+
+        // Content should be different (modified)
+        contentBefore.Should().NotEqual(contentAfter,
+            "Content stream must be modified for true glyph removal");
+
+        // The redacted text should not appear in raw content
+        var rawContent = Encoding.UTF8.GetString(contentAfter);
+        rawContent.Should().NotContain("MODIFY_TEST_DATA",
+            "Redacted text should not appear in raw content stream");
+
+        _output.WriteLine("=== PASSED: Content stream modified ===");
+    }
+
+    /// <summary>
+    /// Binary search of PDF file should not find redacted text
+    /// </summary>
+    [Fact]
+    public void RedactedPdf_BinarySearchShouldNotFindText()
+    {
+        // Arrange
+        _output.WriteLine("=== TEST: RedactedPdf_BinarySearchShouldNotFindText ===");
+
+        var testPdf = CreateTempPath("binary_search_test.pdf");
+        TestPdfGenerator.CreateSimpleTextPdf(testPdf, "BINARY_SEARCH_TARGET");
+        _tempFiles.Add(testPdf);
+
+        // Act
+        var document = PdfReader.Open(testPdf, PdfDocumentOpenMode.Modify);
+        var page = document.Pages[0];
+        _redactionService.RedactArea(page, new Rect(90, 90, 250, 30));
+
+        var redactedPdf = CreateTempPath("binary_search_redacted.pdf");
+        _tempFiles.Add(redactedPdf);
+        document.Save(redactedPdf);
+        document.Dispose();
+
+        // Assert - Read entire PDF as bytes
+        var pdfBytes = File.ReadAllBytes(redactedPdf);
+        var pdfContent = Encoding.UTF8.GetString(pdfBytes);
+
+        // Search for the text in multiple encodings
+        pdfContent.Should().NotContain("BINARY_SEARCH_TARGET",
+            "Redacted text should not appear anywhere in PDF binary");
+
+        // Also check for common PDF string encodings
+        var asciiSearch = Encoding.ASCII.GetString(pdfBytes);
+        asciiSearch.Should().NotContain("BINARY_SEARCH_TARGET",
+            "Redacted text should not appear in ASCII search");
+
+        _output.WriteLine("=== PASSED: Binary search did not find text ===");
+    }
+
+    #endregion
+
+    #region Selective Removal Tests
+
+    /// <summary>
+    /// Verify only targeted content is removed - no collateral damage
+    /// </summary>
+    [Fact]
+    public void RedactArea_ShouldOnlyRemoveTargetedContent()
+    {
+        // Arrange
+        _output.WriteLine("=== TEST: RedactArea_ShouldOnlyRemoveTargetedContent ===");
+
+        var testPdf = CreateTempPath("selective_removal_test.pdf");
+        TestPdfGenerator.CreateMultiTextPdf(testPdf);
+        _tempFiles.Add(testPdf);
+
+        // Verify all text exists before
+        var textBefore = PdfTestHelpers.ExtractAllText(testPdf);
+        _output.WriteLine($"Text before: {textBefore.Replace("\n", " | ")}");
+        textBefore.Should().Contain("CONFIDENTIAL");
+        textBefore.Should().Contain("Public Information");
+        textBefore.Should().Contain("Secret Data");
+        textBefore.Should().Contain("Normal Text");
+
+        // Act - Redact only CONFIDENTIAL (at y=100)
+        var document = PdfReader.Open(testPdf, PdfDocumentOpenMode.Modify);
+        var page = document.Pages[0];
+        _redactionService.RedactArea(page, new Rect(90, 90, 150, 30));
+
+        var redactedPdf = CreateTempPath("selective_removal_redacted.pdf");
+        _tempFiles.Add(redactedPdf);
+        document.Save(redactedPdf);
+        document.Dispose();
+
+        // Assert
+        var textAfter = PdfTestHelpers.ExtractAllText(redactedPdf);
+        _output.WriteLine($"Text after: {textAfter.Replace("\n", " | ")}");
+
+        textAfter.Should().NotContain("CONFIDENTIAL", "Targeted text should be removed");
+        textAfter.Should().Contain("Public Information", "Non-targeted text must be preserved");
+        textAfter.Should().Contain("Secret Data", "Non-targeted text must be preserved");
+        textAfter.Should().Contain("Normal Text", "Non-targeted text must be preserved");
+
+        _output.WriteLine("=== PASSED: Only targeted content removed ===");
+    }
+
+    /// <summary>
+    /// Verify precise boundary - content just outside redaction area is preserved
+    /// </summary>
+    [Fact]
+    public void RedactArea_ShouldRespectBoundaries()
+    {
+        // Arrange
+        _output.WriteLine("=== TEST: RedactArea_ShouldRespectBoundaries ===");
+
+        var testPdf = CreateTempPath("boundary_test.pdf");
+        TestPdfGenerator.CreateMultiTextPdf(testPdf);
+        _tempFiles.Add(testPdf);
+
+        // Act - Redact a very specific small area
+        var document = PdfReader.Open(testPdf, PdfDocumentOpenMode.Modify);
+        var page = document.Pages[0];
+
+        // This small area should only catch CONFIDENTIAL at y=100
+        _redactionService.RedactArea(page, new Rect(95, 95, 130, 20));
+
+        var redactedPdf = CreateTempPath("boundary_redacted.pdf");
+        _tempFiles.Add(redactedPdf);
+        document.Save(redactedPdf);
+        document.Dispose();
+
+        // Assert - All other text should be preserved
+        var textAfter = PdfTestHelpers.ExtractAllText(redactedPdf);
+
+        textAfter.Should().Contain("Public Information",
+            "Text at y=200 should not be affected");
+        textAfter.Should().Contain("Secret Data",
+            "Text at y=300 should not be affected");
+
+        _output.WriteLine("=== PASSED: Boundaries respected ===");
+    }
+
+    #endregion
+
+    #region Multiple Verification Methods
+
+    /// <summary>
+    /// Use multiple extraction methods to verify removal
+    /// </summary>
+    [Fact]
+    public void RedactedText_ShouldFailAllExtractionMethods()
+    {
+        // Arrange
+        _output.WriteLine("=== TEST: RedactedText_ShouldFailAllExtractionMethods ===");
+
+        var testPdf = CreateTempPath("multi_method_test.pdf");
+        TestPdfGenerator.CreateSimpleTextPdf(testPdf, "MULTI_METHOD_SECRET");
+        _tempFiles.Add(testPdf);
+
+        // Act
+        var document = PdfReader.Open(testPdf, PdfDocumentOpenMode.Modify);
+        var page = document.Pages[0];
+        _redactionService.RedactArea(page, new Rect(90, 90, 250, 30));
+
+        var redactedPdf = CreateTempPath("multi_method_redacted.pdf");
+        _tempFiles.Add(redactedPdf);
+        document.Save(redactedPdf);
+        document.Dispose();
+
+        // Assert with multiple methods
+        _output.WriteLine("Testing extraction methods:");
+
+        // Method 1: PdfPig
+        var pdfPigText = ExtractWithPdfPig(redactedPdf);
+        _output.WriteLine($"  PdfPig: '{pdfPigText}'");
+        pdfPigText.Should().NotContain("MULTI_METHOD_SECRET", "PdfPig should not find text");
+
+        // Method 2: PdfTestHelpers (also uses PdfPig)
+        var helperText = PdfTestHelpers.ExtractAllText(redactedPdf);
+        _output.WriteLine($"  PdfTestHelpers: '{helperText}'");
+        helperText.Should().NotContain("MULTI_METHOD_SECRET", "Helper should not find text");
+
+        // Method 3: Raw content stream
+        var contentStream = PdfTestHelpers.GetPageContentStream(redactedPdf);
+        var rawText = Encoding.UTF8.GetString(contentStream);
+        rawText.Should().NotContain("MULTI_METHOD_SECRET", "Raw content should not contain text");
+
+        // Method 4: Binary file search
+        var fileBytes = File.ReadAllBytes(redactedPdf);
+        var fileText = Encoding.UTF8.GetString(fileBytes);
+        fileText.Should().NotContain("MULTI_METHOD_SECRET", "Binary search should not find text");
+
+        _output.WriteLine("=== PASSED: All extraction methods failed to find text ===");
+    }
+
+    #endregion
+
+    #region PDF Validity Tests
+
+    /// <summary>
+    /// Redacted PDF must remain valid and openable
+    /// </summary>
+    [Fact]
+    public void RedactedPdf_ShouldRemainValid()
+    {
+        // Arrange
+        var testPdf = CreateTempPath("validity_test.pdf");
+        TestPdfGenerator.CreateComplexContentPdf(testPdf);
+        _tempFiles.Add(testPdf);
+
+        // Act
+        var document = PdfReader.Open(testPdf, PdfDocumentOpenMode.Modify);
+        var page = document.Pages[0];
+
+        // Multiple redactions
+        _redactionService.RedactArea(page, new Rect(50, 260, 500, 100)); // Sensitive data area
+        _redactionService.RedactArea(page, new Rect(50, 50, 300, 30));   // Title area
+
+        var redactedPdf = CreateTempPath("validity_redacted.pdf");
+        _tempFiles.Add(redactedPdf);
+        document.Save(redactedPdf);
+        document.Dispose();
+
+        // Assert - PDF should be valid
+        PdfTestHelpers.IsValidPdf(redactedPdf).Should().BeTrue(
+            "Redacted PDF must remain valid");
+
+        // Should be openable by multiple libraries
+        Action openWithPdfSharp = () =>
+        {
+            using var doc = PdfReader.Open(redactedPdf, PdfDocumentOpenMode.ReadOnly);
+            doc.PageCount.Should().Be(1);
+        };
+        openWithPdfSharp.Should().NotThrow("PDF should be openable by PdfSharp");
+
+        Action openWithPdfPig = () =>
+        {
+            using var doc = UglyToad.PdfPig.PdfDocument.Open(redactedPdf);
+            doc.NumberOfPages.Should().Be(1);
+        };
+        openWithPdfPig.Should().NotThrow("PDF should be openable by PdfPig");
+    }
+
+    /// <summary>
+    /// Multiple sequential redactions should all work correctly
+    /// </summary>
+    [Fact]
+    public void MultipleRedactions_ShouldAllRemoveContent()
+    {
+        // Arrange
+        var testPdf = CreateTempPath("multiple_redactions_test.pdf");
+        TestPdfGenerator.CreateMultiTextPdf(testPdf);
+        _tempFiles.Add(testPdf);
+
+        // Act - Apply multiple redactions
+        var document = PdfReader.Open(testPdf, PdfDocumentOpenMode.Modify);
+        var page = document.Pages[0];
+
+        // Redact CONFIDENTIAL at y=100
+        _redactionService.RedactArea(page, new Rect(90, 90, 150, 30));
+        // Redact Secret Data at y=300
+        _redactionService.RedactArea(page, new Rect(90, 290, 150, 30));
+
+        var redactedPdf = CreateTempPath("multiple_redactions_redacted.pdf");
+        _tempFiles.Add(redactedPdf);
+        document.Save(redactedPdf);
+        document.Dispose();
+
+        // Assert - Both should be removed
+        var textAfter = PdfTestHelpers.ExtractAllText(redactedPdf);
+
+        textAfter.Should().NotContain("CONFIDENTIAL", "First redaction should work");
+        textAfter.Should().NotContain("Secret Data", "Second redaction should work");
+        textAfter.Should().Contain("Public Information", "Unredacted content preserved");
+        textAfter.Should().Contain("Normal Text", "Unredacted content preserved");
+    }
+
+    #endregion
+
+    #region Black Box Verification
+
+    /// <summary>
+    /// Verify black box is drawn over redacted area
+    /// </summary>
+    [Fact]
+    public void RedactedArea_ShouldHaveBlackBox()
+    {
+        // Arrange
+        var testPdf = CreateTempPath("black_box_test.pdf");
+        TestPdfGenerator.CreateSimpleTextPdf(testPdf, "BLACK_BOX_TEST");
+        _tempFiles.Add(testPdf);
+
+        // Act
+        var document = PdfReader.Open(testPdf, PdfDocumentOpenMode.Modify);
+        var page = document.Pages[0];
+        _redactionService.RedactArea(page, new Rect(90, 90, 200, 30));
+
+        var redactedPdf = CreateTempPath("black_box_redacted.pdf");
+        _tempFiles.Add(redactedPdf);
+        document.Save(redactedPdf);
+        document.Dispose();
+
+        // Assert - Check for black rectangle in content stream
+        var contentStream = PdfTestHelpers.GetPageContentStream(redactedPdf);
+        var content = Encoding.UTF8.GetString(contentStream);
+
+        // Black color should be set (0 g for grayscale black)
+        var hasBlackColor = content.Contains("0 g") || content.Contains("0 0 0 rg");
+        hasBlackColor.Should().BeTrue("Black color should be set for redaction box");
+
+        // Rectangle operation should exist
+        content.Should().Contain(" re ", "Rectangle operation should exist for black box");
+
+        // Fill operation should exist
+        var hasFill = content.Contains(" f") || content.Contains(" F");
+        hasFill.Should().BeTrue("Fill operation should exist for black box");
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private string ExtractWithPdfPig(string pdfPath)
+    {
+        var text = new StringBuilder();
+        using var document = UglyToad.PdfPig.PdfDocument.Open(pdfPath);
+        foreach (var page in document.GetPages())
+        {
+            text.AppendLine(page.Text);
+        }
+        return text.ToString();
+    }
+
+    private string CreateTempPath(string filename)
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "SecurityTests");
+        Directory.CreateDirectory(tempDir);
+        return Path.Combine(tempDir, filename);
+    }
+
+    public void Dispose()
+    {
+        foreach (var file in _tempFiles)
+        {
+            TestPdfGenerator.CleanupTestFile(file);
+        }
+    }
+
+    #endregion
+}

--- a/PdfEditor.Tests/Unit/PdfOperationTests.cs
+++ b/PdfEditor.Tests/Unit/PdfOperationTests.cs
@@ -1,0 +1,312 @@
+using Xunit;
+using FluentAssertions;
+using Avalonia;
+using PdfEditor.Services.Redaction;
+using PdfSharp.Pdf.Content.Objects;
+
+namespace PdfEditor.Tests.Unit;
+
+/// <summary>
+/// Unit tests for PdfOperation intersection and containment logic
+/// These tests verify that the redaction correctly identifies which operations
+/// should be removed based on their bounding boxes.
+/// </summary>
+public class PdfOperationTests
+{
+    #region Intersection Tests
+
+    [Theory]
+    [InlineData(0, 0, 100, 50, 50, 25, 100, 50, true)]     // Overlapping right side
+    [InlineData(0, 0, 100, 50, 200, 200, 50, 50, false)]   // Non-overlapping (distant)
+    [InlineData(0, 0, 100, 50, 25, 10, 50, 30, true)]      // Overlapping contained
+    [InlineData(0, 0, 100, 50, -50, -50, 75, 75, true)]    // Partial overlap top-left
+    [InlineData(100, 100, 50, 50, 0, 0, 100, 100, false)]  // Touching but not overlapping
+    [InlineData(0, 0, 100, 100, 0, 0, 100, 100, true)]     // Exact same area
+    [InlineData(10, 10, 80, 80, 0, 0, 100, 100, true)]     // Inner contained in outer
+    [InlineData(0, 0, 100, 100, 10, 10, 80, 80, true)]     // Outer contains inner
+    [InlineData(0, 0, 100, 50, 100, 0, 100, 50, false)]    // Adjacent horizontally
+    [InlineData(0, 0, 100, 50, 0, 50, 100, 50, false)]     // Adjacent vertically
+    public void IntersectsWith_VariousBounds_ShouldCalculateCorrectly(
+        double op_x, double op_y, double op_w, double op_h,
+        double area_x, double area_y, double area_w, double area_h,
+        bool expectedResult)
+    {
+        // Arrange
+        var operation = CreateTextOperationWithBounds(op_x, op_y, op_w, op_h);
+        var redactionArea = new Rect(area_x, area_y, area_w, area_h);
+
+        // Act
+        var result = operation.IntersectsWith(redactionArea);
+
+        // Assert
+        result.Should().Be(expectedResult,
+            $"Operation at ({op_x},{op_y},{op_w}x{op_h}) intersection with " +
+            $"area ({area_x},{area_y},{area_w}x{area_h}) should be {expectedResult}");
+    }
+
+    [Fact]
+    public void IntersectsWith_ZeroWidthBoundingBox_ShouldReturnFalse()
+    {
+        // Arrange - Operation with zero width
+        var operation = CreateTextOperationWithBounds(50, 50, 0, 20);
+        var redactionArea = new Rect(0, 0, 100, 100);
+
+        // Act
+        var result = operation.IntersectsWith(redactionArea);
+
+        // Assert
+        result.Should().BeFalse("Operations with zero width should not intersect");
+    }
+
+    [Fact]
+    public void IntersectsWith_ZeroHeightBoundingBox_ShouldReturnFalse()
+    {
+        // Arrange - Operation with zero height
+        var operation = CreateTextOperationWithBounds(50, 50, 100, 0);
+        var redactionArea = new Rect(0, 0, 100, 100);
+
+        // Act
+        var result = operation.IntersectsWith(redactionArea);
+
+        // Assert
+        result.Should().BeFalse("Operations with zero height should not intersect");
+    }
+
+    [Fact]
+    public void IntersectsWith_StateOperation_ShouldAlwaysReturnFalse()
+    {
+        // Arrange - State operations should never be removed
+        var cSequence = new CSequence();
+        var stateOp = new StateOperation(cSequence)
+        {
+            Type = StateOperationType.SaveState,
+            BoundingBox = new Rect(0, 0, 100, 100)
+        };
+        var redactionArea = new Rect(0, 0, 100, 100);
+
+        // Act
+        var result = stateOp.IntersectsWith(redactionArea);
+
+        // Assert
+        result.Should().BeFalse("State operations should never be removed");
+    }
+
+    [Fact]
+    public void IntersectsWith_TextStateOperation_ShouldAlwaysReturnFalse()
+    {
+        // Arrange - Text state operations should never be removed
+        var cSequence = new CSequence();
+        var textStateOp = new TextStateOperation(cSequence)
+        {
+            Type = TextStateOperationType.BeginText,
+            BoundingBox = new Rect(0, 0, 100, 100)
+        };
+        var redactionArea = new Rect(0, 0, 100, 100);
+
+        // Act
+        var result = textStateOp.IntersectsWith(redactionArea);
+
+        // Assert
+        result.Should().BeFalse("Text state operations should never be removed");
+    }
+
+    [Fact]
+    public void IntersectsWith_GenericOperation_ShouldAlwaysReturnFalse()
+    {
+        // Arrange - Generic operations should be preserved
+        var cSequence = new CSequence();
+        var genericOp = new GenericOperation(cSequence, "custom")
+        {
+            BoundingBox = new Rect(0, 0, 100, 100)
+        };
+        var redactionArea = new Rect(0, 0, 100, 100);
+
+        // Act
+        var result = genericOp.IntersectsWith(redactionArea);
+
+        // Assert
+        result.Should().BeFalse("Generic operations should be preserved");
+    }
+
+    #endregion
+
+    #region Containment Tests
+
+    [Theory]
+    [InlineData(25, 25, 50, 50, 0, 0, 100, 100, true)]     // Completely contained
+    [InlineData(0, 0, 100, 100, 0, 0, 100, 100, true)]     // Exact match
+    [InlineData(0, 0, 100, 100, 25, 25, 50, 50, false)]    // Larger than container
+    [InlineData(50, 50, 100, 100, 0, 0, 100, 100, false)]  // Partially outside
+    [InlineData(0, 0, 50, 50, 50, 50, 100, 100, false)]    // Completely outside
+    public void IsContainedIn_VariousBounds_ShouldCalculateCorrectly(
+        double op_x, double op_y, double op_w, double op_h,
+        double area_x, double area_y, double area_w, double area_h,
+        bool expectedResult)
+    {
+        // Arrange
+        var operation = CreateTextOperationWithBounds(op_x, op_y, op_w, op_h);
+        var container = new Rect(area_x, area_y, area_w, area_h);
+
+        // Act
+        var result = operation.IsContainedIn(container);
+
+        // Assert
+        result.Should().Be(expectedResult);
+    }
+
+    #endregion
+
+    #region Path Operation Tests
+
+    [Fact]
+    public void PathOperation_Rectangle_ShouldHaveCorrectBoundingBox()
+    {
+        // Arrange
+        var cSequence = new CSequence();
+        var pathOp = new PathOperation(cSequence)
+        {
+            Type = PathType.Rectangle,
+            BoundingBox = new Rect(100, 200, 150, 80)
+        };
+        var overlappingArea = new Rect(120, 220, 50, 50);
+        var nonOverlappingArea = new Rect(300, 300, 50, 50);
+
+        // Act & Assert
+        pathOp.IntersectsWith(overlappingArea).Should().BeTrue();
+        pathOp.IntersectsWith(nonOverlappingArea).Should().BeFalse();
+    }
+
+    [Fact]
+    public void PathOperation_WithStroke_ShouldBeRemovable()
+    {
+        // Arrange
+        var cSequence = new CSequence();
+        var pathOp = new PathOperation(cSequence)
+        {
+            Type = PathType.Stroke,
+            IsStroke = true,
+            IsFill = false,
+            BoundingBox = new Rect(50, 50, 100, 100)
+        };
+        var redactionArea = new Rect(60, 60, 50, 50);
+
+        // Act
+        var result = pathOp.IntersectsWith(redactionArea);
+
+        // Assert
+        result.Should().BeTrue("Stroke operations should be removable");
+    }
+
+    [Fact]
+    public void PathOperation_WithFill_ShouldBeRemovable()
+    {
+        // Arrange
+        var cSequence = new CSequence();
+        var pathOp = new PathOperation(cSequence)
+        {
+            Type = PathType.Fill,
+            IsStroke = false,
+            IsFill = true,
+            BoundingBox = new Rect(50, 50, 100, 100)
+        };
+        var redactionArea = new Rect(60, 60, 50, 50);
+
+        // Act
+        var result = pathOp.IntersectsWith(redactionArea);
+
+        // Assert
+        result.Should().BeTrue("Fill operations should be removable");
+    }
+
+    #endregion
+
+    #region Image Operation Tests
+
+    [Fact]
+    public void ImageOperation_ShouldBeRemovableWhenIntersecting()
+    {
+        // Arrange
+        var cSequence = new CSequence();
+        var imageOp = new ImageOperation(cSequence)
+        {
+            ResourceName = "Im1",
+            Position = new Point(100, 100),
+            Width = 200,
+            Height = 150,
+            BoundingBox = new Rect(100, 100, 200, 150)
+        };
+        var overlappingArea = new Rect(150, 150, 100, 100);
+        var nonOverlappingArea = new Rect(350, 350, 50, 50);
+
+        // Act & Assert
+        imageOp.IntersectsWith(overlappingArea).Should().BeTrue(
+            "Image should be removed when redaction area overlaps");
+        imageOp.IntersectsWith(nonOverlappingArea).Should().BeFalse(
+            "Image should be preserved when redaction area does not overlap");
+    }
+
+    #endregion
+
+    #region Edge Cases
+
+    [Fact]
+    public void IntersectsWith_VerySmallOverlap_ShouldStillBeTrue()
+    {
+        // Arrange - Just 1 point overlap
+        var operation = CreateTextOperationWithBounds(0, 0, 100, 50);
+        var redactionArea = new Rect(99, 49, 50, 50); // 1 point overlap
+
+        // Act
+        var result = operation.IntersectsWith(redactionArea);
+
+        // Assert
+        result.Should().BeTrue("Even tiny overlaps should result in intersection");
+    }
+
+    [Fact]
+    public void IntersectsWith_NegativeCoordinates_ShouldWorkCorrectly()
+    {
+        // Arrange - Negative coordinates (possible in transformed content)
+        var operation = CreateTextOperationWithBounds(-50, -50, 100, 100);
+        var redactionArea = new Rect(-25, -25, 50, 50);
+
+        // Act
+        var result = operation.IntersectsWith(redactionArea);
+
+        // Assert
+        result.Should().BeTrue("Negative coordinates should work correctly");
+    }
+
+    [Fact]
+    public void IntersectsWith_LargeCoordinates_ShouldWorkCorrectly()
+    {
+        // Arrange - Large page coordinates
+        var operation = CreateTextOperationWithBounds(5000, 7000, 200, 50);
+        var redactionArea = new Rect(5050, 7010, 100, 30);
+
+        // Act
+        var result = operation.IntersectsWith(redactionArea);
+
+        // Assert
+        result.Should().BeTrue("Large coordinates should work correctly");
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private TextOperation CreateTextOperationWithBounds(double x, double y, double width, double height)
+    {
+        var cSequence = new CSequence();
+        return new TextOperation(cSequence)
+        {
+            Text = "Test Text",
+            BoundingBox = new Rect(x, y, width, height),
+            Position = new Point(x, y),
+            FontSize = 12,
+            FontName = "Helvetica"
+        };
+    }
+
+    #endregion
+}


### PR DESCRIPTION
- Add unit tests for PdfOperation intersection logic
- Add security verification tests to ensure content is truly removed
- Add precise redaction tests verifying only content beneath black box is removed
- Tests verify text extraction fails for redacted content using PdfPig
- Tests verify non-redacted content is preserved (no false positives)