### PR TITLE
Decode PDFDocEncoding typographic chars (fix outline tofu boxes) (#361)

### DIFF
--- a/Pdfe.Core.Tests/Content/ContentStreamWriterTests.cs
+++ b/Pdfe.Core.Tests/Content/ContentStreamWriterTests.cs
@@ -734,7 +734,12 @@ public class ContentStreamWriterTests
     [Fact]
     public void Write_StringWithAllEscapeTypes_RoundTrips()
     {
-        var complexString = "Path\\(test)\\file\nWith\rWhitespace\tAnd\x01Control";
+        // Use U+0001 (not \x01): C#'s \x escape is greedy, so "\x01Control"
+        // parses as U+001C + "ontrol", and 0x1C is a PDFDocEncoding special
+        // (U+02DD) that legitimately does NOT round-trip as identity. U+0001
+        // is a plain control char the writer octal-escapes and round-trips
+        // cleanly. (#361)
+        var complexString = "Path\\(test)\\file\nWith\rWhitespace\tAnd\u0001Control";
         var op = new ContentOperator("Tj", new PdfObject[] { new PdfString(complexString) });
         var content = new ContentStream(new[] { op });
 

--- a/Pdfe.Core.Tests/Primitives/PdfStringTests.cs
+++ b/Pdfe.Core.Tests/Primitives/PdfStringTests.cs
@@ -427,4 +427,65 @@ public class PdfStringTests
 
         result.Should().Contain("\\000");
     }
+
+    // ---- PDFDocEncoding (ISO 32000-1 Annex D.3): the 0x80–0x9F / 0x18–0x1F
+    // / 0xA0 code points are typographic characters, not the C1 control
+    // characters a plain (char)b cast produces. Decoding them wrong showed
+    // tofu boxes in outline titles etc. (#361). ----
+
+    [Fact]
+    public void PdfDocEncoding_EmDash_DecodesToU2014()
+    {
+        // "Part I—Fundamentals": byte 0x84 is an em dash, not a C1 control box.
+        var str = new PdfString(new byte[]
+            { (byte)'P', (byte)'a', (byte)'r', (byte)'t', (byte)' ', (byte)'I', 0x84,
+              (byte)'F', (byte)'O', (byte)'S', (byte)'S' });
+
+        str.Value.Should().Be("Part I—FOSS");
+        str.Value.Should().NotContain("", "0x84 must not decode to the C1 control char");
+    }
+
+    [Fact]
+    public void PdfDocEncoding_RightSingleQuote_DecodesToU2019()
+    {
+        var str = new PdfString(new byte[] { (byte)'D', 0x90, (byte)'t' });
+
+        str.Value.Should().Be("D’t"); // Doesn’t-style apostrophe
+    }
+
+    [Theory]
+    [InlineData(0x80, '•')] // bullet
+    [InlineData(0x85, '–')] // en dash
+    [InlineData(0x8D, '“')] // left double quote
+    [InlineData(0x8E, '”')] // right double quote
+    [InlineData(0x92, '™')] // trademark
+    [InlineData(0x96, 'Œ')] // OE ligature
+    [InlineData(0xA0, '€')] // euro
+    [InlineData(0x1A, 'ˆ')] // modifier circumflex
+    public void PdfDocEncoding_SpecialCodePoints_MapToUnicode(int rawByte, char expected)
+    {
+        var str = new PdfString(new byte[] { (byte)rawByte });
+
+        str.Value.Should().Be(expected.ToString());
+    }
+
+    [Fact]
+    public void PdfDocEncoding_PlainAsciiAndLatin1_Unchanged()
+    {
+        // Printable ASCII and printable Latin-1 high range still pass through.
+        var str = new PdfString(Encoding.Latin1.GetBytes("Café (déjà) 2024"));
+
+        str.Value.Should().Be("Café (déjà) 2024");
+    }
+
+    [Fact]
+    public void Utf16BomString_TakesPrecedenceOverPdfDocEncoding()
+    {
+        // A string with the UTF-16BE BOM must decode as UTF-16, never via the
+        // PDFDocEncoding table.
+        var str = new PdfString("Hello世界");
+
+        str.Bytes.Should().StartWith(new byte[] { 0xFE, 0xFF });
+        str.Value.Should().Be("Hello世界");
+    }
 }

--- a/Pdfe.Core/Primitives/PdfString.cs
+++ b/Pdfe.Core/Primitives/PdfString.cs
@@ -96,19 +96,88 @@ public sealed class PdfString : PdfObject, IEquatable<PdfString>
     }
 
     /// <summary>
-    /// Decode bytes using PDFDocEncoding.
+    /// Decode bytes using PDFDocEncoding (ISO 32000-1 Annex D.3).
     /// </summary>
+    /// <remarks>
+    /// PDFDocEncoding agrees with Latin-1 across the printable Latin-1 range,
+    /// but assigns typographic characters to code points that Latin-1 leaves
+    /// as control characters — notably 0x80–0x9F (bullet, dagger, em/en dash,
+    /// curly quotes, ligatures, …), 0x18–0x1F (spacing diacritics) and 0xA0
+    /// (€). Decoding those with a plain <c>(char)b</c> cast yields C1 control
+    /// characters that render as tofu boxes (e.g. a bookmark titled
+    /// "Part I—Fundamentals" came out as "Part I□Fundamentals"). See
+    /// <see cref="PdfDocEncodingTable"/>.
+    /// </remarks>
     private static string DecodePdfDocEncoding(byte[] bytes)
     {
         var sb = new StringBuilder(bytes.Length);
         foreach (byte b in bytes)
-        {
-            // PDFDocEncoding maps 0-127 to ASCII, 128-255 to specific characters
-            // For simplicity, we use ISO-8859-1 which is close enough for most cases
-            // A full implementation would have a mapping table for 128-159
-            sb.Append((char)b);
-        }
+            sb.Append(PdfDocEncodingTable[b]);
         return sb.ToString();
+    }
+
+    /// <summary>
+    /// PDFDocEncoding → Unicode for all 256 byte values (ISO 32000-1 Table
+    /// D.2). Identity for everything except the typographic code points; the
+    /// two positions the spec leaves undefined (0x9F, 0xAD) fall through to
+    /// their Latin-1 value so no data is lost on round-trip.
+    /// </summary>
+    private static readonly char[] PdfDocEncodingTable = BuildPdfDocEncodingTable();
+
+    private static char[] BuildPdfDocEncodingTable()
+    {
+        var table = new char[256];
+        for (int i = 0; i < 256; i++)
+            table[i] = (char)i; // Latin-1 default
+
+        // 0x18–0x1F: spacing diacritics.
+        table[0x18] = '˘'; // breve
+        table[0x19] = 'ˇ'; // caron
+        table[0x1A] = 'ˆ'; // modifier circumflex
+        table[0x1B] = '˙'; // dot above
+        table[0x1C] = '˝'; // double acute
+        table[0x1D] = '˛'; // ogonek
+        table[0x1E] = '˚'; // ring above
+        table[0x1F] = '˜'; // small tilde
+
+        // 0x80–0x9E: punctuation, symbols, ligatures, Latin letters.
+        table[0x80] = '•'; // bullet
+        table[0x81] = '†'; // dagger
+        table[0x82] = '‡'; // double dagger
+        table[0x83] = '…'; // horizontal ellipsis
+        table[0x84] = '—'; // em dash
+        table[0x85] = '–'; // en dash
+        table[0x86] = 'ƒ'; // florin
+        table[0x87] = '⁄'; // fraction slash
+        table[0x88] = '‹'; // single left-pointing angle quote
+        table[0x89] = '›'; // single right-pointing angle quote
+        table[0x8A] = '−'; // minus sign
+        table[0x8B] = '‰'; // per mille
+        table[0x8C] = '„'; // double low-9 quote
+        table[0x8D] = '“'; // left double quote
+        table[0x8E] = '”'; // right double quote
+        table[0x8F] = '‘'; // left single quote
+        table[0x90] = '’'; // right single quote
+        table[0x91] = '‚'; // single low-9 quote
+        table[0x92] = '™'; // trademark
+        table[0x93] = 'ﬁ'; // fi ligature
+        table[0x94] = 'ﬂ'; // fl ligature
+        table[0x95] = 'Ł'; // L with stroke
+        table[0x96] = 'Œ'; // OE
+        table[0x97] = 'Š'; // S with caron
+        table[0x98] = 'Ÿ'; // Y with diaeresis
+        table[0x99] = 'Ž'; // Z with caron
+        table[0x9A] = 'ı'; // dotless i
+        table[0x9B] = 'ł'; // l with stroke
+        table[0x9C] = 'œ'; // oe
+        table[0x9D] = 'š'; // s with caron
+        table[0x9E] = 'ž'; // z with caron
+        // 0x9F is undefined in PDFDocEncoding → leave as Latin-1.
+
+        table[0xA0] = '€'; // euro
+        // 0xAD is undefined in PDFDocEncoding → leave as Latin-1.
+
+        return table;
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #361.

**Repro:** open a PDF whose bookmarks use em-dashes / curly quotes (e.g. a book with `Part I—Fundamentals`). The outline showed `Part I□Fundamentals` and `One Size Doesn□t Fit All` — boxes where typographic characters belong.

**Cause:** `PdfString.DecodePdfDocEncoding` decoded every byte with `(char)b` (ISO-8859-1). PDFDocEncoding (ISO 32000-1 Annex D.3) assigns printable typographic characters to 0x80–0x9F, 0x18–0x1F and 0xA0, where Latin-1 has C1 control characters — so `0x84` (em-dash) became U+0084 (tofu), `0x90` (’) became U+0090, etc.

**Fix:** decode through the full PDFDocEncoding → Unicode table (em/en dash, bullet, dagger, ellipsis, curly quotes, fi/fl ligatures, Œœ/Šš/Žž, €, spacing diacritics…). Identity for the printable ASCII/Latin-1 ranges; the two spec-undefined positions (0x9F, 0xAD) fall through to Latin-1. UTF-16BE BOM detection is unchanged and still takes precedence.

This affects every non-UTF-16 PDF *text string*: outline/bookmark titles, the Info dictionary, annotation contents, and form-field values.

## Tests
- New `PdfStringTests`: em-dash → U+2014, right-quote → U+2019, plus a theory over bullet/en-dash/quotes/™/Œ/€/diacritic; ASCII + printable Latin-1 unchanged; UTF-16 BOM still wins.
- Corrected one pre-existing content-stream round-trip test that fed an accidental `0x1C` byte (C#'s greedy `\x` escape turned `\x01Control` into U+001C) and relied on the old identity decode.
- Full `Pdfe.Core.Tests`: **2574 pass**, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)