### PR TITLE
feat(authoring): metadata setters + /Lang (#381) and AcroForm field options (#380)

### DIFF
--- a/Pdfe.Core.Tests/Document/MetadataAndFieldOptionsTests.cs
+++ b/Pdfe.Core.Tests/Document/MetadataAndFieldOptionsTests.cs
@@ -1,0 +1,148 @@
+using System.Linq;
+using AwesomeAssertions;
+using Pdfe.Core.Document;
+using Pdfe.Core.Primitives;
+using Xunit;
+
+namespace Pdfe.Core.Tests.Document;
+
+/// <summary>
+/// Tests for document-metadata setters + catalog /Lang (#381) and the extended
+/// AcroForm field options — /TU tooltip, /MaxLen, comb, date field, tab order
+/// (#380). Everything is verified by saving and reopening so we exercise the
+/// real serialize → parse round-trip.
+/// </summary>
+public class MetadataAndFieldOptionsTests
+{
+    private static PdfDocument RoundTrip(PdfDocument doc)
+        => PdfDocument.Open(doc.SaveToBytes());
+
+    // ── #381 metadata ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Metadata_SettersPersistThroughSaveAndReopen()
+    {
+        var doc = PdfDocument.CreateNew();
+        doc.Pages.AddBlank();
+        doc.SetTitle("Quarterly Report");
+        doc.SetAuthor("Ada Lovelace");
+        doc.SetSubject("Numbers");
+        doc.SetKeywords("pdf;report");
+        doc.Language = "en-US";
+
+        using var reopened = RoundTrip(doc);
+        reopened.Title.Should().Be("Quarterly Report");
+        reopened.Author.Should().Be("Ada Lovelace");
+        reopened.Subject.Should().Be("Numbers");
+        reopened.Keywords.Should().Be("pdf;report");
+        reopened.Language.Should().Be("en-US");
+    }
+
+    [Fact]
+    public void Language_SetNull_RemovesCatalogLang()
+    {
+        var doc = PdfDocument.CreateNew();
+        doc.Pages.AddBlank();
+        doc.Language = "fr-FR";
+        doc.Language.Should().Be("fr-FR");
+        doc.Language = null;
+        doc.Language.Should().BeNull();
+        RoundTrip(doc).Language.Should().BeNull();
+    }
+
+    [Fact]
+    public void Metadata_OnExistingDocWithInfo_UpdatesInPlace()
+    {
+        var first = PdfDocument.CreateNew();
+        first.Pages.AddBlank();
+        first.SetTitle("v1");
+        using var doc = RoundTrip(first);   // now has a real /Info object
+        doc.SetTitle("v2");
+        RoundTrip(doc).Title.Should().Be("v2");
+    }
+
+    // ── #380 field options ────────────────────────────────────────────────────
+
+    private static PdfDocument BlankOnePage()
+    {
+        var doc = PdfDocument.CreateNew();
+        doc.Pages.AddBlank();
+        return doc;
+    }
+
+    [Fact]
+    public void TextField_Tooltip_WritesTU()
+    {
+        var doc = BlankOnePage();
+        doc.AddTextField(1, new PdfRectangle(72, 700, 300, 720), "name", tooltip: "Your full name");
+
+        using var re = RoundTrip(doc);
+        var field = re.GetAcroForm()!.FindField("name")!;
+        field.RawDictionary.GetStringOrNull("TU").Should().Be("Your full name");
+    }
+
+    [Fact]
+    public void TextField_MaxLenAndComb_WriteMaxLenAndFlag()
+    {
+        var doc = BlankOnePage();
+        doc.AddTextField(1, new PdfRectangle(72, 700, 300, 720), "ssn", maxLength: 9, comb: true);
+
+        using var re = RoundTrip(doc);
+        var d = re.GetAcroForm()!.FindField("ssn")!.RawDictionary;
+        d.GetOptional("MaxLen").Should().NotBeNull();
+        ((PdfInteger)d.GetOptional("MaxLen")!).Value.Should().Be(9);
+        var ff = ((PdfInteger)d.GetOptional("Ff")!).Value;
+        (ff & 0x1000000).Should().Be(0x1000000, "comb flag (bit 25) must be set");
+    }
+
+    [Fact]
+    public void TextField_CombWithoutMaxLen_IsIgnored()
+    {
+        var doc = BlankOnePage();
+        doc.AddTextField(1, new PdfRectangle(72, 700, 300, 720), "x", comb: true);
+        using var re = RoundTrip(doc);
+        var d = re.GetAcroForm()!.FindField("x")!.RawDictionary;
+        var ffObj = d.GetOptional("Ff");
+        var ff = ffObj is PdfInteger pi ? pi.Value : 0;
+        (ff & 0x1000000).Should().Be(0, "comb must be ignored without /MaxLen");
+    }
+
+    [Fact]
+    public void DateField_WritesJavaScriptFormatActions()
+    {
+        var doc = BlankOnePage();
+        doc.AddDateField(1, new PdfRectangle(72, 700, 300, 720), "dob", format: "yyyy-mm-dd");
+
+        using var re = RoundTrip(doc);
+        var d = re.GetAcroForm()!.FindField("dob")!.RawDictionary;
+        var aa = re.Resolve(d.GetOptional("AA")!) as PdfDictionary;
+        aa.Should().NotBeNull();
+        var fmt = re.Resolve(aa!.GetOptional("F")!) as PdfDictionary;
+        fmt!.GetStringOrNull("JS").Should().Contain("AFDate_FormatEx");
+        fmt.GetStringOrNull("JS").Should().Contain("yyyy-mm-dd");
+    }
+
+    [Fact]
+    public void CheckBoxAndChoice_AcceptTooltip()
+    {
+        var doc = BlankOnePage();
+        doc.AddCheckBox(1, new PdfRectangle(72, 700, 90, 718), "agree", tooltip: "Accept terms");
+        doc.AddChoiceField(1, new PdfRectangle(72, 660, 300, 678), "tier",
+            new[] { "Basic", "Pro" }, tooltip: "Pick a tier");
+
+        using var re = RoundTrip(doc);
+        var form = re.GetAcroForm()!;
+        form.FindField("agree")!.RawDictionary.GetStringOrNull("TU").Should().Be("Accept terms");
+        form.FindField("tier")!.RawDictionary.GetStringOrNull("TU").Should().Be("Pick a tier");
+    }
+
+    [Fact]
+    public void SetTabOrder_WritesPageTabs()
+    {
+        var doc = BlankOnePage();
+        doc.SetTabOrder(1, AcroFormAuthoring.TabOrder.Structure);
+
+        using var re = RoundTrip(doc);
+        re.GetPage(1).Dictionary.GetNameOrNull("Tabs").Should().Be("S");
+    }
+}

--- a/Pdfe.Core.Tests/PublicApi/Pdfe.Core.approved.txt
+++ b/Pdfe.Core.Tests/PublicApi/Pdfe.Core.approved.txt
@@ -44,21 +44,27 @@ namespace Pdfe.Core.Authoring
         public double ContentLeft { get; }
         public double ContentWidth { get; }
         public int PageCount { get; }
+        public Pdfe.Core.Authoring.PdfDocumentBuilder Author(string author) { }
         public Pdfe.Core.Document.PdfDocument Build() { }
-        public Pdfe.Core.Authoring.PdfDocumentBuilder CheckBox(string label, string? fieldName = null, bool checkedByDefault = false) { }
+        public Pdfe.Core.Authoring.PdfDocumentBuilder CheckBox(string label, string? fieldName = null, bool checkedByDefault = false, string? tooltip = null) { }
         public Pdfe.Core.Authoring.PdfDocumentBuilder Custom(System.Action<Pdfe.Core.Graphics.PdfGraphics, Pdfe.Core.Authoring.LayoutContext> draw) { }
-        public Pdfe.Core.Authoring.PdfDocumentBuilder Dropdown(string label, System.Collections.Generic.IEnumerable<string> options, string? fieldName = null, string? defaultValue = null) { }
+        public Pdfe.Core.Authoring.PdfDocumentBuilder DateField(string label, string? fieldName = null, string format = "yyyy-mm-dd", bool required = false, string? tooltip = null) { }
+        public Pdfe.Core.Authoring.PdfDocumentBuilder Dropdown(string label, System.Collections.Generic.IEnumerable<string> options, string? fieldName = null, string? defaultValue = null, string? tooltip = null) { }
         public Pdfe.Core.Authoring.PdfDocumentBuilder Heading(string text, int level = 1, Pdfe.Core.Authoring.TextStyle? style = null) { }
         public Pdfe.Core.Authoring.PdfDocumentBuilder HorizontalRule(double thickness = 0.5, Pdfe.Core.Graphics.PdfColor? color = default) { }
         public Pdfe.Core.Authoring.PdfDocumentBuilder KeyValue(string label, string value, double labelWidth = 0.3) { }
+        public Pdfe.Core.Authoring.PdfDocumentBuilder Keywords(string keywords) { }
+        public Pdfe.Core.Authoring.PdfDocumentBuilder Language(string bcp47) { }
         public Pdfe.Core.Authoring.PdfDocumentBuilder PageBreak() { }
         public Pdfe.Core.Authoring.PdfDocumentBuilder Paragraph(string text, Pdfe.Core.Authoring.TextStyle? style = null) { }
         public void Save(System.IO.Stream stream) { }
         public void Save(string path) { }
         public byte[] SaveToBytes() { }
         public Pdfe.Core.Authoring.PdfDocumentBuilder Spacer(double points) { }
+        public Pdfe.Core.Authoring.PdfDocumentBuilder Subject(string subject) { }
         public Pdfe.Core.Authoring.PdfDocumentBuilder Table(System.Collections.Generic.IEnumerable<System.Collections.Generic.IReadOnlyList<string>> rows, double[]? columnWeights = null, bool headerRow = false, bool gridLines = true) { }
-        public Pdfe.Core.Authoring.PdfDocumentBuilder TextField(string label, string? fieldName = null, bool multiline = false, bool required = false, int lines = 1, string? defaultValue = null) { }
+        public Pdfe.Core.Authoring.PdfDocumentBuilder TextField(string label, string? fieldName = null, bool multiline = false, bool required = false, int lines = 1, string? defaultValue = null, string? tooltip = null, int? maxLength = default, bool comb = false) { }
+        public Pdfe.Core.Authoring.PdfDocumentBuilder Title(string title) { }
         public static Pdfe.Core.Authoring.PdfDocumentBuilder Create(Pdfe.Core.Authoring.PageSize? pageSize = default, Pdfe.Core.Authoring.PageMargins? margins = default) { }
     }
     public sealed class TextStyle : System.IEquatable<Pdfe.Core.Authoring.TextStyle>
@@ -237,10 +243,18 @@ namespace Pdfe.Core.Document
 {
     public static class AcroFormAuthoring
     {
-        public static Pdfe.Core.Document.PdfField AddCheckBox(this Pdfe.Core.Document.PdfDocument document, int pageNumber, Pdfe.Core.Document.PdfRectangle rect, string fieldName, bool defaultChecked = false, bool readOnly = false) { }
-        public static Pdfe.Core.Document.PdfField AddChoiceField(this Pdfe.Core.Document.PdfDocument document, int pageNumber, Pdfe.Core.Document.PdfRectangle rect, string fieldName, System.Collections.Generic.IEnumerable<string> options, string? defaultValue = null, bool readOnly = false) { }
-        public static Pdfe.Core.Document.PdfField AddSignatureField(this Pdfe.Core.Document.PdfDocument document, int pageNumber, Pdfe.Core.Document.PdfRectangle rect, string fieldName) { }
-        public static Pdfe.Core.Document.PdfField AddTextField(this Pdfe.Core.Document.PdfDocument document, int pageNumber, Pdfe.Core.Document.PdfRectangle rect, string fieldName, string? defaultValue = null, bool multiline = false, bool readOnly = false, bool required = false) { }
+        public static Pdfe.Core.Document.PdfField AddCheckBox(this Pdfe.Core.Document.PdfDocument document, int pageNumber, Pdfe.Core.Document.PdfRectangle rect, string fieldName, bool defaultChecked = false, bool readOnly = false, string? tooltip = null) { }
+        public static Pdfe.Core.Document.PdfField AddChoiceField(this Pdfe.Core.Document.PdfDocument document, int pageNumber, Pdfe.Core.Document.PdfRectangle rect, string fieldName, System.Collections.Generic.IEnumerable<string> options, string? defaultValue = null, bool readOnly = false, string? tooltip = null) { }
+        public static Pdfe.Core.Document.PdfField AddDateField(this Pdfe.Core.Document.PdfDocument document, int pageNumber, Pdfe.Core.Document.PdfRectangle rect, string fieldName, string format = "yyyy-mm-dd", string? defaultValue = null, bool required = false, string? tooltip = null) { }
+        public static Pdfe.Core.Document.PdfField AddSignatureField(this Pdfe.Core.Document.PdfDocument document, int pageNumber, Pdfe.Core.Document.PdfRectangle rect, string fieldName, string? tooltip = null) { }
+        public static Pdfe.Core.Document.PdfField AddTextField(this Pdfe.Core.Document.PdfDocument document, int pageNumber, Pdfe.Core.Document.PdfRectangle rect, string fieldName, string? defaultValue = null, bool multiline = false, bool readOnly = false, bool required = false, string? tooltip = null, int? maxLength = default, bool comb = false) { }
+        public static void SetTabOrder(this Pdfe.Core.Document.PdfDocument document, int pageNumber, Pdfe.Core.Document.AcroFormAuthoring.TabOrder order) { }
+        public enum TabOrder
+        {
+            Row = 0,
+            Column = 1,
+            Structure = 2,
+        }
     }
     public sealed class NamedDestination : System.IEquatable<Pdfe.Core.Document.NamedDestination>
     {
@@ -373,6 +387,7 @@ namespace Pdfe.Core.Document
         public bool IsEncrypted { get; }
         public bool IsTaggedPdf { get; }
         public string? Keywords { get; }
+        public string? Language { get; set; }
         public int PageCount { get; }
         public Pdfe.Core.Document.PageCollection Pages { get; }
         public string? Producer { get; }
@@ -402,6 +417,12 @@ namespace Pdfe.Core.Document
         public void ScrubInfoKeys(params string[] keys) { }
         public void ScrubMetadata(bool scrubAttachments = true) { }
         public void SetAcroFormNeedAppearances() { }
+        public void SetAuthor(string author) { }
+        public void SetCreator(string creator) { }
+        public void SetKeywords(string keywords) { }
+        public void SetProducer(string producer) { }
+        public void SetSubject(string subject) { }
+        public void SetTitle(string title) { }
         public static Pdfe.Core.Document.PdfDocument CreateNew(string version = "1.7") { }
         public static Pdfe.Core.Document.PdfDocument Open(byte[] data, bool allowEncrypted = false) { }
         public static Pdfe.Core.Document.PdfDocument Open(string path, bool allowEncrypted = false) { }

--- a/Pdfe.Core/Authoring/PdfDocumentBuilder.cs
+++ b/Pdfe.Core/Authoring/PdfDocumentBuilder.cs
@@ -68,6 +68,26 @@ public sealed class PdfDocumentBuilder
     /// <summary>The number of pages added so far.</summary>
     public int PageCount => _document.PageCount;
 
+    // ── document metadata (#381) ─────────────────────────────────────────────
+
+    /// <summary>Sets the document title (Info <c>/Title</c>).</summary>
+    public PdfDocumentBuilder Title(string title) { _document.SetTitle(title); return this; }
+
+    /// <summary>Sets the document author (Info <c>/Author</c>).</summary>
+    public PdfDocumentBuilder Author(string author) { _document.SetAuthor(author); return this; }
+
+    /// <summary>Sets the document subject (Info <c>/Subject</c>).</summary>
+    public PdfDocumentBuilder Subject(string subject) { _document.SetSubject(subject); return this; }
+
+    /// <summary>Sets the document keywords (Info <c>/Keywords</c>).</summary>
+    public PdfDocumentBuilder Keywords(string keywords) { _document.SetKeywords(keywords); return this; }
+
+    /// <summary>
+    /// Sets the document language as a BCP 47 tag (catalog <c>/Lang</c>, e.g.
+    /// <c>"en-US"</c>) — required by PDF/UA for accessible documents.
+    /// </summary>
+    public PdfDocumentBuilder Language(string bcp47) { _document.Language = bcp47; return this; }
+
     // ── content blocks ──────────────────────────────────────────────────────
 
     /// <summary>
@@ -198,7 +218,10 @@ public sealed class PdfDocumentBuilder
         bool multiline = false,
         bool required = false,
         int lines = 1,
-        string? defaultValue = null)
+        string? defaultValue = null,
+        string? tooltip = null,
+        int? maxLength = null,
+        bool comb = false)
     {
         EnsurePage();
         fieldName ??= NextFieldName("text");
@@ -211,8 +234,39 @@ public sealed class PdfDocumentBuilder
 
         var rect = ReserveBox(boxHeight);
         DrawBoxBorder(rect);
+        // Default the accessible name (/TU) to the visible label so screen
+        // readers announce the field even when no explicit tooltip is given.
         _document.AddTextField(_currentPageNumber, rect, fieldName,
-            defaultValue: defaultValue, multiline: multiline, required: required);
+            defaultValue: defaultValue, multiline: multiline, required: required,
+            tooltip: tooltip ?? label, maxLength: maxLength, comb: comb);
+
+        _cursorY -= TextStyle.Body.SpaceAfter;
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a labelled date field — a text field with viewer-side date
+    /// formatting (Acrobat <c>AFDate</c> actions). <paramref name="format"/>
+    /// is an Acrobat date mask, e.g. <c>"yyyy-mm-dd"</c>.
+    /// </summary>
+    public PdfDocumentBuilder DateField(
+        string label,
+        string? fieldName = null,
+        string format = "yyyy-mm-dd",
+        bool required = false,
+        string? tooltip = null)
+    {
+        EnsurePage();
+        fieldName ??= NextFieldName("date");
+
+        DrawFieldLabel(label, required);
+
+        var bodyFont = TextStyle.Body.ResolveFont();
+        double boxHeight = bodyFont.LineHeight + 6;
+        var rect = ReserveBox(boxHeight);
+        DrawBoxBorder(rect);
+        _document.AddDateField(_currentPageNumber, rect, fieldName,
+            format: format, required: required, tooltip: tooltip ?? $"{label} ({format})");
 
         _cursorY -= TextStyle.Body.SpaceAfter;
         return this;
@@ -224,7 +278,8 @@ public sealed class PdfDocumentBuilder
     public PdfDocumentBuilder CheckBox(
         string label,
         string? fieldName = null,
-        bool checkedByDefault = false)
+        bool checkedByDefault = false,
+        string? tooltip = null)
     {
         EnsurePage();
         fieldName ??= NextFieldName("check");
@@ -238,7 +293,8 @@ public sealed class PdfDocumentBuilder
         double bottom = top - box;
         var rect = new PdfRectangle(ContentLeft, bottom, ContentLeft + box, top);
         DrawBoxBorder(rect);
-        _document.AddCheckBox(_currentPageNumber, rect, fieldName, defaultChecked: checkedByDefault);
+        _document.AddCheckBox(_currentPageNumber, rect, fieldName,
+            defaultChecked: checkedByDefault, tooltip: tooltip ?? label);
 
         // Label baseline aligned to the checkbox.
         double baseline = top - font.Ascender;
@@ -256,7 +312,8 @@ public sealed class PdfDocumentBuilder
         string label,
         IEnumerable<string> options,
         string? fieldName = null,
-        string? defaultValue = null)
+        string? defaultValue = null,
+        string? tooltip = null)
     {
         ArgumentNullException.ThrowIfNull(options);
         EnsurePage();
@@ -268,7 +325,8 @@ public sealed class PdfDocumentBuilder
         double boxHeight = bodyFont.LineHeight + 6;
         var rect = ReserveBox(boxHeight);
         DrawBoxBorder(rect);
-        _document.AddChoiceField(_currentPageNumber, rect, fieldName, options, defaultValue: defaultValue);
+        _document.AddChoiceField(_currentPageNumber, rect, fieldName, options,
+            defaultValue: defaultValue, tooltip: tooltip ?? label);
 
         _cursorY -= TextStyle.Body.SpaceAfter;
         return this;

--- a/Pdfe.Core/Document/AcroFormAuthoring.cs
+++ b/Pdfe.Core/Document/AcroFormAuthoring.cs
@@ -43,7 +43,10 @@ public static class AcroFormAuthoring
         string? defaultValue = null,
         bool multiline = false,
         bool readOnly = false,
-        bool required = false)
+        bool required = false,
+        string? tooltip = null,
+        int? maxLength = null,
+        bool comb = false)
     {
         ValidateName(fieldName);
 
@@ -52,16 +55,72 @@ public static class AcroFormAuthoring
         widget.SetString("T", fieldName);
         if (defaultValue != null)
             widget.SetString("V", defaultValue);
+        SetTooltip(widget, tooltip);
+
+        // /MaxLen caps the input length; required for a comb field.
+        if (maxLength.HasValue)
+            widget.SetInt("MaxLen", maxLength.Value);
 
         int flags = 0;
-        if (readOnly)  flags |= 0x1;
-        if (required)  flags |= 0x2;
-        if (multiline) flags |= 0x1000;
+        if (readOnly)  flags |= 0x1;        // ReadOnly
+        if (required)  flags |= 0x2;        // Required
+        if (multiline) flags |= 0x1000;     // Multiline (bit 13)
+        // Comb (bit 25) lays text into /MaxLen equal cells. Spec §12.7.4.3:
+        // valid only with /MaxLen and not combined with Multiline/Password/
+        // FileSelect — ignore the request if those preconditions aren't met.
+        if (comb && maxLength.HasValue && !multiline)
+            flags |= 0x1000000;
         if (flags != 0) widget.SetInt("Ff", flags);
 
         // Default appearance: 10-point Helvetica, black. /Helv resolves
         // through the AcroForm /DR resources we set up on first add.
         widget.SetString("DA", "/Helv 10 Tf 0 g");
+
+        return AttachWidget(document, pageNumber, widget, fieldName);
+    }
+
+    /// <summary>
+    /// Add a date text field — a text field carrying Acrobat date format/keystroke
+    /// JavaScript actions so conforming viewers validate and format input, plus an
+    /// optional <paramref name="tooltip"/> (<c>/TU</c>) accessible name.
+    /// <paramref name="format"/> is an Acrobat date mask, e.g. <c>"mm/dd/yyyy"</c>
+    /// or <c>"yyyy-mm-dd"</c>.
+    /// </summary>
+    public static PdfField AddDateField(
+        this PdfDocument document,
+        int pageNumber,
+        PdfRectangle rect,
+        string fieldName,
+        string format = "yyyy-mm-dd",
+        string? defaultValue = null,
+        bool required = false,
+        string? tooltip = null)
+    {
+        ValidateName(fieldName);
+
+        var widget = NewWidgetDict(rect);
+        widget.SetName("FT", "Tx");
+        widget.SetString("T", fieldName);
+        if (defaultValue != null)
+            widget.SetString("V", defaultValue);
+        SetTooltip(widget, tooltip);
+
+        int flags = 0;
+        if (required) flags |= 0x2;
+        if (flags != 0) widget.SetInt("Ff", flags);
+        widget.SetString("DA", "/Helv 10 Tf 0 g");
+
+        // /AA additional-actions: format (F) on display, keystroke (K) on input.
+        var format1 = new PdfDictionary();
+        format1.SetName("S", "JavaScript");
+        format1.SetString("JS", $"AFDate_FormatEx(\"{format}\");");
+        var keystroke = new PdfDictionary();
+        keystroke.SetName("S", "JavaScript");
+        keystroke.SetString("JS", $"AFDate_KeystrokeEx(\"{format}\");");
+        var aa = new PdfDictionary();
+        aa["F"] = format1;
+        aa["K"] = keystroke;
+        widget["AA"] = aa;
 
         return AttachWidget(document, pageNumber, widget, fieldName);
     }
@@ -75,7 +134,8 @@ public static class AcroFormAuthoring
         PdfRectangle rect,
         string fieldName,
         bool defaultChecked = false,
-        bool readOnly = false)
+        bool readOnly = false,
+        string? tooltip = null)
     {
         ValidateName(fieldName);
 
@@ -84,6 +144,7 @@ public static class AcroFormAuthoring
         widget.SetString("T", fieldName);
         widget.SetName("V", defaultChecked ? "Yes" : "Off");
         widget.SetName("AS", defaultChecked ? "Yes" : "Off");
+        SetTooltip(widget, tooltip);
         if (readOnly) widget.SetInt("Ff", 0x1);
 
         return AttachWidget(document, pageNumber, widget, fieldName);
@@ -100,7 +161,8 @@ public static class AcroFormAuthoring
         string fieldName,
         IEnumerable<string> options,
         string? defaultValue = null,
-        bool readOnly = false)
+        bool readOnly = false,
+        string? tooltip = null)
     {
         ValidateName(fieldName);
         var optList = options?.ToList() ?? new List<string>();
@@ -110,6 +172,7 @@ public static class AcroFormAuthoring
         var widget = NewWidgetDict(rect);
         widget.SetName("FT", "Ch");
         widget.SetString("T", fieldName);
+        SetTooltip(widget, tooltip);
 
         var optArr = new PdfArray();
         foreach (var opt in optList)
@@ -143,16 +206,55 @@ public static class AcroFormAuthoring
         this PdfDocument document,
         int pageNumber,
         PdfRectangle rect,
-        string fieldName)
+        string fieldName,
+        string? tooltip = null)
     {
         ValidateName(fieldName);
         var widget = NewWidgetDict(rect);
         widget.SetName("FT", "Sig");
         widget.SetString("T", fieldName);
+        SetTooltip(widget, tooltip);
         return AttachWidget(document, pageNumber, widget, fieldName);
     }
 
+    /// <summary>
+    /// Widget/annotation tab-traversal order for a page (<c>/Tabs</c>, §12.5).
+    /// </summary>
+    public enum TabOrder
+    {
+        /// <summary>Rows, left-to-right then top-to-bottom (<c>/R</c>).</summary>
+        Row,
+        /// <summary>Columns, top-to-bottom then left-to-right (<c>/C</c>).</summary>
+        Column,
+        /// <summary>Document logical-structure order (<c>/S</c>) — recommended for accessibility.</summary>
+        Structure
+    }
+
+    /// <summary>
+    /// Set the tab-traversal order of a page's annotations/fields by writing the
+    /// page <c>/Tabs</c> entry. <see cref="TabOrder.Structure"/> follows the
+    /// document's logical structure tree and is the accessible choice.
+    /// </summary>
+    public static void SetTabOrder(this PdfDocument document, int pageNumber, TabOrder order)
+    {
+        var page = document.GetPage(pageNumber);
+        var name = order switch
+        {
+            TabOrder.Row => "R",
+            TabOrder.Column => "C",
+            _ => "S"
+        };
+        page.Dictionary.SetName("Tabs", name);
+    }
+
     // ── plumbing ────────────────────────────────────────────────────────────
+
+    /// <summary>Set the field's <c>/TU</c> (tooltip / accessible name) when provided.</summary>
+    private static void SetTooltip(PdfDictionary widget, string? tooltip)
+    {
+        if (!string.IsNullOrEmpty(tooltip))
+            widget.SetString("TU", tooltip);
+    }
 
     private static PdfDictionary NewWidgetDict(PdfRectangle rect)
     {

--- a/Pdfe.Core/Document/PdfDocument.cs
+++ b/Pdfe.Core/Document/PdfDocument.cs
@@ -137,9 +137,10 @@ public class PdfDocument : IDisposable
     public bool IsEncrypted => Trailer.ContainsKey("Encrypt");
 
     /// <summary>
-    /// Information dictionary (metadata).
+    /// Information dictionary (metadata). Publicly read-only; created on demand
+    /// by the metadata setters (<see cref="SetTitle"/> etc.) when absent.
     /// </summary>
-    public PdfDictionary? Info { get; }
+    public PdfDictionary? Info { get; private set; }
 
     /// <summary>
     /// Collection of pages in the document.
@@ -720,6 +721,56 @@ public class PdfDocument : IDisposable
     /// Get document metadata producer.
     /// </summary>
     public string? Producer => Info?.GetStringOrNull("Producer");
+
+    // ── Metadata / catalog authoring (#381) ──────────────────────────────────
+
+    /// <summary>
+    /// The document's natural language as a BCP 47 tag (catalog <c>/Lang</c>,
+    /// e.g. <c>"en-US"</c>). Required by PDF/UA for accessible documents so
+    /// screen readers pronounce content correctly. Setting <c>null</c> removes
+    /// the entry. PDF spec §14.9.2.
+    /// </summary>
+    public string? Language
+    {
+        get => Catalog.GetStringOrNull("Lang");
+        set
+        {
+            if (value == null) Catalog.Remove("Lang");
+            else Catalog.SetString("Lang", value);
+        }
+    }
+
+    /// <summary>Set the document title (Info <c>/Title</c>).</summary>
+    public void SetTitle(string title) => EnsureInfo().SetString("Title", title ?? string.Empty);
+
+    /// <summary>Set the document author (Info <c>/Author</c>).</summary>
+    public void SetAuthor(string author) => EnsureInfo().SetString("Author", author ?? string.Empty);
+
+    /// <summary>Set the document subject (Info <c>/Subject</c>).</summary>
+    public void SetSubject(string subject) => EnsureInfo().SetString("Subject", subject ?? string.Empty);
+
+    /// <summary>Set the document keywords (Info <c>/Keywords</c>).</summary>
+    public void SetKeywords(string keywords) => EnsureInfo().SetString("Keywords", keywords ?? string.Empty);
+
+    /// <summary>Set the creating application (Info <c>/Creator</c>).</summary>
+    public void SetCreator(string creator) => EnsureInfo().SetString("Creator", creator ?? string.Empty);
+
+    /// <summary>Set the producer (Info <c>/Producer</c>).</summary>
+    public void SetProducer(string producer) => EnsureInfo().SetString("Producer", producer ?? string.Empty);
+
+    /// <summary>
+    /// Return the Info dictionary, creating and wiring it into the trailer
+    /// (<c>/Info</c>) on first use. Newly created documents have no Info dict.
+    /// </summary>
+    private PdfDictionary EnsureInfo()
+    {
+        if (Info != null) return Info;
+        var info = new PdfDictionary();
+        var reference = AddIndirectObject(info);
+        Trailer["Info"] = reference;
+        Info = info;   // keep the read-side properties (Title/Author/…) in sync
+        return info;
+    }
 
     /// <summary>
     /// Get the document's interactive form (AcroForm), if present.


### PR DESCRIPTION
Two cohesive Writer-MVP issues (epic #382), building on the v2.4.0 authoring facade.

### #381 — document metadata authoring
- `PdfDocument.SetTitle/SetAuthor/SetSubject/SetKeywords/SetCreator/SetProducer` — create and wire the `/Info` dict into the trailer on first use (new docs have none).
- `PdfDocument.Language` read/write → catalog `/Lang` (required by PDF/UA).

### #380 — AcroForm field options
- `/TU` tooltip (accessible name) on all four `Add*` field methods.
- `/MaxLen` + comb (Ff bit 25, guarded on `/MaxLen` & `!multiline`) for text fields.
- `AddDateField` — text field with Acrobat `AFDate` format/keystroke JS actions.
- `SetTabOrder` — page `/Tabs` (Row/Column/Structure; Structure = accessible).

### Facade
`PdfDocumentBuilder` gains `Title/Author/Subject/Keywords/Language`, `DateField`, and `tooltip/maxLength/comb` on `TextField` (+ `tooltip` on `CheckBox`/`Dropdown`, defaulting `/TU` to the visible label).

### Testing
9 new save→reopen round-trip tests; full `Pdfe.Core` suite green (**2754**), 0 warnings. Public-API gate baseline regenerated (purely additive → MINOR).

Closes #380, closes #381.

🤖 Generated with [Claude Code](https://claude.com/claude-code)