### PR TITLE
Fix the remaining known bug/security/correctness issues (#345 #346 #347 #353 #359 #364)

### DIFF
--- a/Pdfe.Core.Tests/Content/Operators/InlineImageTests.cs
+++ b/Pdfe.Core.Tests/Content/Operators/InlineImageTests.cs
@@ -294,4 +294,45 @@ public class InlineImageTests
         tj[0].TextContent.Should().Be("before");
         tj[1].TextContent.Should().Be("after");
     }
+
+    [Fact]
+    public void Parse_LargeInlineImage_NoLength_ScansLinearly_FindsRealEI()
+    {
+        // 8 MB of binary data WITHOUT /L, sprinkled with non-boundary "EI"
+        // byte sequences that must NOT be mistaken for the end marker. An
+        // O(n^2) scan would take minutes here; the O(n) boundary scan finds the
+        // real EI quickly. (#347)
+        const int size = 8 * 1024 * 1024;
+        var raw = new byte[size];
+        for (int i = 0; i < size; i++) raw[i] = (byte)((i % 251) + 1); // non-zero, no whitespace
+        for (int i = 1000; i < size - 1000; i += 4096) { raw[i] = (byte)'E'; raw[i + 1] = (byte)'I'; }
+
+        var header = Encoding.ASCII.GetBytes("BI /W 1 /H 1 /BPC 8 /CS /G ID ");
+        var footer = Encoding.ASCII.GetBytes("\nEI\nBT (after) Tj ET\n");
+        var content = header.Concat(raw).Concat(footer).ToArray();
+
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        var result = new ContentStreamParser(content).Parse();
+        sw.Stop();
+
+        result.Operators.Should().ContainSingle(op => op.Name == "BI");
+        result.Operators.Should().Contain(op => op.Name == "Tj",
+            "the operator after the real word-boundary EI must be reached");
+        sw.Elapsed.Should().BeLessThan(System.TimeSpan.FromSeconds(10),
+            "the scan must be linear, not O(n^2)");
+    }
+
+    [Fact]
+    public void Parse_InlineImage_NoLength_NoEI_ScansToEndGracefully()
+    {
+        // No /L and no EI marker: the scan runs to end-of-content (bounded by
+        // the safety cap) and still yields exactly one BI without hanging. (#347)
+        var raw = new byte[1024];
+        for (int i = 0; i < raw.Length; i++) raw[i] = (byte)((i % 200) + 1);
+        var content = Encoding.ASCII.GetBytes("BI /W 1 /H 1 /BPC 8 /CS /G ID ").Concat(raw).ToArray();
+
+        var result = new ContentStreamParser(content).Parse();
+
+        result.Operators.Count(op => op.Name == "BI").Should().Be(1);
+    }
 }

--- a/Pdfe.Core.Tests/Parsing/ParserHardeningTests.cs
+++ b/Pdfe.Core.Tests/Parsing/ParserHardeningTests.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Text;
+using System.Threading;
+using AwesomeAssertions;
+using Pdfe.Core.Content;
+using Pdfe.Core.Parsing;
+using Xunit;
+
+namespace Pdfe.Core.Tests.Parsing;
+
+/// <summary>
+/// #346: the parsers must survive hostile input — bound recursion (deeply
+/// nested arrays/dicts) with a typed exception instead of a StackOverflow, and
+/// honor a CancellationToken so a caller can bound a runaway parse.
+/// </summary>
+public class ParserHardeningTests
+{
+    // ---- recursion-depth guard ----
+
+    [Fact]
+    public void PdfParser_DeeplyNestedArray_ThrowsTypedException_NotStackOverflow()
+    {
+        var data = Encoding.ASCII.GetBytes(new string('[', 5000));
+        var parser = new PdfParser(data);
+
+        var act = () => parser.ParseObject();
+
+        act.Should().Throw<PdfParseException>().WithMessage("*nesting depth*");
+    }
+
+    [Fact]
+    public void PdfParser_DeeplyNestedDictionary_ThrowsTypedException()
+    {
+        var data = Encoding.ASCII.GetBytes(string.Concat(System.Linq.Enumerable.Repeat("<< /a ", 5000)));
+        var parser = new PdfParser(data);
+
+        var act = () => parser.ParseObject();
+
+        act.Should().Throw<PdfParseException>().WithMessage("*nesting depth*");
+    }
+
+    [Fact]
+    public void ContentStreamParser_DeeplyNestedArray_ThrowsTypedException()
+    {
+        // A content-stream operand of 5000 nested arrays would recurse
+        // ParseArray->ParseToken->ParseArray to a StackOverflow without a guard.
+        var content = Encoding.ASCII.GetBytes(new string('[', 5000));
+        var parser = new ContentStreamParser(content);
+
+        var act = () => parser.Parse();
+
+        act.Should().Throw<PdfParseException>().WithMessage("*nesting depth*");
+    }
+
+    [Fact]
+    public void ContentStreamParser_LegitimateNesting_ParsesFine()
+    {
+        // A normal TJ array with a modest nested array still parses.
+        var content = Encoding.ASCII.GetBytes("BT /F1 12 Tf [ (a) -10 (b) [1 2] ] TJ ET");
+        var parser = new ContentStreamParser(content);
+
+        var result = parser.Parse();
+
+        result.Operators.Should().Contain(op => op.Name == "TJ");
+    }
+
+    // ---- cancellation ----
+
+    [Fact]
+    public void ContentStreamParser_CancelledToken_ThrowsOperationCanceled()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var parser = new ContentStreamParser(Encoding.ASCII.GetBytes("BT /F1 12 Tf (hello) Tj ET"));
+
+        var act = () => parser.Parse(cts.Token);
+
+        act.Should().Throw<OperationCanceledException>();
+    }
+
+    [Fact]
+    public void ContentStreamParser_DefaultToken_DoesNotCancel()
+    {
+        var parser = new ContentStreamParser(Encoding.ASCII.GetBytes("BT /F1 12 Tf (hello) Tj ET"));
+
+        var act = () => parser.Parse(); // CancellationToken.None
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void PdfParser_CancelledToken_ThrowsOperationCanceled()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var parser = new PdfParser(Encoding.ASCII.GetBytes("[1 2 3]")) { CancellationToken = cts.Token };
+
+        var act = () => parser.ParseObject();
+
+        act.Should().Throw<OperationCanceledException>();
+    }
+}

--- a/Pdfe.Core.Tests/Pdfe.Core.Tests.csproj
+++ b/Pdfe.Core.Tests/Pdfe.Core.Tests.csproj
@@ -7,6 +7,12 @@
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+
+    <!-- xUnit1051 asks every call to a CancellationToken-accepting method (e.g.
+         the new ContentStreamParser.Parse(ct), #346) to thread
+         TestContext.Current.CancellationToken. That's noise for unit tests that
+         intentionally call the parameterless overload. -->
+    <NoWarn>$(NoWarn);xUnit1051</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Pdfe.Core.Tests/Text/Segmentation/CidRedactionEndToEndTests.cs
+++ b/Pdfe.Core.Tests/Text/Segmentation/CidRedactionEndToEndTests.cs
@@ -1,0 +1,113 @@
+using System.IO;
+using System.Linq;
+using System.Text;
+using AwesomeAssertions;
+using Pdfe.Core.Document;
+using Pdfe.Core.Text.Segmentation;
+using Xunit;
+
+namespace Pdfe.Core.Tests.Text.Segmentation;
+
+/// <summary>
+/// End-to-end CID/Type0 (CJK) redaction on a real Identity-H PDF (issue #353):
+/// redacting one CJK glyph must remove its original 2-byte code from the rebuilt
+/// content stream while the surviving glyph keeps its ORIGINAL code (not a
+/// Unicode/UTF-8 re-encoding a CID font can't render). This exercises the whole
+/// pipeline through the real extractor + content-stream parser, not synthetic
+/// Letter objects.
+/// </summary>
+public class CidRedactionEndToEndTests
+{
+    // 中 = U+4E2D (CID 0x4E2D), 文 = U+6587 (CID 0x6587), drawn via <4E2D6587> Tj.
+    private static readonly byte[] ZhongCode = { 0x4E, 0x2D };
+    private static readonly byte[] WenCode = { 0x65, 0x87 };
+
+    [Fact]
+    public void RedactArea_OverSecondCjkGlyph_RemovesItsCode_KeepsFirstWithOriginalCode()
+    {
+        var pdf = BuildIdentityHPdf();
+        using var doc = PdfDocument.Open(pdf);
+        var page = doc.GetPage(1);
+
+        // Sanity: the extractor reads both CJK letters with their CID codes.
+        var letters = page.Letters;
+        string.Concat(letters.Select(l => l.Value)).Should().Contain("中文",
+            "the Identity-H + ToUnicode font must extract as 中文");
+
+        // Locate 文 (the 2nd glyph) and redact a band over just it.
+        var wen = letters.First(l => l.Value == "文");
+        var area = new PdfRectangle(wen.GlyphRectangle.Left + 0.5, wen.GlyphRectangle.Bottom - 2,
+                                    wen.GlyphRectangle.Right + 2, wen.GlyphRectangle.Top + 2);
+        page.RedactArea(area, GlyphRemovalStrategy.AnyOverlap);
+
+        var saved = doc.SaveToBytes();
+        var content = Encoding.Latin1.GetString(
+            PdfDocument.Open(saved).GetPage(1).GetContentStreamBytes());
+
+        content.Should().NotContain(Encoding.Latin1.GetString(WenCode),
+            "the redacted glyph's original 2-byte CID code must be gone from the rebuilt stream");
+        content.Should().Contain(Encoding.Latin1.GetString(ZhongCode),
+            "the surviving glyph keeps its ORIGINAL 2-byte CID code");
+        // And NOT re-encoded as UTF-8 (a CID font can't render Unicode bytes).
+        content.Should().NotContain(Encoding.Latin1.GetString(Encoding.UTF8.GetBytes("中")),
+            "the kept CJK glyph must not be emitted as UTF-8");
+    }
+
+    /// <summary>
+    /// Minimal one-page PDF whose only text is two CJK glyphs in a Type0
+    /// Identity-H font with a ToUnicode CMap and /W widths (no embedded font
+    /// file needed — the extractor uses widths + ToUnicode).
+    /// </summary>
+    private static byte[] BuildIdentityHPdf()
+    {
+        // ToUnicode CMap: CID code -> Unicode (identity here, since these CIDs
+        // equal their code points).
+        var cmap =
+            "/CIDInit /ProcSet findresource begin\n12 dict begin\nbegincmap\n" +
+            "/CMapType 2 def\n1 begincodespacerange\n<0000> <FFFF>\nendcodespacerange\n" +
+            "2 beginbfchar\n<4E2D> <4E2D>\n<6587> <6587>\nendbfchar\n" +
+            "endcmap\nCMapName currentdict /CMap defineresource pop\nend\nend\n";
+
+        var content = "BT /F1 24 Tf 100 700 Td <4E2D6587> Tj ET";
+
+        // Object bodies (1..8).
+        var bodies = new[]
+        {
+            "<< /Type /Catalog /Pages 2 0 R >>",
+            "<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R " +
+                "/Resources << /Font << /F1 5 0 R >> >> >>",
+            StreamBody("", content),
+            "<< /Type /Font /Subtype /Type0 /BaseFont /STSong /Encoding /Identity-H " +
+                "/DescendantFonts [6 0 R] /ToUnicode 7 0 R >>",
+            "<< /Type /Font /Subtype /CIDFontType2 /BaseFont /STSong " +
+                "/CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> " +
+                "/FontDescriptor 8 0 R /CIDToGIDMap /Identity /DW 1000 " +
+                "/W [ 20013 [1000] 25991 [1000] ] >>",
+            StreamBody("", cmap),
+            "<< /Type /FontDescriptor /FontName /STSong /Flags 4 /FontBBox [0 0 1000 1000] " +
+                "/ItalicAngle 0 /Ascent 1000 /Descent 0 /CapHeight 1000 /StemV 80 >>",
+        };
+
+        using var ms = new MemoryStream();
+        void W(string s) { var b = Encoding.Latin1.GetBytes(s); ms.Write(b, 0, b.Length); }
+        W("%PDF-1.5\n");
+        var off = new long[bodies.Length + 1];
+        for (int i = 0; i < bodies.Length; i++)
+        {
+            off[i + 1] = ms.Position;
+            W($"{i + 1} 0 obj\n{bodies[i]}\nendobj\n");
+        }
+        long xref = ms.Position;
+        W($"xref\n0 {bodies.Length + 1}\n0000000000 65535 f \n");
+        for (int i = 1; i <= bodies.Length; i++) W($"{off[i]:D10} 00000 n \n");
+        W($"trailer\n<< /Root 1 0 R /Size {bodies.Length + 1} >>\nstartxref\n{xref}\n%%EOF");
+        return ms.ToArray();
+    }
+
+    private static string StreamBody(string dictExtra, string content)
+    {
+        var data = Encoding.Latin1.GetBytes(content);
+        return $"<< {dictExtra} /Length {data.Length} >>\nstream\n{content}\nendstream";
+    }
+}

--- a/Pdfe.Core.Tests/Writing/PdfDocumentWriterTests.cs
+++ b/Pdfe.Core.Tests/Writing/PdfDocumentWriterTests.cs
@@ -359,4 +359,35 @@ public class PdfDocumentWriterTests
     }
 
     #endregion
+
+    #region Cross-reference plumbing not re-emitted (#359)
+
+    [Fact]
+    public void Save_DropsObjStmAndXRefStreams_SoFreedCompressedObjectsCannotLeak()
+    {
+        // The writer emits a classic xref table and writes object-stream members
+        // as standalone objects. Re-emitting the /ObjStm (or /XRef) container is
+        // redundant AND a leak path: a redacted Form XObject that was inlined and
+        // freed (RemoveObject) would still ship inside the container's bytes. (#359)
+        using var doc = PdfDocument.Open(CreateSimplePdf("Hi"));
+
+        var keep = new PdfStream(System.Text.Encoding.ASCII.GetBytes("KEEPME_DATA"));
+        doc.AddIndirectObject(keep);
+
+        var objStm = new PdfStream(System.Text.Encoding.ASCII.GetBytes("SECRET_IN_OBJSTM"));
+        objStm["Type"] = new PdfName("ObjStm");
+        doc.AddIndirectObject(objStm);
+
+        var xref = new PdfStream(System.Text.Encoding.ASCII.GetBytes("SECRET_IN_XREF"));
+        xref["Type"] = new PdfName("XRef");
+        doc.AddIndirectObject(xref);
+
+        var saved = System.Text.Encoding.Latin1.GetString(doc.SaveToBytes());
+
+        saved.Should().Contain("KEEPME_DATA", "normal objects are still written");
+        saved.Should().NotContain("SECRET_IN_OBJSTM", "/ObjStm containers must not be re-emitted");
+        saved.Should().NotContain("SECRET_IN_XREF", "/XRef streams must not be re-emitted");
+    }
+
+    #endregion
 }

--- a/Pdfe.Core/Content/ContentStreamParser.cs
+++ b/Pdfe.Core/Content/ContentStreamParser.cs
@@ -1,6 +1,9 @@
+using System;
 using System.Text;
+using System.Threading;
 using Pdfe.Core.Document;
 using Pdfe.Core.Primitives;
+using Pdfe.Core.Parsing;
 
 namespace Pdfe.Core.Content;
 
@@ -13,6 +16,15 @@ public class ContentStreamParser
     private readonly byte[] _content;
     private readonly PdfPage? _page;
     private int _pos;
+
+    // Hostile-input guards (#346): bound recursion (nested arrays) and offer a
+    // cooperative cancellation point so a pathological stream can't spin or
+    // overflow the stack past the caller's timeout.
+    private int _nestingDepth;
+    private CancellationToken _cancellationToken;
+
+    /// <summary>Max nesting depth for content-stream arrays before bailing.</summary>
+    public int MaxNestingDepth { get; set; } = 256;
 
     // Graphics state tracking
     private readonly Stack<GraphicsState> _stateStack = new();
@@ -56,14 +68,19 @@ public class ContentStreamParser
     /// <summary>
     /// Parse the content stream into a ContentStream object.
     /// </summary>
-    public ContentStream Parse()
+    /// <param name="cancellationToken">Cooperatively cancels a runaway parse of
+    /// hostile/huge input (#346).</param>
+    public ContentStream Parse(CancellationToken cancellationToken = default)
     {
+        _cancellationToken = cancellationToken;
+        _nestingDepth = 0;
         _pos = 0;
         var operators = new List<ContentOperator>();
         var operands = new List<PdfObject>();
 
         while (_pos < _content.Length)
         {
+            _cancellationToken.ThrowIfCancellationRequested();
             SkipWhitespaceAndComments();
             if (_pos >= _content.Length) break;
 
@@ -1218,24 +1235,38 @@ public class ContentStreamParser
 
     private PdfArray ParseArray()
     {
-        var result = new PdfArray();
-        _pos++; // Skip '['
-
-        while (_pos < _content.Length)
+        // Bound recursion: ParseArray -> ParseToken -> ParseArray for nested
+        // arrays. A deeply nested array in hostile input would otherwise drive
+        // a StackOverflow. (#346)
+        if (++_nestingDepth > MaxNestingDepth)
         {
-            SkipWhitespaceAndComments();
-            if (_pos >= _content.Length || _content[_pos] == ']')
+            _nestingDepth--;
+            throw new PdfParseException(
+                $"Maximum nesting depth ({MaxNestingDepth}) exceeded while parsing content-stream array");
+        }
+        try
+        {
+            var result = new PdfArray();
+            _pos++; // Skip '['
+
+            while (_pos < _content.Length)
             {
-                _pos++;
-                break;
+                _cancellationToken.ThrowIfCancellationRequested();
+                SkipWhitespaceAndComments();
+                if (_pos >= _content.Length || _content[_pos] == ']')
+                {
+                    _pos++;
+                    break;
+                }
+
+                var item = ParseToken();
+                if (item is PdfObject pdfObj)
+                    result.Add(pdfObj);
             }
 
-            var item = ParseToken();
-            if (item is PdfObject pdfObj)
-                result.Add(pdfObj);
+            return result;
         }
-
-        return result;
+        finally { _nestingDepth--; }
     }
 
     private PdfName ParseName()

--- a/Pdfe.Core/Content/ContentStreamParser.cs
+++ b/Pdfe.Core/Content/ContentStreamParser.cs
@@ -26,6 +26,13 @@ public class ContentStreamParser
     /// <summary>Max nesting depth for content-stream arrays before bailing.</summary>
     public int MaxNestingDepth { get; set; } = 256;
 
+    /// <summary>
+    /// Upper bound on an inline image's data scan when no <c>/L</c> length is
+    /// declared (#347). Inline images are meant to be small (§8.9.7); this is
+    /// far larger than any legitimate one and just bounds malicious input.
+    /// </summary>
+    private const int MaxInlineImageScanBytes = 64 * 1024 * 1024;
+
     // Graphics state tracking
     private readonly Stack<GraphicsState> _stateStack = new();
     private GraphicsState _state = new();
@@ -761,12 +768,20 @@ public class ContentStreamParser
         }
 
         // 2b. No usable length: scan for 'EI' at a word boundary, consuming raw
-        // image data. This is O(n) in the data size and always terminates.
+        // image data. Each iteration advances _pos by at least one byte and
+        // does a constant-time boundary check, so this is O(n) in the data size
+        // and always terminates. A safety bound bails on absurd input — an
+        // inline image with no /L that exceeds MaxInlineImageScanBytes without a
+        // boundary EI is treated as malformed rather than scanned to the end of
+        // a huge stream. (#347)
         if (!consumed)
         {
             dataEnd = _content.Length;
             while (_pos < _content.Length)
             {
+                if (_pos - dataStart > MaxInlineImageScanBytes)
+                    throw new PdfParseException(
+                        $"Inline image (no /L) exceeded {MaxInlineImageScanBytes} bytes without an EI marker");
                 if (IsWhitespaceByte(_content[_pos]) || _pos == dataStart)
                 {
                     // Consume the whitespace, then check for 'EI'

--- a/Pdfe.Core/Document/PdfAnnotationParser.cs
+++ b/Pdfe.Core/Document/PdfAnnotationParser.cs
@@ -178,7 +178,7 @@ internal static class PdfAnnotationParser
 
         byte[]? bytes;
         try { bytes = stream.DecodedData; }
-        catch { bytes = null; }
+        catch (Exception __ex) when (__ex is not OutOfMemoryException) { bytes = null; }
 
         var mime = stream.GetNameOrNull("Subtype");
         return (fileName, bytes, mime);
@@ -368,7 +368,7 @@ internal static class PdfAnnotationParser
 
             return new DateTimeOffset(year, month, day, hour, minute, second, offset);
         }
-        catch
+        catch (Exception __ex) when (__ex is not OutOfMemoryException)
         {
             return null;
         }

--- a/Pdfe.Core/Document/PdfDocument.cs
+++ b/Pdfe.Core/Document/PdfDocument.cs
@@ -106,7 +106,7 @@ public class PdfDocument : IDisposable
                     {
                         PdfObject target;
                         try { target = GetObject(r.ObjectNum); }
-                        catch { break; }
+                        catch (Exception __ex) when (__ex is not OutOfMemoryException) { break; }
                         stack.Push(target);
                     }
                     break;
@@ -250,7 +250,7 @@ public class PdfDocument : IDisposable
         {
             return Open(stream, ownsStream: true, allowEncrypted: allowEncrypted);
         }
-        catch
+        catch (Exception __ex) when (__ex is not OutOfMemoryException)
         {
             stream.Dispose();
             throw;
@@ -596,7 +596,7 @@ public class PdfDocument : IDisposable
                 {
                     _decompressor.Decompress(s);
                 }
-                catch
+                catch (Exception __ex) when (__ex is not OutOfMemoryException)
                 {
                     // Some streams can't be decompressed (images, etc.) - that's OK
                 }
@@ -661,7 +661,7 @@ public class PdfDocument : IDisposable
     private PdfObject? ResolveLengthReference(int objectNumber)
     {
         try { return GetObject(objectNumber); }
-        catch { return null; }
+        catch (Exception __ex) when (__ex is not OutOfMemoryException) { return null; }
     }
 
     /// <summary>
@@ -839,7 +839,7 @@ public class PdfDocument : IDisposable
         if (metaObj == null) return null;
         if (Resolve(metaObj) is not PdfStream stream) return null;
         try { return stream.DecodedData; }
-        catch { return null; }
+        catch (Exception __ex) when (__ex is not OutOfMemoryException) { return null; }
     }
 
     /// <summary>

--- a/Pdfe.Core/Document/PdfEmbeddedFileParser.cs
+++ b/Pdfe.Core/Document/PdfEmbeddedFileParser.cs
@@ -135,7 +135,7 @@ internal static class PdfEmbeddedFileParser
             if (fileStreamObj != null && doc.Resolve(fileStreamObj) is PdfStream stream)
             {
                 try { bytes = stream.DecodedData; }
-                catch { bytes = null; }
+                catch (Exception __ex) when (__ex is not OutOfMemoryException) { bytes = null; }
 
                 mimeType = stream.GetNameOrNull("Subtype");
 
@@ -206,7 +206,7 @@ internal static class PdfEmbeddedFileParser
             var dt = new DateTime(year, month, day, hour, minute, second);
             return new DateTimeOffset(dt, offset);
         }
-        catch
+        catch (Exception __ex) when (__ex is not OutOfMemoryException)
         {
             return null;
         }

--- a/Pdfe.Core/Fonts/CffParser.cs
+++ b/Pdfe.Core/Fonts/CffParser.cs
@@ -172,7 +172,7 @@ internal static class CffParser
                 CidToGlyph = cidToGlyph,
             };
         }
-        catch
+        catch (Exception __ex) when (__ex is not OutOfMemoryException)
         {
             return null;
         }

--- a/Pdfe.Core/Parsing/PdfParser.cs
+++ b/Pdfe.Core/Parsing/PdfParser.cs
@@ -364,7 +364,7 @@ public class PdfParser : IDisposable
             _lexer.Seek(savedPos);
             return ParseIndirectObject();
         }
-        catch
+        catch (Exception __ex) when (__ex is not OutOfMemoryException)
         {
             _lexer.Seek(savedPos);
             return null;

--- a/Pdfe.Core/Parsing/PdfParser.cs
+++ b/Pdfe.Core/Parsing/PdfParser.cs
@@ -28,6 +28,14 @@ public class PdfParser : IDisposable
     public int MaxNestingDepth { get; set; } = 512;
 
     /// <summary>
+    /// Cooperative cancellation for runaway parses of hostile/huge input.
+    /// Checked at object-parse entry and inside the array/dictionary element
+    /// loops, so a caller's timeout can bound a single pathological object
+    /// rather than only the whole document. See issue #346.
+    /// </summary>
+    public System.Threading.CancellationToken CancellationToken { get; set; } = default;
+
+    /// <summary>
     /// Creates a new parser with the specified lexer.
     /// </summary>
     public PdfParser(PdfLexer lexer, bool ownsLexer = false)
@@ -78,6 +86,7 @@ public class PdfParser : IDisposable
     /// </summary>
     public PdfObject ParseObject()
     {
+        CancellationToken.ThrowIfCancellationRequested();
         var token = _lexer.NextToken();
         return ParseObjectFromToken(token);
     }
@@ -168,6 +177,7 @@ public class PdfParser : IDisposable
 
             while (true)
             {
+                CancellationToken.ThrowIfCancellationRequested();
                 var token = _lexer.NextToken();
 
                 if (token.Type == PdfTokenType.ArrayEnd)
@@ -221,6 +231,7 @@ public class PdfParser : IDisposable
 
             while (true)
             {
+                CancellationToken.ThrowIfCancellationRequested();
                 var token = _lexer.NextToken();
 
                 if (token.Type == PdfTokenType.DictionaryEnd)

--- a/Pdfe.Core/Parsing/StreamDecompressor.cs
+++ b/Pdfe.Core/Parsing/StreamDecompressor.cs
@@ -549,7 +549,7 @@ public class StreamDecompressor
                 return DecodeGroup3_2D(data, columns, rows, K, blackIs1);
             }
         }
-        catch
+        catch (Exception __ex) when (__ex is not OutOfMemoryException)
         {
             return new byte[0];
         }
@@ -587,7 +587,7 @@ public class StreamDecompressor
 
             return output.ToArray();
         }
-        catch
+        catch (Exception __ex) when (__ex is not OutOfMemoryException)
         {
             return new byte[0];
         }
@@ -671,7 +671,7 @@ public class StreamDecompressor
 
             return output.ToArray();
         }
-        catch
+        catch (Exception __ex) when (__ex is not OutOfMemoryException)
         {
             return new byte[0];
         }
@@ -731,7 +731,7 @@ public class StreamDecompressor
 
             return output.ToArray();
         }
-        catch
+        catch (Exception __ex) when (__ex is not OutOfMemoryException)
         {
             return new byte[0];
         }

--- a/Pdfe.Core/Text/Segmentation/FormXObjectFlattener.cs
+++ b/Pdfe.Core/Text/Segmentation/FormXObjectFlattener.cs
@@ -258,7 +258,7 @@ internal static class FormXObjectFlattener
 
         byte[] formBytes;
         try { formBytes = form.DecodedData; }
-        catch { output.Add(Rewrite(op, rename)); return; } // can't decode → leave as-is
+        catch (Exception __ex) when (__ex is not OutOfMemoryException) { output.Add(Rewrite(op, rename)); return; } // can't decode → leave as-is
 
         var formOps = new ContentStreamParser(formBytes, null).Parse().Operators;
         var formResources = ctx.Resolve(form.GetOptional("Resources")) as PdfDictionary

--- a/Pdfe.Core/Text/TextExtractor.cs
+++ b/Pdfe.Core/Text/TextExtractor.cs
@@ -79,7 +79,7 @@ public class TextExtractor
     {
         IReadOnlyList<PdfField> fields;
         try { fields = _page.GetFormFields(); }
-        catch { return; }
+        catch (Exception __ex) when (__ex is not OutOfMemoryException) { return; }
 
         foreach (var field in fields)
         {
@@ -932,7 +932,7 @@ public class TextExtractor
         {
             return ToUnicodeCMapParser.Parse(stream.DecodedData);
         }
-        catch
+        catch (Exception __ex) when (__ex is not OutOfMemoryException)
         {
             // If CMap parsing fails, fall back to encoding
             return null;

--- a/Pdfe.Core/Writing/PdfDocumentWriter.cs
+++ b/Pdfe.Core/Writing/PdfDocumentWriter.cs
@@ -55,9 +55,27 @@ public class PdfDocumentWriter
 
         foreach (var (objNum, gen, obj) in objects)
         {
+            // Skip cross-reference plumbing: object streams (/ObjStm) and
+            // cross-reference streams (/XRef). GetAllObjects already yields the
+            // ObjStm's members decompressed as standalone objects, and we emit
+            // a classic xref table + trailer, so these containers are redundant.
+            // Re-emitting an /ObjStm would also be a security leak: an object
+            // freed via RemoveObject (e.g. a redacted Form XObject inlined and
+            // pruned, #359) would still ship inside the container's bytes. Their
+            // object numbers simply become free entries in the xref.
+            if (IsCrossReferencePlumbing(obj))
+                continue;
+
             _objectOffsets[objNum] = writer.BaseStream.Position;
             WriteIndirectObject(writer, objNum, gen, obj);
         }
+    }
+
+    private static bool IsCrossReferencePlumbing(PdfObject obj)
+    {
+        if (obj is not PdfStream s) return false;
+        var type = s.GetNameOrNull("Type");
+        return type == "ObjStm" || type == "XRef";
     }
 
     private void WriteIndirectObject(BinaryWriter writer, int objNum, int gen, PdfObject obj)

--- a/Pdfe.Rendering.Tests/SkiaRendererTests.cs
+++ b/Pdfe.Rendering.Tests/SkiaRendererTests.cs
@@ -112,6 +112,44 @@ public class SkiaRendererTests
         pixel.Should().NotBe(SKColors.White, "rectangle area should be filled");
     }
 
+    // ---- page /Rotate support (#356 rendering follow-up) ----
+
+    [Theory]
+    [InlineData(0, 612, 792)]
+    [InlineData(90, 792, 612)]
+    [InlineData(180, 612, 792)]
+    [InlineData(270, 792, 612)]
+    public void RenderPage_Rotation_ProducesVisualDimensions(int rotation, int expectedW, int expectedH)
+    {
+        using var doc = PdfDocument.Open(CreatePdfWithRectangle(0, 0, 50, 50));
+        var page = doc.GetPage(1);
+        page.Rotation = rotation;
+
+        using var bitmap = new SkiaRenderer().RenderPage(page, new RenderOptions { Dpi = 72 });
+
+        // 90/270 swap width and height (the page is displayed quarter-turned).
+        bitmap.Width.Should().Be(expectedW);
+        bitmap.Height.Should().Be(expectedH);
+    }
+
+    [Fact]
+    public void RenderPage_Rotation90_MovesContentBottomLeftToBitmapTopLeft()
+    {
+        // A black square in the content's bottom-left corner...
+        using var doc = PdfDocument.Open(CreatePdfWithRectangle(0, 0, 60, 60));
+        var page = doc.GetPage(1);
+        page.Rotation = 90;
+
+        using var bitmap = new SkiaRenderer().RenderPage(page, new RenderOptions { Dpi = 72 });
+
+        // ...lands in the bitmap's top-left under a clockwise 90° rotation,
+        // and the opposite corner stays background.
+        bitmap.GetPixel(15, 15).Should().NotBe(SKColors.White,
+            "the rotated content's bottom-left square renders in the top-left");
+        bitmap.GetPixel(bitmap.Width - 15, bitmap.Height - 15).Should().Be(SKColors.White,
+            "the opposite corner is background");
+    }
+
     [Fact]
     public void RenderPage_StrokedRectangle_ShowsOutline()
     {

--- a/Pdfe.Rendering/SkiaRenderer.cs
+++ b/Pdfe.Rendering/SkiaRenderer.cs
@@ -25,10 +25,15 @@ public class SkiaRenderer
     /// </summary>
     public SKBitmap RenderPage(PdfPage page, RenderOptions options)
     {
-        // Calculate pixel dimensions
         var scale = options.Dpi / 72.0;
-        var width = (int)Math.Round(page.Width * scale);
-        var height = (int)Math.Round(page.Height * scale);
+        float s = (float)scale, W = (float)page.Width, H = (float)page.Height;
+
+        // The page /Rotate entry rotates the page clockwise when displayed.
+        // The output bitmap is in *visual* dimensions (W/H swap for 90/270).
+        int rot = ((page.Rotation % 360) + 360) % 360;
+        bool quarter = rot is 90 or 270;
+        var width = (int)Math.Round((quarter ? page.Height : page.Width) * scale);
+        var height = (int)Math.Round((quarter ? page.Width : page.Height) * scale);
 
         // Create bitmap
         var bitmap = new SKBitmap(width, height, SKColorType.Rgba8888, SKAlphaType.Premul);
@@ -37,12 +42,20 @@ public class SkiaRenderer
         // Fill background
         canvas.Clear(options.BackgroundColor);
 
-        // Set up coordinate transformation:
-        // PDF: origin at bottom-left, Y increases upward
-        // Skia: origin at top-left, Y increases downward
-        // We need to: scale, then flip Y, then translate
-        canvas.Scale((float)scale, -(float)scale);
-        canvas.Translate(0, -(float)page.Height);
+        // Map content space (PDF: bottom-left origin, Y up) to device pixels
+        // (top-left origin, Y down) of the visual bitmap, applying /Rotate.
+        // Derived as the inverse of PdfPage.ToContentStreamCoordinates (#356);
+        // the 0° case is the classic scale+flip+translate. SKMatrix args are
+        // (scaleX, skewX, transX, skewY, scaleY, transY, persp0, persp1, persp2)
+        // where px = scaleX*cx + skewX*cy + transX, py = skewY*cx + scaleY*cy + transY.
+        SKMatrix m = rot switch
+        {
+            90  => new SKMatrix(0, s, 0,   s, 0, 0,     0, 0, 1),
+            180 => new SKMatrix(-s, 0, s * W,   0, s, 0,    0, 0, 1),
+            270 => new SKMatrix(0, -s, s * H,   -s, 0, s * W,  0, 0, 1),
+            _   => new SKMatrix(s, 0, 0,   0, -s, s * H,   0, 0, 1),
+        };
+        canvas.SetMatrix(m);
 
         // Render content
         var context = new RenderContext(canvas, page, options);


### PR DESCRIPTION
Closes #345, #346, #347, #353, #359, #364.

Clears the outstanding non-test bug/security/correctness issues (the redaction trio + PDFDocEncoding shipped in v2.2.0).

## Parser robustness / hardening
- **#345** — stop swallowing `OutOfMemoryException` in the best-effort `catch { return default; }` blocks across the parse/decode paths (PdfParser, StreamDecompressor, CffParser, TextExtractor, PdfDocument, embedded-file/annotation parsers, flattener). 18 catches now use `catch (Exception ex) when (ex is not OutOfMemoryException)`, so malformed-input exceptions are still tolerated but fatal exhaustion isn't hidden when processing attacker bytes.
- **#346** — bound `ContentStreamParser` array recursion (typed `PdfParseException`, default depth 256; `PdfParser` already capped dict/array) and thread a `CancellationToken` through both parsers (`ContentStreamParser.Parse(ct)` + a `PdfParser.CancellationToken` property, checked in the element loops) so a caller's timeout can bound a single pathological object. Tests: 5000-deep nesting → typed exception; cancellation honored.
- **#347** — the no-`/L` inline-image `EI` scan is already O(n) (the `/L` fast-path covers declared lengths); add an explicit 64 MB safety cap. Test: an 8 MB inline image with embedded `EI` sequences parses in ~0.3s.

## Redaction security
- **#359** — the writer no longer re-emits `/ObjStm`/`/XRef` cross-reference streams. They were redundant (members are written standalone) *and* a leak path: a Form XObject inlined and freed during flatten-redact (#355) still shipped inside its object-stream container. Verified by a writer test + 211 corpus round-trip tests.
- **#353** (critical) — end-to-end CID/Type0 (CJK) redaction proven on a real Identity-H PDF: redacting one CJK glyph removes its 2-byte code from the rebuilt stream while the survivor keeps its **original** code (not a UTF-8 re-encoding a CID font can't render). The `RawBytes` path shipped in v2.1.0; this closes the acceptance-test gap.

## Rendering
- **#364** — `SkiaRenderer` now applies the page `/Rotate` entry (bitmap sized in visual dimensions; rotation-aware content→device matrix derived from #356). The 0° path is byte-identical to before. Tests: per-rotation dimensions + content-corner placement; 113 existing renderer tests unchanged.

## Tests
- Pdfe.Core: **2714 pass**; Rendering (deterministic): **213 pass**; Cli: **22 pass**. Solution builds with **0 warnings**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)