### PR TITLE
fix(ui): decouple outline & thumbnails sidebars + toolbar toggles/shortcuts (#369)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to pdfe are documented here. Format roughly follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this project uses
 semantic versioning.
 
+## [2.2.2] — 2026-06-03
+
+### Fixed
+- **Outline and page-preview (thumbnail) sidebars are now independently
+  toggleable (#369).** The outline panel was nested inside the thumbnails
+  sidebar, so "Show Outline" did nothing unless "Show Thumbnails" was also on,
+  and hiding thumbnails hid the outline too. The left sidebar now shows when
+  *either* panel is enabled, each panel binds its own visibility, and the
+  splitter appears only when both are visible.
+
+### Added
+- **Toolbar toggle buttons** for the outline (📑) and page previews (🗐), plus
+  **keyboard shortcuts** Ctrl+Shift+O (outline) and Ctrl+Shift+T (thumbnails) —
+  the toggles were previously buried as View-menu checkboxes only. (#369)
+
 ## [2.2.1] — 2026-06-03
 
 Maintenance release: parser-robustness hardening, a rotated-page render fix,

--- a/PdfEditor.Tests/Unit/MainWindowViewModelTests.cs
+++ b/PdfEditor.Tests/Unit/MainWindowViewModelTests.cs
@@ -442,6 +442,64 @@ public class MainWindowViewModelTests
     }
 
     [Fact]
+    public void OutlineSidebar_CanShowIndependentlyOfThumbnails()
+    {
+        // Regression for #369: the outline used to be nested inside the
+        // thumbnails sidebar, so turning thumbnails off hid the outline too.
+        _viewModel.IsThumbnailsSidebarVisible = false;
+        _viewModel.IsOutlineSidebarVisible = true;
+
+        _viewModel.IsLeftSidebarVisible.Should().BeTrue(
+            "the left sidebar must stay visible for the outline even with thumbnails off");
+        _viewModel.IsSidebarSplitterVisible.Should().BeFalse(
+            "the splitter only shows when BOTH panels are visible");
+    }
+
+    [Fact]
+    public void ThumbnailsSidebar_CanShowIndependentlyOfOutline()
+    {
+        _viewModel.IsOutlineSidebarVisible = false;
+        _viewModel.IsThumbnailsSidebarVisible = true;
+
+        _viewModel.IsLeftSidebarVisible.Should().BeTrue();
+        _viewModel.IsSidebarSplitterVisible.Should().BeFalse();
+    }
+
+    [Fact]
+    public void LeftSidebar_HiddenWhenBothOutlineAndThumbnailsOff()
+    {
+        _viewModel.IsOutlineSidebarVisible = false;
+        _viewModel.IsThumbnailsSidebarVisible = false;
+
+        _viewModel.IsLeftSidebarVisible.Should().BeFalse(
+            "with neither panel enabled the whole left sidebar collapses");
+    }
+
+    [Fact]
+    public void SidebarSplitter_VisibleOnlyWhenBothPanelsVisible()
+    {
+        _viewModel.IsOutlineSidebarVisible = true;
+        _viewModel.IsThumbnailsSidebarVisible = true;
+        _viewModel.IsSidebarSplitterVisible.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ToggleOutlineCommand_FlipsOutlineVisibility()
+    {
+        var before = _viewModel.IsOutlineSidebarVisible;
+        _viewModel.ToggleOutlineCommand.Execute().Subscribe();
+        _viewModel.IsOutlineSidebarVisible.Should().Be(!before);
+    }
+
+    [Fact]
+    public void ToggleThumbnailsCommand_FlipsThumbnailsVisibility()
+    {
+        var before = _viewModel.IsThumbnailsSidebarVisible;
+        _viewModel.ToggleThumbnailsCommand.Execute().Subscribe();
+        _viewModel.IsThumbnailsSidebarVisible.Should().Be(!before);
+    }
+
+    [Fact]
     public void IsClipboardSidebarVisible_InitiallyTrue()
     {
         _viewModel.IsClipboardSidebarVisible.Should().BeTrue();

--- a/PdfEditor/ViewModels/MainWindowViewModel.cs
+++ b/PdfEditor/ViewModels/MainWindowViewModel.cs
@@ -129,6 +129,8 @@ public partial class MainWindowViewModel : ViewModelBase
 
         ToggleTextSelectionModeCommand = ReactiveCommand.Create(ToggleTextSelectionMode);
         ToggleFormAuthoringModeCommand = ReactiveCommand.Create(() => { IsFormAuthoringMode = !IsFormAuthoringMode; });
+        ToggleOutlineCommand = ReactiveCommand.Create(ToggleOutlineSidebar);
+        ToggleThumbnailsCommand = ReactiveCommand.Create(ToggleThumbnailsSidebar);
         AutoDetectFieldsCommand = ReactiveCommand.Create(() => AutoDetectAndApplyFormFields());
         CopyTextCommand = ReactiveCommand.CreateFromTask(CopyTextAsync);
         ZoomInCommand = ReactiveCommand.Create(ZoomIn);
@@ -219,6 +221,8 @@ public partial class MainWindowViewModel : ViewModelBase
 
         ToggleTextSelectionModeCommand = ReactiveCommand.Create(ToggleTextSelectionMode);
         ToggleFormAuthoringModeCommand = ReactiveCommand.Create(() => { IsFormAuthoringMode = !IsFormAuthoringMode; });
+        ToggleOutlineCommand = ReactiveCommand.Create(ToggleOutlineSidebar);
+        ToggleThumbnailsCommand = ReactiveCommand.Create(ToggleThumbnailsSidebar);
         AutoDetectFieldsCommand = ReactiveCommand.Create(() => AutoDetectAndApplyFormFields());
         CopyTextCommand = ReactiveCommand.CreateFromTask(CopyTextAsync);
         ZoomInCommand = ReactiveCommand.Create(ZoomIn);
@@ -286,7 +290,14 @@ public partial class MainWindowViewModel : ViewModelBase
     public bool IsOutlineSidebarVisible
     {
         get => _isOutlineSidebarVisible;
-        set => this.RaiseAndSetIfChanged(ref _isOutlineSidebarVisible, value);
+        set
+        {
+            this.RaiseAndSetIfChanged(ref _isOutlineSidebarVisible, value);
+            // The left sidebar Border and the inter-panel splitter are computed
+            // from both visibility flags, so re-raise them. (#369)
+            this.RaisePropertyChanged(nameof(IsLeftSidebarVisible));
+            this.RaisePropertyChanged(nameof(IsSidebarSplitterVisible));
+        }
     }
 
     private Models.OutlineNode? _selectedOutlineNode;
@@ -667,12 +678,27 @@ public partial class MainWindowViewModel : ViewModelBase
         }
     }
 
-    /// <summary>Visibility of the left thumbnail strip. Toggled from View menu.</summary>
+    /// <summary>Visibility of the left thumbnail strip. Toggled from View menu / toolbar.</summary>
     public bool IsThumbnailsSidebarVisible
     {
         get => _isThumbnailsSidebarVisible;
-        set => this.RaiseAndSetIfChanged(ref _isThumbnailsSidebarVisible, value);
+        set
+        {
+            this.RaiseAndSetIfChanged(ref _isThumbnailsSidebarVisible, value);
+            this.RaisePropertyChanged(nameof(IsLeftSidebarVisible));
+            this.RaisePropertyChanged(nameof(IsSidebarSplitterVisible));
+        }
     }
+
+    /// <summary>
+    /// The left sidebar host is shown when *either* the outline or the
+    /// thumbnails panel is enabled — so the two can be toggled independently
+    /// (previously the whole sidebar was gated on thumbnails alone). (#369)
+    /// </summary>
+    public bool IsLeftSidebarVisible => IsOutlineSidebarVisible || IsThumbnailsSidebarVisible;
+
+    /// <summary>The outline/thumbnails splitter only makes sense when both panels show. (#369)</summary>
+    public bool IsSidebarSplitterVisible => IsOutlineSidebarVisible && IsThumbnailsSidebarVisible;
 
     /// <summary>Visibility of the right clipboard / pending-redactions sidebar.</summary>
     public bool IsClipboardSidebarVisible
@@ -945,6 +971,8 @@ public partial class MainWindowViewModel : ViewModelBase
     public ReactiveCommand<Unit, Unit> ApplyAllRedactionsCommand { get; }
     public ReactiveCommand<Unit, Unit> ToggleTextSelectionModeCommand { get; }
     public ReactiveCommand<Unit, Unit> ToggleFormAuthoringModeCommand { get; }
+    public ReactiveCommand<Unit, Unit> ToggleOutlineCommand { get; }
+    public ReactiveCommand<Unit, Unit> ToggleThumbnailsCommand { get; }
     public ReactiveCommand<Unit, int> AutoDetectFieldsCommand { get; }
     public ReactiveCommand<Unit, Unit> CopyTextCommand { get; }
     public ReactiveCommand<Unit, Unit> ZoomInCommand { get; }

--- a/PdfEditor/Views/MainWindow.axaml
+++ b/PdfEditor/Views/MainWindow.axaml
@@ -136,9 +136,11 @@
                 <Separator/>
                 <MenuItem Header="Show _Outline"
                           ToggleType="CheckBox"
+                          InputGesture="Ctrl+Shift+O"
                           IsChecked="{Binding IsOutlineSidebarVisible, Mode=TwoWay}"/>
                 <MenuItem Header="Show _Thumbnails"
                           ToggleType="CheckBox"
+                          InputGesture="Ctrl+Shift+T"
                           IsChecked="{Binding IsThumbnailsSidebarVisible, Mode=TwoWay}"/>
                 <MenuItem Header="Show _Clipboard History"
                           ToggleType="CheckBox"
@@ -187,6 +189,25 @@
             <Grid ColumnDefinitions="Auto,*,Auto">
                 <!-- Left: Main Actions -->
                 <StackPanel Grid.Column="0" Orientation="Horizontal" Spacing="4">
+                    <!-- View Group: sidebar toggles (outline + page previews) -->
+                    <Button Content="📑" Command="{Binding ToggleOutlineCommand}"
+                            Classes="modern-button toggle"
+                            Classes.active="{Binding IsOutlineSidebarVisible}"
+                            Padding="10,6"
+                            ToolTip.Tip="Show/hide Outline (Ctrl+Shift+O)"
+                            AutomationProperties.Name="Toggle Outline Sidebar"
+                            AutomationProperties.HelpText="Show or hide the document outline / bookmarks panel"/>
+                    <Button Content="🗐" Command="{Binding ToggleThumbnailsCommand}"
+                            Classes="modern-button toggle"
+                            Classes.active="{Binding IsThumbnailsSidebarVisible}"
+                            Padding="10,6"
+                            ToolTip.Tip="Show/hide Page Previews (Ctrl+Shift+T)"
+                            AutomationProperties.Name="Toggle Thumbnails Sidebar"
+                            AutomationProperties.HelpText="Show or hide the page thumbnails / previews panel"/>
+
+                    <Border Width="1" Height="24" Margin="6,0"
+                            Background="{DynamicResource DividerBrush}"/>
+
                     <!-- File Group -->
                     <Button Content="📁 Open" Command="{Binding OpenFileCommand}"
                             Classes="modern-button" Padding="12,6"
@@ -445,7 +466,7 @@
                  hasn't toggled it off via View → Show Outline. -->
             <Border Grid.Column="0"
                     Width="220"
-                    IsVisible="{Binding IsThumbnailsSidebarVisible}"
+                    IsVisible="{Binding IsLeftSidebarVisible}"
                     Background="{DynamicResource SidebarBackgroundBrush}"
                     BorderBrush="{DynamicResource BorderBrush}"
                     BorderThickness="0,0,1,0">
@@ -503,10 +524,11 @@
                               Background="{DynamicResource BorderBrush}"
                               HorizontalAlignment="Stretch"
                               ResizeDirection="Rows"
-                              IsVisible="{Binding IsOutlineSidebarVisible}"/>
+                              IsVisible="{Binding IsSidebarSplitterVisible}"/>
 
                 <!-- Thumbnails -->
-                <Grid Grid.Row="2" RowDefinitions="Auto,*">
+                <Grid Grid.Row="2" RowDefinitions="Auto,*"
+                      IsVisible="{Binding IsThumbnailsSidebarVisible}">
                     <Border Grid.Row="0"
                             Background="{DynamicResource SecondaryBackgroundBrush}"
                             BorderBrush="{DynamicResource BorderBrush}"

--- a/PdfEditor/Views/MainWindow.axaml.cs
+++ b/PdfEditor/Views/MainWindow.axaml.cs
@@ -207,6 +207,25 @@ public partial class MainWindow : Window
         if (DataContext is not MainWindowViewModel viewModel)
             return;
 
+        // Sidebar toggles. These Ctrl+Shift combos are checked FIRST, before the
+        // plain Ctrl+O handler below (which doesn't exclude Shift and would
+        // otherwise swallow Ctrl+Shift+O). (#369)
+        // Ctrl+Shift+O: toggle the outline / bookmarks sidebar
+        if (e.Key == Key.O && e.KeyModifiers.HasFlag(KeyModifiers.Control) && e.KeyModifiers.HasFlag(KeyModifiers.Shift))
+        {
+            viewModel.ToggleOutlineCommand?.Execute().Subscribe();
+            e.Handled = true;
+            return;
+        }
+
+        // Ctrl+Shift+T: toggle the page-previews / thumbnails sidebar
+        if (e.Key == Key.T && e.KeyModifiers.HasFlag(KeyModifiers.Control) && e.KeyModifiers.HasFlag(KeyModifiers.Shift))
+        {
+            viewModel.ToggleThumbnailsCommand?.Execute().Subscribe();
+            e.Handled = true;
+            return;
+        }
+
         // Ctrl+O: Open file
         if (e.Key == Key.O && e.KeyModifiers.HasFlag(KeyModifiers.Control))
         {


### PR DESCRIPTION
Fixes #369.

The outline panel was nested inside the thumbnails sidebar, and the whole left `Border` was gated on `IsThumbnailsSidebarVisible` — so **"Show Outline" did nothing unless "Show Thumbnails" was also on**, and turning thumbnails off hid the outline too. The toggles were also undiscoverable (View-menu checkboxes only).

### Changes
- **Decouple visibility (VM + XAML):** new computed `IsLeftSidebarVisible` (outline OR thumbnails) and `IsSidebarSplitterVisible` (outline AND thumbnails); left Border / thumbnails grid / splitter each bind to the right flag. The two panels now toggle independently.
- **Toolbar:** two new toggle buttons (📑 outline, 🗐 thumbnails) matching the existing `modern-button toggle` / `Classes.active` style.
- **Shortcuts:** Ctrl+Shift+O (outline), Ctrl+Shift+T (thumbnails), checked before the plain Ctrl+O so they aren't swallowed; shown in the View menu.
- **Tests:** 6 regression tests (independent visibility, splitter gate, both commands).

### Validation
- PdfEditor build: 0 warnings / 0 errors
- MainWindowViewModel tests: 128 passed (incl. 6 new)
- Keyboard/UI/VM filter: 160 passed / 3 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)