### PR TITLE
release: build + attach macOS .app (arm64)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,10 +187,57 @@ jobs:
             dist/*.zip.sha256
           if-no-files-found: error
 
-  # ── 3. Attach installers to the GitHub release ──────────────────────
+  # ── 3. Build the macOS .app bundle (arm64) ──────────────────────────
+  macos-app:
+    name: macOS .app (arm64)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # so `git describe --tags` works
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Cache nuget
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: nuget-macos-${{ hashFiles('**/*.csproj') }}
+          restore-keys: nuget-macos-
+
+      - name: Resolve version
+        id: ver
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            v="${{ github.event.inputs.version }}"
+          elif [[ "${{ github.event_name }}" == "release" ]]; then
+            v="${GITHUB_REF#refs/tags/}"; v="${v#v}"
+          elif [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            v="${GITHUB_REF#refs/tags/}"; v="${v#v}"
+          else
+            v="$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || echo 0.0.0)"
+          fi
+          echo "version=$v" >> "$GITHUB_OUTPUT"
+          echo "▶ version: $v"
+
+      - name: Build macOS .app (arm64)
+        run: ./scripts/build-macos-app.sh --version "${{ steps.ver.outputs.version }}" --rid osx-arm64 --output dist
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: macos-app
+          path: |
+            dist/*.zip
+            dist/*.zip.sha256
+          if-no-files-found: error
+
+  # ── 4. Attach installers to the GitHub release ──────────────────────
   publish:
     name: Attach to GitHub release
-    needs: [linux-deb, windows-exe]
+    needs: [linux-deb, windows-exe, macos-app]
     runs-on: ubuntu-latest
     # Only auto-create a release when the trigger was a tag push or a
     # release event. workflow_dispatch reruns just produce artifacts you
@@ -232,6 +279,7 @@ jobs:
           files: |
             artifacts/linux-installer/*
             artifacts/windows-installer/*
+            artifacts/macos-app/*
           body: |
             ## Installers
 
@@ -239,6 +287,7 @@ jobs:
             |-----------------|------------------------------------------------|
             | Ubuntu / Debian | `pdfe_<version>_amd64.deb`                     |
             | Windows 10/11   | `pdfe-<version>-win-x64-setup.exe`             |
+            | macOS (Apple Silicon) | `pdfe-<version>-macos-arm64.zip`         |
 
             Portable archives (`*.tar.gz`, `*.zip`) are also attached
             for users who prefer to extract and run the binary directly.
@@ -256,6 +305,14 @@ jobs:
             or silently:
             ```powershell
             pdfe-<version>-win-x64-setup.exe /VERYSILENT /SUPPRESSMSGBOXES /NORESTART
+            ```
+
+            **macOS (Apple Silicon)**
+            Unzip and move `pdfe.app` to `/Applications`. The bundle is
+            **unsigned**, so Gatekeeper quarantines it — open it the first
+            time via right-click → Open, or clear the quarantine flag:
+            ```bash
+            xattr -dr com.apple.quarantine /Applications/pdfe.app
             ```
 
             ### Verification

--- a/scripts/build-macos-app.sh
+++ b/scripts/build-macos-app.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Build a macOS .app bundle for pdfe (the PdfEditor GUI), self-contained.
+# Produces dist/pdfe-<version>-macos-<arch>.zip (+ .sha256).
+#
+# Must run on macOS (uses sips / iconutil / ditto). The .app is UNSIGNED —
+# Gatekeeper will quarantine it; users open via right-click → Open or
+# `xattr -dr com.apple.quarantine pdfe.app`. Signing/notarization needs an
+# Apple Developer cert (not configured).
+#
+# Usage:
+#   scripts/build-macos-app.sh --version 2.4.1 [--rid osx-arm64] [--output dist]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+VERSION="0.0.0"
+RID="osx-arm64"
+OUT="$ROOT/dist"
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --version) VERSION="$2"; shift 2 ;;
+        --rid)     RID="$2"; shift 2 ;;
+        --output)  OUT="$2"; shift 2 ;;
+        --help|-h) sed -n '2,12p' "$0"; exit 0 ;;
+        *) echo "Unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+
+ARCH="${RID#osx-}"            # arm64 | x64
+APP_NAME="pdfe"
+BUNDLE="$OUT/${APP_NAME}.app"
+PUBLISH_DIR="$ROOT/artifacts/macos-publish"
+
+rm -rf "$BUNDLE" "$PUBLISH_DIR"
+mkdir -p "$OUT"
+
+echo "▶ Publishing PdfEditor ($RID, self-contained)"
+dotnet publish "$ROOT/PdfEditor/PdfEditor.csproj" \
+    -c Release -r "$RID" --self-contained true \
+    -p:PublishSingleFile=false \
+    -o "$PUBLISH_DIR"
+
+echo "▶ Assembling $BUNDLE"
+mkdir -p "$BUNDLE/Contents/MacOS" "$BUNDLE/Contents/Resources"
+cp -R "$PUBLISH_DIR/." "$BUNDLE/Contents/MacOS/"
+chmod +x "$BUNDLE/Contents/MacOS/PdfEditor" || true
+
+# ── Icon (best-effort): SVG -> 1024 PNG -> .iconset -> .icns ────────────────
+ICON_SVG="$ROOT/PdfEditor/Assets/pdfe_logo.svg"
+ICON_PLIST=""
+MAGICK="$(command -v magick || command -v convert || true)"
+if [[ -n "$MAGICK" && -f "$ICON_SVG" ]]; then
+    ICON_SET="$PUBLISH_DIR/pdfe.iconset"
+    mkdir -p "$ICON_SET"
+    if "$MAGICK" -background none -density 512 "$ICON_SVG" -resize 1024x1024 "$PUBLISH_DIR/icon_1024.png"; then
+        sips -z 16 16     "$PUBLISH_DIR/icon_1024.png" --out "$ICON_SET/icon_16x16.png"      >/dev/null 2>&1 || true
+        sips -z 32 32     "$PUBLISH_DIR/icon_1024.png" --out "$ICON_SET/icon_16x16@2x.png"   >/dev/null 2>&1 || true
+        sips -z 32 32     "$PUBLISH_DIR/icon_1024.png" --out "$ICON_SET/icon_32x32.png"      >/dev/null 2>&1 || true
+        sips -z 64 64     "$PUBLISH_DIR/icon_1024.png" --out "$ICON_SET/icon_32x32@2x.png"   >/dev/null 2>&1 || true
+        sips -z 128 128   "$PUBLISH_DIR/icon_1024.png" --out "$ICON_SET/icon_128x128.png"    >/dev/null 2>&1 || true
+        sips -z 256 256   "$PUBLISH_DIR/icon_1024.png" --out "$ICON_SET/icon_128x128@2x.png" >/dev/null 2>&1 || true
+        sips -z 256 256   "$PUBLISH_DIR/icon_1024.png" --out "$ICON_SET/icon_256x256.png"    >/dev/null 2>&1 || true
+        sips -z 512 512   "$PUBLISH_DIR/icon_1024.png" --out "$ICON_SET/icon_256x256@2x.png" >/dev/null 2>&1 || true
+        sips -z 512 512   "$PUBLISH_DIR/icon_1024.png" --out "$ICON_SET/icon_512x512.png"    >/dev/null 2>&1 || true
+        cp "$PUBLISH_DIR/icon_1024.png" "$ICON_SET/icon_512x512@2x.png" 2>/dev/null || true
+        if iconutil -c icns "$ICON_SET" -o "$BUNDLE/Contents/Resources/pdfe.icns"; then
+            ICON_PLIST=$'    <key>CFBundleIconFile</key>\n    <string>pdfe</string>'
+        fi
+    fi
+else
+    echo "::warning::ImageMagick not found (or icon missing); building .app without a custom icon"
+fi
+
+echo "▶ Writing Info.plist"
+cat > "$BUNDLE/Contents/Info.plist" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleName</key>
+    <string>pdfe</string>
+    <key>CFBundleDisplayName</key>
+    <string>pdfe</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.marcjones.pdfe</string>
+    <key>CFBundleVersion</key>
+    <string>${VERSION}</string>
+    <key>CFBundleShortVersionString</key>
+    <string>${VERSION}</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleExecutable</key>
+    <string>PdfEditor</string>
+${ICON_PLIST}
+    <key>LSMinimumSystemVersion</key>
+    <string>11.0</string>
+    <key>NSHighResolutionCapable</key>
+    <true/>
+    <key>LSApplicationCategoryType</key>
+    <string>public.app-category.productivity</string>
+</dict>
+</plist>
+PLIST
+
+ZIP="${APP_NAME}-${VERSION}-macos-${ARCH}.zip"
+echo "▶ Zipping $OUT/$ZIP"
+rm -f "$OUT/$ZIP"
+# ditto preserves bundle structure + resource forks; keepParent zips pdfe.app/.
+( cd "$OUT" && /usr/bin/ditto -c -k --sequesterRsrc --keepParent "${APP_NAME}.app" "$ZIP" )
+( cd "$OUT" && shasum -a 256 "$ZIP" > "$ZIP.sha256" )
+
+echo "✔ Built $OUT/$ZIP"


### PR DESCRIPTION
Wires the macOS release into `release.yml` (the `.app` was a manual Mac-only step before).

- New **`macos-app`** job on `macos-latest`: publishes `PdfEditor` self-contained for `osx-arm64`, assembles a proper `pdfe.app` (Info.plist + best-effort `.icns` from the SVG logo via ImageMagick→`sips`→`iconutil`), zips with `ditto` → `pdfe-<version>-macos-arm64.zip` (+ `.sha256`).
- Wired into `publish` (`needs` + `files` + release-notes table + Gatekeeper note). The bundle is **unsigned** (no Apple Developer cert) — users open via right-click → Open or `xattr -dr com.apple.quarantine`.
- Logic lives in `scripts/build-macos-app.sh` (keeps the YAML thin).

**Validation plan:** after merge, trigger `release.yml` via `workflow_dispatch` (artifacts-only — the publish job is gated to tag/release events) to confirm the `.app` builds, then backfill the v2.4.1 macOS asset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)