### PR TITLE
feat(authoring): high-level PdfDocumentBuilder writer facade (#383)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,41 @@ All notable changes to pdfe are documented here. Format roughly follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this project uses
 semantic versioning.
 
+## [2.4.0] — 2026-06-05
+
+Adds a friendly, high-level **PDF authoring** API so third-party .NET apps can
+generate PDFs from structured content without touching coordinates — the
+writer-side facade tracked by #383 (PromptResponse writer epic #382).
+
+### Added
+- **`Pdfe.Core.Authoring.PdfDocumentBuilder` — high-level writer facade (#383).**
+  A fluent, flow-layout builder over the existing `PdfGraphics` /
+  `AcroFormAuthoring` API. Content flows top-to-bottom inside the page's content
+  area with automatic word-wrap and pagination, so callers never compute
+  coordinates or manage the PDF's bottom-left Y axis.
+  - Content blocks: `Heading(level)`, `Paragraph` (word-wrap + hard-break
+    aware), `Spacer`, `HorizontalRule`, `KeyValue`, `Table` (column weights,
+    optional header row + grid lines), `PageBreak`.
+  - Fillable AcroForm fields, flow-positioned with drawn labels and borders:
+    `TextField` (multiline/required), `CheckBox`, `Dropdown` (combo). Auto-names
+    fields when none is supplied.
+  - `Custom(Action<PdfGraphics, LayoutContext>)` escape hatch to the low-level
+    API; `Build()` returns the `PdfDocument` for further manipulation;
+    `SaveToBytes()` / `Save(path)` / `Save(Stream)` output.
+- **Authoring value types.** `PageSize` (Letter/Legal/A4/A3/A5 +
+  `Landscape()`/`Portrait()`), `PageMargins` (`All`/`Symmetric`/`Default`),
+  immutable `TextStyle` record (family/size/bold/italic/color/alignment/
+  line-spacing/space-after with `With…` helpers), `FontFamily`, `LayoutContext`.
+- README: a copy-paste "Authoring PDFs from scratch (high-level)" sample.
+
+### Notes
+- Targets the base-14 fonts and Latin text available today; Unicode / embedded
+  TrueType-OpenType fonts (#378), richer text layout (#379), more AcroForm
+  field options (#380), and document metadata setters (#381) extend the facade.
+- Verified against external readers: generated forms pass `qpdf --check`,
+  `pdfinfo` reports a live `AcroForm`, content auto-paginates, and `pdftotext`
+  extracts all text. 17 new tests; full `Pdfe.Core` suite green (2744 passing).
+
 ## [2.3.1] — 2026-06-04
 
 ### Fixed

--- a/Pdfe.Avalonia/Pdfe.Avalonia.csproj
+++ b/Pdfe.Avalonia/Pdfe.Avalonia.csproj
@@ -12,7 +12,7 @@
   <!-- NuGet package metadata (packed explicitly via `dotnet pack`, not on build). -->
   <PropertyGroup>
     <PackageId>Pdfe.Avalonia</PackageId>
-    <Version>2.3.1</Version>
+    <Version>2.4.0</Version>
     <Authors>Marc Jones</Authors>
     <Description>A reusable, pure-managed PDF viewer control for Avalonia. Renders with SkiaSharp (no native PDFium), supports zoom/pan, page navigation, text selection, search highlights, annotations, links, and form-field overlays. Built on Pdfe.Core + Pdfe.Rendering.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Pdfe.Core.Tests/Authoring/PdfDocumentBuilderTests.cs
+++ b/Pdfe.Core.Tests/Authoring/PdfDocumentBuilderTests.cs
@@ -1,0 +1,241 @@
+using System.Linq;
+using System.Text;
+using AwesomeAssertions;
+using Pdfe.Core.Authoring;
+using Pdfe.Core.Document;
+using Pdfe.Core.Graphics;
+using Pdfe.Core.Text;
+using Xunit;
+
+namespace Pdfe.Core.Tests.Authoring;
+
+/// <summary>
+/// Tests for the high-level <see cref="PdfDocumentBuilder"/> writer facade
+/// (issue #383). Verifies the friendly API produces real, parseable PDFs:
+/// text is extractable, content flows across pages, and form fields are live.
+/// </summary>
+public class PdfDocumentBuilderTests
+{
+    private static string ExtractAllText(byte[] pdf)
+    {
+        using var doc = PdfDocument.Open(pdf);
+        var sb = new StringBuilder();
+        foreach (var page in doc.GetPages())
+            sb.AppendLine(new TextExtractor(page).ExtractText());
+        return sb.ToString();
+    }
+
+    [Fact]
+    public void Create_WithNoContent_ProducesNoPagesUntilContentAdded()
+    {
+        var builder = PdfDocumentBuilder.Create();
+        builder.PageCount.Should().Be(0, "pages are created lazily on first content");
+
+        builder.Paragraph("hello");
+        builder.PageCount.Should().Be(1);
+    }
+
+    [Fact]
+    public void HeadingAndParagraph_TextIsExtractable()
+    {
+        var pdf = PdfDocumentBuilder.Create()
+            .Heading("Quarterly Report")
+            .Paragraph("This document summarizes the results for the quarter.")
+            .SaveToBytes();
+
+        var text = ExtractAllText(pdf);
+        text.Should().Contain("Quarterly Report");
+        text.Should().Contain("summarizes the results");
+    }
+
+    [Fact]
+    public void SaveToBytes_RoundTripsThroughOpen()
+    {
+        var pdf = PdfDocumentBuilder.Create()
+            .Heading("Title")
+            .Paragraph("Body text.")
+            .SaveToBytes();
+
+        var act = () => PdfDocument.Open(pdf);
+        act.Should().NotThrow();
+
+        using var doc = PdfDocument.Open(pdf);
+        doc.PageCount.Should().Be(1);
+    }
+
+    [Fact]
+    public void LongContent_FlowsOntoMultiplePages()
+    {
+        var builder = PdfDocumentBuilder.Create();
+        // ~120 lines of text far exceeds one Letter page (~49 body lines).
+        for (int i = 0; i < 120; i++)
+            builder.Paragraph($"Line number {i} of the overflow test paragraph.");
+
+        var pdf = builder.SaveToBytes();
+        using var doc = PdfDocument.Open(pdf);
+        doc.PageCount.Should().BeGreaterThan(1, "content longer than a page must paginate");
+    }
+
+    [Fact]
+    public void Paragraph_WrapsLongTextWithinContentColumn()
+    {
+        // A single long paragraph with no hard breaks must wrap to many lines.
+        var longText = string.Join(" ", Enumerable.Repeat("word", 400));
+        var pdf = PdfDocumentBuilder.Create()
+            .Paragraph(longText)
+            .SaveToBytes();
+
+        var text = ExtractAllText(pdf);
+        text.Should().Contain("word");
+        // It wrapped/flowed without throwing and stayed parseable.
+        using var doc = PdfDocument.Open(pdf);
+        doc.PageCount.Should().BeGreaterThanOrEqualTo(1);
+    }
+
+    [Fact]
+    public void PageBreak_ForcesNewPage()
+    {
+        var pdf = PdfDocumentBuilder.Create()
+            .Paragraph("Page one.")
+            .PageBreak()
+            .Paragraph("Page two.")
+            .SaveToBytes();
+
+        using var doc = PdfDocument.Open(pdf);
+        doc.PageCount.Should().Be(2);
+
+        new TextExtractor(doc.GetPage(1)).ExtractText().Should().Contain("Page one");
+        new TextExtractor(doc.GetPage(2)).ExtractText().Should().Contain("Page two");
+    }
+
+    [Fact]
+    public void TextField_CreatesLiveAcroFormField()
+    {
+        var pdf = PdfDocumentBuilder.Create()
+            .TextField("Full name", fieldName: "fullName", required: true)
+            .SaveToBytes();
+
+        using var doc = PdfDocument.Open(pdf);
+        var form = doc.GetAcroForm();
+        form.Should().NotBeNull();
+        form!.Fields.Should().ContainSingle(f => f.FullName == "fullName");
+        form.Fields.Single(f => f.FullName == "fullName").FieldType.Should().Be(PdfFieldType.Text);
+
+        // The label (with required marker) is drawn as page content.
+        ExtractAllText(pdf).Should().Contain("Full name");
+    }
+
+    [Fact]
+    public void CheckBoxAndDropdown_CreateLiveFields()
+    {
+        var pdf = PdfDocumentBuilder.Create()
+            .CheckBox("I agree", fieldName: "agree")
+            .Dropdown("Country", new[] { "USA", "Canada", "Mexico" }, fieldName: "country", defaultValue: "Canada")
+            .SaveToBytes();
+
+        using var doc = PdfDocument.Open(pdf);
+        var form = doc.GetAcroForm();
+        form.Should().NotBeNull();
+        form!.Fields.Select(f => f.FullName).Should().Contain(new[] { "agree", "country" });
+    }
+
+    [Fact]
+    public void AutoFieldNames_AreUniqueWhenNotSupplied()
+    {
+        var pdf = PdfDocumentBuilder.Create()
+            .TextField("A")
+            .TextField("B")
+            .SaveToBytes();
+
+        using var doc = PdfDocument.Open(pdf);
+        var names = doc.GetAcroForm()!.Fields.Select(f => f.FullName).ToList();
+        names.Should().OnlyHaveUniqueItems();
+        names.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void KeyValue_RendersLabelAndValue()
+    {
+        var pdf = PdfDocumentBuilder.Create()
+            .KeyValue("Name", "Ada Lovelace")
+            .KeyValue("Role", "Mathematician")
+            .SaveToBytes();
+
+        var text = ExtractAllText(pdf);
+        text.Should().Contain("Name");
+        text.Should().Contain("Ada Lovelace");
+        text.Should().Contain("Mathematician");
+    }
+
+    [Fact]
+    public void Table_RendersAllCells()
+    {
+        var rows = new[]
+        {
+            new[] { "Item", "Qty", "Price" },
+            new[] { "Widget", "3", "$9.00" },
+            new[] { "Gadget", "1", "$4.50" },
+        };
+
+        var pdf = PdfDocumentBuilder.Create()
+            .Table(rows, columnWeights: new[] { 2.0, 1.0, 1.0 }, headerRow: true)
+            .SaveToBytes();
+
+        var text = ExtractAllText(pdf);
+        foreach (var cell in new[] { "Item", "Qty", "Price", "Widget", "Gadget", "$9.00", "$4.50" })
+            text.Should().Contain(cell);
+    }
+
+    [Fact]
+    public void Custom_GivesDirectGraphicsAccess()
+    {
+        var pdf = PdfDocumentBuilder.Create()
+            .Custom((g, ctx) =>
+                g.DrawString("custom drawn", PdfFont.Helvetica(12), PdfBrush.Black, ctx.Left, ctx.Top - 20))
+            .SaveToBytes();
+
+        ExtractAllText(pdf).Should().Contain("custom drawn");
+    }
+
+    [Fact]
+    public void A4Landscape_UsesRequestedPageSize()
+    {
+        var pdf = PdfDocumentBuilder.Create(PageSize.A4.Landscape())
+            .Paragraph("landscape")
+            .SaveToBytes();
+
+        using var doc = PdfDocument.Open(pdf);
+        var page = doc.GetPage(1);
+        page.Width.Should().BeGreaterThan(page.Height, "A4 landscape is wider than tall");
+        page.Width.Should().BeApproximately(841.89, 0.5);
+    }
+
+    [Theory]
+    [InlineData("", 1)]                                  // empty → one empty line
+    [InlineData("short", 1)]
+    public void WrapText_EmptyAndShortStaySingleLine(string input, int expectedLines)
+    {
+        var font = PdfFont.Helvetica(11);
+        var lines = PdfDocumentBuilder.WrapText(input, font, 400).ToList();
+        lines.Should().HaveCount(expectedLines);
+    }
+
+    [Fact]
+    public void WrapText_HardBreaksArePreserved()
+    {
+        var font = PdfFont.Helvetica(11);
+        var lines = PdfDocumentBuilder.WrapText("one\ntwo\nthree", font, 400).ToList();
+        lines.Should().Equal("one", "two", "three");
+    }
+
+    [Fact]
+    public void WrapText_WrapsWhenExceedingWidth()
+    {
+        var font = PdfFont.Helvetica(11);
+        var text = string.Join(" ", Enumerable.Repeat("word", 100));
+        var lines = PdfDocumentBuilder.WrapText(text, font, 100).ToList();
+        lines.Count.Should().BeGreaterThan(1);
+        lines.All(l => font.MeasureWidth(l) <= 100 || !l.Contains(' '))
+             .Should().BeTrue("each wrapped line fits the column (or is a single oversized word)");
+    }
+}

--- a/Pdfe.Core/Authoring/PageMargins.cs
+++ b/Pdfe.Core/Authoring/PageMargins.cs
@@ -1,0 +1,18 @@
+namespace Pdfe.Core.Authoring;
+
+/// <summary>
+/// Page margins in PDF points. The content area is the page minus these
+/// margins; the builder flows content top-to-bottom inside it.
+/// </summary>
+public readonly record struct PageMargins(double Left, double Top, double Right, double Bottom)
+{
+    /// <summary>Default 1-inch (72 pt) margins on all sides.</summary>
+    public static PageMargins Default => All(72);
+
+    /// <summary>Equal margins on all four sides.</summary>
+    public static PageMargins All(double points) => new(points, points, points, points);
+
+    /// <summary>Symmetric horizontal/vertical margins.</summary>
+    public static PageMargins Symmetric(double horizontal, double vertical) =>
+        new(horizontal, vertical, horizontal, vertical);
+}

--- a/Pdfe.Core/Authoring/PageSize.cs
+++ b/Pdfe.Core/Authoring/PageSize.cs
@@ -1,0 +1,30 @@
+namespace Pdfe.Core.Authoring;
+
+/// <summary>
+/// A page size in PDF points (1 pt = 1/72 inch), portrait by convention.
+/// Use the presets (<see cref="Letter"/>, <see cref="A4"/>, …) or construct
+/// your own; call <see cref="Landscape"/> to swap the dimensions.
+/// </summary>
+public readonly record struct PageSize(double Width, double Height)
+{
+    /// <summary>US Letter — 8.5 × 11 in (612 × 792 pt).</summary>
+    public static PageSize Letter => new(612, 792);
+
+    /// <summary>US Legal — 8.5 × 14 in (612 × 1008 pt).</summary>
+    public static PageSize Legal => new(612, 1008);
+
+    /// <summary>ISO A4 — 210 × 297 mm (595.28 × 841.89 pt).</summary>
+    public static PageSize A4 => new(595.28, 841.89);
+
+    /// <summary>ISO A3 — 297 × 420 mm (841.89 × 1190.55 pt).</summary>
+    public static PageSize A3 => new(841.89, 1190.55);
+
+    /// <summary>ISO A5 — 148 × 210 mm (419.53 × 595.28 pt).</summary>
+    public static PageSize A5 => new(419.53, 595.28);
+
+    /// <summary>Returns this size rotated to landscape (wider than tall).</summary>
+    public PageSize Landscape() => new(Math.Max(Width, Height), Math.Min(Width, Height));
+
+    /// <summary>Returns this size rotated to portrait (taller than wide).</summary>
+    public PageSize Portrait() => new(Math.Min(Width, Height), Math.Max(Width, Height));
+}

--- a/Pdfe.Core/Authoring/PdfDocumentBuilder.cs
+++ b/Pdfe.Core/Authoring/PdfDocumentBuilder.cs
@@ -1,0 +1,529 @@
+using Pdfe.Core.Document;
+using Pdfe.Core.Graphics;
+
+namespace Pdfe.Core.Authoring;
+
+/// <summary>
+/// A friendly, high-level API for authoring PDFs from structured content
+/// without touching raw coordinates or content-stream operators.
+///
+/// <para>
+/// Content flows top-to-bottom inside the page's content area (page minus
+/// <see cref="PageMargins"/>); the builder wraps text, advances a cursor, and
+/// adds pages automatically when a block would overflow. It sits on top of the
+/// low-level <see cref="PdfGraphics"/> / <see cref="AcroFormAuthoring"/> API —
+/// drop down to those (via <see cref="Custom"/> or <see cref="Build"/>) when
+/// you need full control.
+/// </para>
+///
+/// <example>
+/// <code>
+/// var bytes = PdfDocumentBuilder.Create()
+///     .Heading("Application")
+///     .Paragraph("Please complete every field.")
+///     .KeyValue("Name", "Ada Lovelace")
+///     .TextField("Comments", "comments", multiline: true)
+///     .SaveToBytes();
+/// </code>
+/// </example>
+///
+/// <remarks>
+/// This is the writer-side facade tracked by issue #383. It targets the
+/// base-14 fonts and Latin text available today; Unicode/embedded fonts
+/// (#378), richer layout (#379), more AcroForm options (#380) and document
+/// metadata (#381) extend it.
+/// </remarks>
+/// </summary>
+public sealed class PdfDocumentBuilder
+{
+    private readonly PdfDocument _document;
+    private readonly PageSize _pageSize;
+    private readonly PageMargins _margins;
+
+    private PdfPage? _currentPage;
+    private PdfGraphics? _graphics;
+    private int _currentPageNumber;   // 1-based
+    private double _cursorY;          // PDF coords (bottom-left origin), top of next block
+    private int _autoFieldSeq;
+
+    private PdfDocumentBuilder(PageSize pageSize, PageMargins margins)
+    {
+        _pageSize = pageSize;
+        _margins = margins;
+        _document = PdfDocument.CreateNew();
+    }
+
+    /// <summary>
+    /// Starts a new document. Defaults to US Letter with 1-inch margins.
+    /// </summary>
+    public static PdfDocumentBuilder Create(PageSize? pageSize = null, PageMargins? margins = null) =>
+        new(pageSize ?? PageSize.Letter, margins ?? PageMargins.Default);
+
+    /// <summary>The left edge of the content column, in PDF points.</summary>
+    public double ContentLeft => _margins.Left;
+
+    /// <summary>The width of the content column, in PDF points.</summary>
+    public double ContentWidth => _pageSize.Width - _margins.Left - _margins.Right;
+
+    /// <summary>The number of pages added so far.</summary>
+    public int PageCount => _document.PageCount;
+
+    // ── content blocks ──────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Adds a heading. <paramref name="level"/> 1–4 maps to decreasing size;
+    /// override the look entirely by passing a <paramref name="style"/>.
+    /// </summary>
+    public PdfDocumentBuilder Heading(string text, int level = 1, TextStyle? style = null)
+    {
+        style ??= HeadingStyle(level);
+        return Paragraph(text, style);
+    }
+
+    /// <summary>
+    /// Adds a paragraph of text, word-wrapped to the content column and
+    /// flowed across pages as needed. Honors hard line breaks in the input.
+    /// </summary>
+    public PdfDocumentBuilder Paragraph(string text, TextStyle? style = null)
+    {
+        style ??= TextStyle.Body;
+        EnsurePage();
+
+        var font = style.ResolveFont();
+        var brush = style.ResolveBrush();
+        double lineHeight = style.LineHeight;
+
+        foreach (var line in WrapText(text ?? string.Empty, font, ContentWidth))
+        {
+            EnsureSpace(lineHeight);
+            // Baseline sits one ascent below the top of the line box.
+            double baseline = _cursorY - font.Ascender;
+            DrawAligned(line, font, brush, style.Alignment, baseline);
+            _cursorY -= lineHeight;
+        }
+
+        _cursorY -= style.SpaceAfter;
+        return this;
+    }
+
+    /// <summary>Adds vertical blank space, in points.</summary>
+    public PdfDocumentBuilder Spacer(double points)
+    {
+        EnsurePage();
+        _cursorY -= points;
+        return this;
+    }
+
+    /// <summary>Draws a horizontal rule across the content column.</summary>
+    public PdfDocumentBuilder HorizontalRule(double thickness = 0.5, PdfColor? color = null)
+    {
+        EnsurePage();
+        EnsureSpace(thickness + 6);
+        _cursorY -= 3;
+        var pen = new PdfPen(color ?? PdfColor.FromGray(0.6), thickness);
+        _graphics!.DrawLine(ContentLeft, _cursorY, ContentLeft + ContentWidth, _cursorY, pen);
+        _cursorY -= 3;
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a "label: value" row — the label bold on the left, the value
+    /// wrapped on the right. <paramref name="labelWidth"/> is the left
+    /// column width as a fraction (0–1) of the content column.
+    /// </summary>
+    public PdfDocumentBuilder KeyValue(string label, string value, double labelWidth = 0.3)
+    {
+        labelWidth = Math.Clamp(labelWidth, 0.1, 0.9);
+        var labelStyle = TextStyle.Body.AsBold().WithSpaceAfter(0);
+        var valueStyle = TextStyle.Body.WithSpaceAfter(0);
+        return Row(
+            new[] { (label ?? string.Empty, labelStyle), (value ?? string.Empty, valueStyle) },
+            new[] { labelWidth, 1 - labelWidth },
+            cellPadding: 2,
+            spaceAfter: 4);
+    }
+
+    /// <summary>
+    /// Adds a table. <paramref name="columnWeights"/> are relative widths
+    /// (normalized to the content column); omit to split evenly. The first
+    /// row can optionally be drawn as a bold header.
+    /// </summary>
+    public PdfDocumentBuilder Table(
+        IEnumerable<IReadOnlyList<string>> rows,
+        double[]? columnWeights = null,
+        bool headerRow = false,
+        bool gridLines = true)
+    {
+        ArgumentNullException.ThrowIfNull(rows);
+        EnsurePage();
+
+        var rowList = rows.Select(r => (IReadOnlyList<string>)r.ToList()).ToList();
+        if (rowList.Count == 0)
+            return this;
+
+        int cols = rowList.Max(r => r.Count);
+        double[] weights = NormalizeWeights(columnWeights, cols);
+
+        for (int i = 0; i < rowList.Count; i++)
+        {
+            var style = (headerRow && i == 0) ? TextStyle.Body.AsBold().WithSpaceAfter(0)
+                                              : TextStyle.Body.WithSpaceAfter(0);
+            var cells = new (string, TextStyle)[cols];
+            for (int c = 0; c < cols; c++)
+                cells[c] = (c < rowList[i].Count ? rowList[i][c] ?? string.Empty : string.Empty, style);
+
+            Row(cells, weights, cellPadding: 4, spaceAfter: 0, gridLines: gridLines);
+        }
+
+        _cursorY -= TextStyle.Body.SpaceAfter;
+        return this;
+    }
+
+    /// <summary>Forces subsequent content onto a new page.</summary>
+    public PdfDocumentBuilder PageBreak()
+    {
+        NewPage();
+        return this;
+    }
+
+    // ── form fields (fillable AcroForm) ─────────────────────────────────────
+
+    /// <summary>
+    /// Adds a labelled text input field. The label is drawn above the input
+    /// box. Set <paramref name="multiline"/> for a taller box.
+    /// </summary>
+    public PdfDocumentBuilder TextField(
+        string label,
+        string? fieldName = null,
+        bool multiline = false,
+        bool required = false,
+        int lines = 1,
+        string? defaultValue = null)
+    {
+        EnsurePage();
+        fieldName ??= NextFieldName("text");
+
+        DrawFieldLabel(label, required);
+
+        var bodyFont = TextStyle.Body.ResolveFont();
+        double rows = multiline ? Math.Max(lines, 2) : 1;
+        double boxHeight = rows * bodyFont.LineHeight + 6;
+
+        var rect = ReserveBox(boxHeight);
+        DrawBoxBorder(rect);
+        _document.AddTextField(_currentPageNumber, rect, fieldName,
+            defaultValue: defaultValue, multiline: multiline, required: required);
+
+        _cursorY -= TextStyle.Body.SpaceAfter;
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a checkbox with a label to its right.
+    /// </summary>
+    public PdfDocumentBuilder CheckBox(
+        string label,
+        string? fieldName = null,
+        bool checkedByDefault = false)
+    {
+        EnsurePage();
+        fieldName ??= NextFieldName("check");
+
+        var font = TextStyle.Body.ResolveFont();
+        double box = font.Size;                 // square checkbox sized to the text
+        double rowHeight = Math.Max(box, font.LineHeight) + 4;
+        EnsureSpace(rowHeight);
+
+        double top = _cursorY;
+        double bottom = top - box;
+        var rect = new PdfRectangle(ContentLeft, bottom, ContentLeft + box, top);
+        DrawBoxBorder(rect);
+        _document.AddCheckBox(_currentPageNumber, rect, fieldName, defaultChecked: checkedByDefault);
+
+        // Label baseline aligned to the checkbox.
+        double baseline = top - font.Ascender;
+        _graphics!.DrawString(label ?? string.Empty, font, PdfBrush.Black, ContentLeft + box + 6, baseline);
+
+        _cursorY -= rowHeight;
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a labelled dropdown (combo box) populated with
+    /// <paramref name="options"/>.
+    /// </summary>
+    public PdfDocumentBuilder Dropdown(
+        string label,
+        IEnumerable<string> options,
+        string? fieldName = null,
+        string? defaultValue = null)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        EnsurePage();
+        fieldName ??= NextFieldName("choice");
+
+        DrawFieldLabel(label, required: false);
+
+        var bodyFont = TextStyle.Body.ResolveFont();
+        double boxHeight = bodyFont.LineHeight + 6;
+        var rect = ReserveBox(boxHeight);
+        DrawBoxBorder(rect);
+        _document.AddChoiceField(_currentPageNumber, rect, fieldName, options, defaultValue: defaultValue);
+
+        _cursorY -= TextStyle.Body.SpaceAfter;
+        return this;
+    }
+
+    /// <summary>
+    /// Escape hatch: draw directly with <see cref="PdfGraphics"/>. The callback
+    /// receives the current page's graphics and a layout snapshot (content
+    /// box + cursor). Advance the cursor yourself via the returned height by
+    /// calling <see cref="Spacer"/> afterward if needed.
+    /// </summary>
+    public PdfDocumentBuilder Custom(Action<PdfGraphics, LayoutContext> draw)
+    {
+        ArgumentNullException.ThrowIfNull(draw);
+        EnsurePage();
+        draw(_graphics!, new LayoutContext(ContentLeft, _cursorY, ContentWidth, _cursorY - _margins.Bottom, _currentPageNumber));
+        return this;
+    }
+
+    // ── output ──────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Finalizes layout and returns the underlying <see cref="PdfDocument"/>
+    /// for further manipulation or saving.
+    /// </summary>
+    public PdfDocument Build()
+    {
+        _graphics?.Flush();
+        return _document;
+    }
+
+    /// <summary>Builds and serializes the document to a byte array.</summary>
+    public byte[] SaveToBytes() => Build().SaveToBytes();
+
+    /// <summary>Builds and writes the document to a file.</summary>
+    public void Save(string path) => Build().Save(path);
+
+    /// <summary>Builds and writes the document to a stream.</summary>
+    public void Save(Stream stream) => Build().Save(stream);
+
+    // ── layout engine ───────────────────────────────────────────────────────
+
+    private void EnsurePage()
+    {
+        if (_currentPage == null)
+            NewPage();
+    }
+
+    private void NewPage()
+    {
+        _graphics?.Flush();
+        _currentPage = _document.Pages.AddBlank(_pageSize.Width, _pageSize.Height);
+        _currentPageNumber = _document.PageCount;
+        _graphics = _currentPage.GetGraphics();
+        _cursorY = _pageSize.Height - _margins.Top;
+    }
+
+    /// <summary>Ensure at least <paramref name="height"/> remains; else paginate.</summary>
+    private void EnsureSpace(double height)
+    {
+        EnsurePage();
+        if (_cursorY - height < _margins.Bottom)
+            NewPage();
+    }
+
+    /// <summary>Reserve a full-width box of the given height; returns its rect.</summary>
+    private PdfRectangle ReserveBox(double height)
+    {
+        EnsureSpace(height);
+        double top = _cursorY;
+        double bottom = top - height;
+        _cursorY = bottom;
+        return new PdfRectangle(ContentLeft, bottom, ContentLeft + ContentWidth, top);
+    }
+
+    private void DrawAligned(string text, PdfFont font, PdfBrush brush, TextAlignment alignment, double baseline)
+    {
+        double x = alignment switch
+        {
+            TextAlignment.Center => ContentLeft + ContentWidth / 2,
+            TextAlignment.Right => ContentLeft + ContentWidth,
+            _ => ContentLeft
+        };
+        _graphics!.DrawString(text, font, brush, x, baseline, alignment);
+    }
+
+    private void DrawFieldLabel(string label, bool required)
+    {
+        var style = TextStyle.Body.AsBold().WithSpaceAfter(2);
+        Paragraph(required ? $"{label} *" : label, style);
+    }
+
+    private void DrawBoxBorder(PdfRectangle rect)
+    {
+        var pen = new PdfPen(PdfColor.FromGray(0.5), 0.75);
+        _graphics!.DrawRectangle(rect.Left, rect.Bottom, rect.Width, rect.Height, fill: null, stroke: pen);
+    }
+
+    /// <summary>
+    /// Draws a single multi-column row, wrapping each cell within its column.
+    /// Used by <see cref="KeyValue"/> and <see cref="Table"/>.
+    /// </summary>
+    private PdfDocumentBuilder Row(
+        IReadOnlyList<(string Text, TextStyle Style)> cells,
+        double[] weights,
+        double cellPadding,
+        double spaceAfter,
+        bool gridLines = false)
+    {
+        EnsurePage();
+
+        int cols = cells.Count;
+        var colWidths = new double[cols];
+        for (int c = 0; c < cols; c++)
+            colWidths[c] = weights[c] * ContentWidth;
+
+        // Wrap each cell and find the tallest.
+        var wrapped = new List<string>[cols];
+        double maxLines = 1;
+        for (int c = 0; c < cols; c++)
+        {
+            var font = cells[c].Style.ResolveFont();
+            wrapped[c] = WrapText(cells[c].Text ?? string.Empty, font, colWidths[c] - 2 * cellPadding).ToList();
+            maxLines = Math.Max(maxLines, wrapped[c].Count);
+        }
+
+        double lineHeight = cells.Count > 0 ? cells[0].Style.LineHeight : TextStyle.Body.LineHeight;
+        double rowHeight = maxLines * lineHeight + 2 * cellPadding;
+        EnsureSpace(rowHeight);
+
+        double top = _cursorY;
+        double x = ContentLeft;
+        for (int c = 0; c < cols; c++)
+        {
+            var style = cells[c].Style;
+            var font = style.ResolveFont();
+            var brush = style.ResolveBrush();
+            double textTop = top - cellPadding;
+            for (int li = 0; li < wrapped[c].Count; li++)
+            {
+                double baseline = textTop - font.Ascender - li * lineHeight;
+                _graphics!.DrawString(wrapped[c][li], font, brush, x + cellPadding, baseline);
+            }
+
+            if (gridLines)
+            {
+                var rect = new PdfRectangle(x, top - rowHeight, x + colWidths[c], top);
+                var pen = new PdfPen(PdfColor.FromGray(0.7), 0.5);
+                _graphics!.DrawRectangle(rect.Left, rect.Bottom, rect.Width, rect.Height, fill: null, stroke: pen);
+            }
+
+            x += colWidths[c];
+        }
+
+        _cursorY = top - rowHeight - spaceAfter;
+        return this;
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private static double[] NormalizeWeights(double[]? weights, int cols)
+    {
+        if (weights == null || weights.Length == 0)
+        {
+            var even = new double[cols];
+            Array.Fill(even, 1.0 / cols);
+            return even;
+        }
+
+        var w = new double[cols];
+        double sum = 0;
+        for (int c = 0; c < cols; c++)
+        {
+            double v = c < weights.Length ? Math.Max(0, weights[c]) : 0;
+            w[c] = v;
+            sum += v;
+        }
+        if (sum <= 0)
+        {
+            Array.Fill(w, 1.0 / cols);
+            return w;
+        }
+        for (int c = 0; c < cols; c++)
+            w[c] /= sum;
+        return w;
+    }
+
+    private static TextStyle HeadingStyle(int level) => level switch
+    {
+        <= 1 => new TextStyle { Size = 18, Bold = true, SpaceAfter = 10 },
+        2 => new TextStyle { Size = 14, Bold = true, SpaceAfter = 8 },
+        3 => new TextStyle { Size = 12, Bold = true, SpaceAfter = 6 },
+        _ => new TextStyle { Size = 11, Bold = true, SpaceAfter = 5 }
+    };
+
+    private string NextFieldName(string prefix) => $"{prefix}_{++_autoFieldSeq}";
+
+    /// <summary>
+    /// Greedy word-wrap to <paramref name="maxWidth"/> points using the font's
+    /// own metrics. Hard line breaks (\n, \r\n) in the input are preserved; a
+    /// single word longer than the column is emitted on its own (over)long line.
+    /// </summary>
+    internal static IEnumerable<string> WrapText(string text, PdfFont font, double maxWidth)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            yield return string.Empty;
+            yield break;
+        }
+
+        var hardLines = text.Replace("\r\n", "\n").Replace('\r', '\n').Split('\n');
+        foreach (var hardLine in hardLines)
+        {
+            if (hardLine.Length == 0)
+            {
+                yield return string.Empty;
+                continue;
+            }
+
+            var words = hardLine.Split(' ');
+            var current = new System.Text.StringBuilder();
+            foreach (var word in words)
+            {
+                if (current.Length == 0)
+                {
+                    current.Append(word);
+                    continue;
+                }
+
+                var candidate = current.ToString() + " " + word;
+                if (maxWidth > 0 && font.MeasureWidth(candidate) > maxWidth)
+                {
+                    yield return current.ToString();
+                    current.Clear();
+                    current.Append(word);
+                }
+                else
+                {
+                    current.Append(' ').Append(word);
+                }
+            }
+
+            if (current.Length > 0)
+                yield return current.ToString();
+        }
+    }
+}
+
+/// <summary>
+/// A snapshot of the current layout passed to <see cref="PdfDocumentBuilder.Custom"/>.
+/// Coordinates are in PDF points (bottom-left origin).
+/// </summary>
+/// <param name="Left">Left edge of the content column.</param>
+/// <param name="Top">Y of the current cursor (top of the next block).</param>
+/// <param name="Width">Width of the content column.</param>
+/// <param name="RemainingHeight">Space remaining above the bottom margin.</param>
+/// <param name="PageNumber">Current page number (1-based).</param>
+public readonly record struct LayoutContext(double Left, double Top, double Width, double RemainingHeight, int PageNumber);

--- a/Pdfe.Core/Authoring/TextStyle.cs
+++ b/Pdfe.Core/Authoring/TextStyle.cs
@@ -1,0 +1,104 @@
+using Pdfe.Core.Graphics;
+
+namespace Pdfe.Core.Authoring;
+
+/// <summary>
+/// One of the three base-14 font families available without embedding.
+/// (Unicode / embedded TrueType-OpenType fonts are tracked by issue #378.)
+/// </summary>
+public enum FontFamily
+{
+    /// <summary>Sans-serif (Helvetica).</summary>
+    SansSerif,
+    /// <summary>Serif (Times).</summary>
+    Serif,
+    /// <summary>Monospace (Courier).</summary>
+    Monospace
+}
+
+/// <summary>
+/// The look of a run of text: family, size, weight/slant, color, alignment,
+/// line spacing, and the gap left after the block. Immutable — the
+/// <c>With…</c> helpers return a modified copy, so styles compose cleanly.
+/// </summary>
+public sealed record TextStyle
+{
+    /// <summary>Font family. Default <see cref="FontFamily.SansSerif"/>.</summary>
+    public FontFamily Family { get; init; } = FontFamily.SansSerif;
+
+    /// <summary>Font size in points. Default 11.</summary>
+    public double Size { get; init; } = 11;
+
+    /// <summary>Bold weight. Default false.</summary>
+    public bool Bold { get; init; }
+
+    /// <summary>Italic/oblique slant. Default false.</summary>
+    public bool Italic { get; init; }
+
+    /// <summary>Text color. Default black.</summary>
+    public PdfColor Color { get; init; } = PdfColor.Black;
+
+    /// <summary>Horizontal alignment within the content column. Default left.</summary>
+    public TextAlignment Alignment { get; init; } = TextAlignment.Left;
+
+    /// <summary>Line height as a multiple of the font size. Default 1.2.</summary>
+    public double LineSpacing { get; init; } = 1.2;
+
+    /// <summary>Vertical gap left after the block, in points. Default 6.</summary>
+    public double SpaceAfter { get; init; } = 6;
+
+    /// <summary>The default body style (11-pt Helvetica, left, black).</summary>
+    public static TextStyle Body => new();
+
+    /// <summary>Returns a copy with the given size.</summary>
+    public TextStyle WithSize(double size) => this with { Size = size };
+
+    /// <summary>Returns a bold copy.</summary>
+    public TextStyle AsBold() => this with { Bold = true };
+
+    /// <summary>Returns an italic copy.</summary>
+    public TextStyle AsItalic() => this with { Italic = true };
+
+    /// <summary>Returns a copy with the given color.</summary>
+    public TextStyle WithColor(PdfColor color) => this with { Color = color };
+
+    /// <summary>Returns a copy with the given alignment.</summary>
+    public TextStyle WithAlignment(TextAlignment alignment) => this with { Alignment = alignment };
+
+    /// <summary>Returns a copy with the given trailing gap (points).</summary>
+    public TextStyle WithSpaceAfter(double points) => this with { SpaceAfter = points };
+
+    /// <summary>Resolves this style to a concrete <see cref="PdfFont"/> at its size.</summary>
+    public PdfFont ResolveFont() => new("F1", ResolveBaseFont(), Size);
+
+    /// <summary>The brush matching this style's color.</summary>
+    public PdfBrush ResolveBrush() => new(Color);
+
+    /// <summary>Line height in points (Size × LineSpacing).</summary>
+    public double LineHeight => Size * LineSpacing;
+
+    private string ResolveBaseFont() => Family switch
+    {
+        FontFamily.Serif => (Bold, Italic) switch
+        {
+            (true, true) => PdfFont.StandardFonts.TimesBoldItalic,
+            (true, false) => PdfFont.StandardFonts.TimesBold,
+            (false, true) => PdfFont.StandardFonts.TimesItalic,
+            _ => PdfFont.StandardFonts.TimesRoman
+        },
+        FontFamily.Monospace => (Bold, Italic) switch
+        {
+            (true, true) => PdfFont.StandardFonts.CourierBoldOblique,
+            (true, false) => PdfFont.StandardFonts.CourierBold,
+            (false, true) => PdfFont.StandardFonts.CourierOblique,
+            _ => PdfFont.StandardFonts.Courier
+        },
+        _ => (Bold, Italic) switch
+        {
+            (true, true) => PdfFont.StandardFonts.HelveticaBoldOblique,
+            (true, false) => PdfFont.StandardFonts.HelveticaBold,
+            (false, true) => PdfFont.StandardFonts.HelveticaOblique,
+            _ => PdfFont.StandardFonts.Helvetica
+        }
+    };
+}

--- a/Pdfe.Core/Pdfe.Core.csproj
+++ b/Pdfe.Core/Pdfe.Core.csproj
@@ -8,7 +8,7 @@
 
   <PropertyGroup>
     <PackageId>Pdfe.Core</PackageId>
-    <Version>2.3.1</Version>
+    <Version>2.4.0</Version>
     <Authors>Marc Jones</Authors>
     <Description>Pure-managed PDF parser, document model, and writer for .NET. Open/edit/save PDFs, extract text/links/annotations/forms, and perform true glyph-level redaction. No native dependencies; cross-platform and trim/AOT-friendlier.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Pdfe.Rendering/Pdfe.Rendering.csproj
+++ b/Pdfe.Rendering/Pdfe.Rendering.csproj
@@ -8,7 +8,7 @@
 
   <PropertyGroup>
     <PackageId>Pdfe.Rendering</PackageId>
-    <Version>2.3.1</Version>
+    <Version>2.4.0</Version>
     <Authors>Marc Jones</Authors>
     <Description>Pure-managed, SkiaSharp-based PDF render API for .NET. Render pages to SKBitmap or PNG with DPI/clip/rotation support and cancellable rendering. Framework-neutral engine behind Pdfe.Avalonia; no native PDFium. Cross-platform, trim/AOT-friendlier.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/README.md
+++ b/README.md
@@ -171,6 +171,38 @@ Multiple areas across multiple pages can be marked and applied as a single batch
 3. Drag a rect on the page — the new field appears immediately and is editable.
 4. **🪄 Auto-detect** scans the current document for likely field positions — long horizontal strokes (text-field underlines) and small square outlines (checkboxes) — and creates them in one click.
 
+### Authoring PDFs from scratch (high-level)
+
+`Pdfe.Core.Authoring.PdfDocumentBuilder` is a friendly, flow-layout writer that
+handles word-wrap, pagination, and field placement so you never touch raw
+coordinates. It sits on top of the low-level `PdfGraphics` / `AcroFormAuthoring`
+API (drop down to those any time via `.Custom(...)` or `.Build()`).
+
+```csharp
+using Pdfe.Core.Authoring;
+
+byte[] pdf = PdfDocumentBuilder.Create()           // US Letter, 1-inch margins
+    .Heading("Membership Application")
+    .Paragraph("Please complete all required fields.")
+    .HorizontalRule()
+    .KeyValue("Date", "2026-06-05")
+    .TextField("Full name", "fullName", required: true)
+    .CheckBox("I agree to the terms", "agree")
+    .Dropdown("Tier", new[] { "Basic", "Standard", "Premium" }, "tier", "Standard")
+    .TextField("Comments", "comments", multiline: true, lines: 4)
+    .Table(new[]
+    {
+        new[] { "Item", "Qty", "Price" },
+        new[] { "Widget", "3", "$9.00" },
+    }, columnWeights: new[] { 2.0, 1.0, 1.0 }, headerRow: true)
+    .SaveToBytes();                                 // or .Save("form.pdf")
+```
+
+The result is a real, fillable AcroForm PDF: text is extractable, content
+flows onto new pages automatically, and the form fields are live in any viewer.
+Styling is via the immutable `TextStyle` record (family/size/bold/italic/color/
+alignment); page size/margins via `PageSize` and `PageMargins`. See issue #383.
+
 ### Reveal Hidden Text
 
 `Tools → Reveal Hidden Text` finds text that's been visually hidden by overlays:


### PR DESCRIPTION
## Summary

Adds **`Pdfe.Core.Authoring.PdfDocumentBuilder`** — a friendly, high-level PDF *writer* facade so third-party .NET apps (starting with PromptResponse, epic #382) can author PDFs from structured content without touching raw coordinates. It sits entirely on top of the existing `PdfGraphics` / `AcroFormAuthoring` API — **no engine changes**.

```csharp
byte[] pdf = PdfDocumentBuilder.Create()
    .Heading("Membership Application")
    .Paragraph("Please complete all required fields.")
    .KeyValue("Date", "2026-06-05")
    .TextField("Full name", "fullName", required: true)
    .CheckBox("I agree to the terms", "agree")
    .Dropdown("Tier", new[] { "Basic", "Standard", "Premium" }, "tier", "Standard")
    .SaveToBytes();
```

## What's included
- **`PdfDocumentBuilder`** — flow layout with automatic word-wrap + pagination. Blocks: `Heading`, `Paragraph`, `Spacer`, `HorizontalRule`, `KeyValue`, `Table`, `PageBreak`. Fillable fields: `TextField` (multiline/required), `CheckBox`, `Dropdown`. `Custom()` escape hatch; `Build()`/`SaveToBytes()`/`Save()`.
- **Value types**: `PageSize`, `PageMargins`, immutable `TextStyle` (+`FontFamily`), `LayoutContext`.
- Trio version bump 2.3.1 → **2.4.0**; CHANGELOG `[2.4.0]`; README sample.

## Testing
- 17 new tests in `Pdfe.Core.Tests/Authoring/`.
- Full `Pdfe.Core` suite green: **2744 passed, 0 failed**; **0 build warnings**.
- External-reader validation: `qpdf --check` clean, `pdfinfo` reports `Form: AcroForm` across auto-paginated pages, `pdftotext` extracts all content.

## Scope
Targets base-14 / Latin text today. Capability gaps stay in #378 (Unicode/fonts), #379 (layout), #380 (field options), #381 (metadata). The remaining **stability/packaging** half of #383 (API marking, SemVer policy, public-API CI gate, SourceLink/symbols) follows next.

Closes part of #383 (capability half). Part of epic #382.

🤖 Generated with [Claude Code](https://claude.com/claude-code)