### PR TITLE
release: v2.4.1 — fix cold-cache installer build (#387) + packaging/API-gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,11 @@ on:
 
 env:
   DOTNET_VERSION: '10.0.x'
+  # ReactiveUI/Splat's author signing certificate was revoked upstream, so a
+  # cold `dotnet restore` fails with NU3012 (revoked cert). ci.yml already sets
+  # this; release.yml didn't, so a version-bump cache miss surfaced it as a
+  # silent restore failure in the license-manifest step (#387). Match ci.yml.
+  DOTNET_NUGET_SIGNATURE_VERIFICATION: false
 
 # Lets the release job push installers as release assets.
 permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,41 @@ All notable changes to pdfe are documented here. Format roughly follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this project uses
 semantic versioning.
 
+## [2.4.1] — 2026-06-06
+
+Packaging, API-stability, and CI hardening on top of v2.4.0. No public-API
+changes (enforced by the new gate) — a pure patch.
+
+### Added
+- **Public-API gate (#383).** `PublicApiApprovalTests` snapshots the full
+  `Pdfe.Core` public surface against a committed baseline
+  (`Pdfe.Core.Tests/PublicApi/Pdfe.Core.approved.txt`); any public-API change
+  fails CI until intentionally re-approved (`APPROVE_PUBLIC_API=1`). Makes every
+  API change a deliberate SemVer decision.
+- **SourceLink + symbols.** The three publishable libraries (`Pdfe.Core`,
+  `Pdfe.Rendering`, `Pdfe.Avalonia`) now ship portable `.snupkg` symbol packages
+  with SourceLink and deterministic CI builds (shared `Packaging.props`), so
+  consumers can step into the source while debugging.
+- README "Versioning & API stability" section documenting the SemVer policy,
+  the `Pdfe.Core.Authoring.*` stable writer surface, and local-feed (not
+  nuget.org) distribution.
+
+### Fixed
+- **Release pipeline cold-cache restore (#387).** `release.yml` now sets
+  `DOTNET_NUGET_SIGNATURE_VERIFICATION=false` (matching `ci.yml`) so a
+  version-bump cache miss no longer fails the license-manifest step with NU3012
+  (revoked ReactiveUI/Splat signing cert). The v2.4.0 Windows/Debian/macOS
+  installers — absent from that release due to this bug — are restored here.
+- `generate-license-manifest.sh` no longer hard-fails on a cold NuGet cache and
+  no longer suppresses restore output.
+
+### CI / dev
+- Headless GUI tests (`PdfEditor.Tests`) now run only when GUI-relevant paths
+  change (or on `main`), so library-only PRs aren't gated on the slow GUI suite.
+- Quarantined the flaky `KeyboardShortcutTests.CtrlS_SavesFile` on headless CI
+  (#363) — it intermittently deadlocked the Avalonia dispatcher and crashed the
+  test host. Still runs locally; the save path stays covered elsewhere.
+
 ## [2.4.0] — 2026-06-05
 
 Adds a friendly, high-level **PDF authoring** API so third-party .NET apps can

--- a/Pdfe.Avalonia/Pdfe.Avalonia.csproj
+++ b/Pdfe.Avalonia/Pdfe.Avalonia.csproj
@@ -14,7 +14,7 @@
   <!-- NuGet package metadata (packed explicitly via `dotnet pack`, not on build). -->
   <PropertyGroup>
     <PackageId>Pdfe.Avalonia</PackageId>
-    <Version>2.4.0</Version>
+    <Version>2.4.1</Version>
     <Authors>Marc Jones</Authors>
     <Description>A reusable, pure-managed PDF viewer control for Avalonia. Renders with SkiaSharp (no native PDFium), supports zoom/pan, page navigation, text selection, search highlights, annotations, links, and form-field overlays. Built on Pdfe.Core + Pdfe.Rendering.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Pdfe.Core/Pdfe.Core.csproj
+++ b/Pdfe.Core/Pdfe.Core.csproj
@@ -10,7 +10,7 @@
 
   <PropertyGroup>
     <PackageId>Pdfe.Core</PackageId>
-    <Version>2.4.0</Version>
+    <Version>2.4.1</Version>
     <Authors>Marc Jones</Authors>
     <Description>Pure-managed PDF parser, document model, and writer for .NET. Open/edit/save PDFs, extract text/links/annotations/forms, and perform true glyph-level redaction. No native dependencies; cross-platform and trim/AOT-friendlier.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Pdfe.Rendering/Pdfe.Rendering.csproj
+++ b/Pdfe.Rendering/Pdfe.Rendering.csproj
@@ -10,7 +10,7 @@
 
   <PropertyGroup>
     <PackageId>Pdfe.Rendering</PackageId>
-    <Version>2.4.0</Version>
+    <Version>2.4.1</Version>
     <Authors>Marc Jones</Authors>
     <Description>Pure-managed, SkiaSharp-based PDF render API for .NET. Render pages to SKBitmap or PNG with DPI/clip/rotation support and cancellable rendering. Framework-neutral engine behind Pdfe.Avalonia; no native PDFium. Cross-platform, trim/AOT-friendlier.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/scripts/generate-license-manifest.sh
+++ b/scripts/generate-license-manifest.sh
@@ -55,7 +55,9 @@ mkdir -p "$(dirname "$OUT")"
 [[ "$RUN_SCANCODE" == "1" ]] && mkdir -p "$SCANCODE_DIR"
 
 echo "▶ Restoring $PROJECT"
-dotnet restore "$ROOT/$PROJECT" >/dev/null
+# Don't suppress output: a hidden `>/dev/null` masked an NU3012 cold-restore
+# failure during the v2.4.0 release (#387). Let restore errors be visible.
+dotnet restore "$ROOT/$PROJECT"
 
 echo "▶ Resolving deps"
 PKG_LIST="$(dotnet list "$ROOT/$PROJECT" package --include-transitive --format json 2>/dev/null \


### PR DESCRIPTION
Patch release on top of v2.4.0. **No public-API change** (enforced by the new gate).

### Fixes #387 (the v2.4.0 installer build failure)
Root cause: `release.yml` lacked `DOTNET_NUGET_SIGNATURE_VERIFICATION=false` (which `ci.yml` has). A warm cache hid it; the version bump's cache miss surfaced a cold restore failing with **NU3012** (revoked ReactiveUI/Splat signing cert) in the license-manifest step. This PR matches `ci.yml`, and stops the script suppressing restore output. Restores the Windows/.deb/macOS installers absent from v2.4.0.

### Also bundles (from #383/#386, already on main)
- SourceLink + `.snupkg` symbols on the three publishable libs.
- Public-API gate (`PublicApiApprovalTests`) + README SemVer policy.

Trio bumped 2.4.0 → **2.4.1**; CHANGELOG `[2.4.1]`.

> Library-only change — with the new path-scoped CI (#388) the GUI suite is skipped on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)