### PR TITLE
feat(authoring): embed TrueType fonts + draw Unicode text (#378)

### DIFF
--- a/Pdfe.Core.Tests/Graphics/EmbeddedFontTests.cs
+++ b/Pdfe.Core.Tests/Graphics/EmbeddedFontTests.cs
@@ -1,0 +1,108 @@
+using System.IO;
+using System.Linq;
+using AwesomeAssertions;
+using Pdfe.Core.Document;
+using Pdfe.Core.Graphics;
+using Pdfe.Core.Primitives;
+using Pdfe.Core.Text;
+using Xunit;
+
+namespace Pdfe.Core.Tests.Graphics;
+
+/// <summary>
+/// Tests for TrueType/OpenType font embedding + Unicode text (#378). They embed a
+/// real system font, so each skips cleanly when that font isn't installed.
+/// </summary>
+public class EmbeddedFontTests
+{
+    private const string DejaVu = "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf";
+
+    private static string ExtractAll(byte[] pdf)
+    {
+        using var doc = PdfDocument.Open(pdf);
+        return string.Join("\n", doc.GetPages().Select(p => new TextExtractor(p).ExtractText()));
+    }
+
+    private static byte[] AuthorWith(string text, out PdfFont font)
+    {
+        font = PdfFont.FromFile(DejaVu, 18);
+        var doc = PdfDocument.CreateNew();
+        var page = doc.Pages.AddBlank(400, 200);
+        using (var g = page.GetGraphics())
+            g.DrawString(text, font, PdfBrush.Black, 40, 120);
+        return doc.SaveToBytes();
+    }
+
+    [Fact]
+    public void FromFile_ProducesType0EmbeddedFont()
+    {
+        Assert.SkipUnless(File.Exists(DejaVu), "DejaVuSans not installed");
+        var font = PdfFont.FromFile(DejaVu, 12);
+        font.Should().BeOfType<PdfTrueTypeFont>();
+        // Identity-H encodes 2-byte glyph ids as a hex string.
+        font.EncodeString("AB").Should().StartWith("<").And.EndWith(">");
+        font.EncodeString("AB").Should().HaveLength(10); // <XXXXXXXX>
+    }
+
+    [Fact]
+    public void EmbeddedFont_UnicodeText_RoundTripsThroughExtraction()
+    {
+        Assert.SkipUnless(File.Exists(DejaVu), "DejaVuSans not installed");
+        const string text = "Café résumé naïve — Ø ½ € Ελληνικά Кириллица";
+        var pdf = AuthorWith(text, out _);
+
+        var extracted = ExtractAll(pdf);
+        extracted.Should().Contain("Café résumé naïve");
+        extracted.Should().Contain("Ελληνικά");
+        extracted.Should().Contain("Кириллица");
+        extracted.Should().Contain("€");
+    }
+
+    [Fact]
+    public void EmbeddedFont_DictionaryIsType0WithFontFile2AndToUnicode()
+    {
+        Assert.SkipUnless(File.Exists(DejaVu), "DejaVuSans not installed");
+        var pdf = AuthorWith("Hello Café", out _);
+        using var doc = PdfDocument.Open(pdf);
+        var page = doc.GetPage(1);
+
+        var (_, fontDict) = page.GetFonts().First();
+        fontDict.GetNameOrNull("Subtype").Should().Be("Type0");
+        fontDict.GetNameOrNull("Encoding").Should().Be("Identity-H");
+        doc.Resolve(fontDict.GetOptional("ToUnicode")!).Should().BeOfType<PdfStream>();
+
+        var descendants = doc.Resolve(fontDict.GetOptional("DescendantFonts")!) as PdfArray;
+        var cid = doc.Resolve(descendants![0]) as PdfDictionary;
+        cid!.GetNameOrNull("Subtype").Should().Be("CIDFontType2");
+        var fd = doc.Resolve(cid.GetOptional("FontDescriptor")!) as PdfDictionary;
+        doc.Resolve(fd!.GetOptional("FontFile2")!).Should().BeOfType<PdfStream>("the TTF must be embedded");
+    }
+
+    [Fact]
+    public void EmbeddedFont_MeasureWidth_IsPositiveAndScalesWithText()
+    {
+        Assert.SkipUnless(File.Exists(DejaVu), "DejaVuSans not installed");
+        var font = PdfFont.FromFile(DejaVu, 20);
+        double w1 = font.MeasureWidth("i");
+        double wLong = font.MeasureWidth("WWWWW");
+        w1.Should().BeGreaterThan(0);
+        wLong.Should().BeGreaterThan(w1);
+    }
+
+    [Fact]
+    public void EmbeddedFont_RoundTripsThroughOpen_NoErrors()
+    {
+        Assert.SkipUnless(File.Exists(DejaVu), "DejaVuSans not installed");
+        var pdf = AuthorWith("Round trip Ω", out _);
+        var act = () => PdfDocument.Open(pdf).Dispose();
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void FromTrueType_RejectsNonTrueTypeData()
+    {
+        var bogus = new byte[] { 0x25, 0x50, 0x44, 0x46, 0x2D, 0x31, 0x2E }; // "%PDF-1."
+        var act = () => PdfFont.FromTrueType(bogus, 12);
+        act.Should().Throw<System.Exception>();
+    }
+}

--- a/Pdfe.Core.Tests/PublicApi/Pdfe.Core.approved.txt
+++ b/Pdfe.Core.Tests/PublicApi/Pdfe.Core.approved.txt
@@ -660,22 +660,25 @@ namespace Pdfe.Core.Graphics
     public class PdfFont
     {
         public PdfFont(string name, string baseFont, double size) { }
-        public double Ascender { get; }
+        public virtual double Ascender { get; }
         public string BaseFont { get; }
-        public double Descender { get; }
+        public virtual double Descender { get; }
         public bool IsStandard14 { get; }
-        public double LineHeight { get; }
+        public virtual double LineHeight { get; }
         public string Name { get; }
         public double Size { get; }
         public Pdfe.Core.Primitives.PdfDictionary CreateFontDictionary() { }
-        public string EncodeString(string text) { }
-        public double MeasureWidth(string text) { }
+        public virtual string EncodeString(string text) { }
+        public virtual double MeasureWidth(string text) { }
         public override string ToString() { }
         public Pdfe.Core.Graphics.PdfFont WithName(string name) { }
         public Pdfe.Core.Graphics.PdfFont WithSize(double size) { }
         public static Pdfe.Core.Graphics.PdfFont Courier(double size) { }
         public static Pdfe.Core.Graphics.PdfFont CourierBold(double size) { }
         public static Pdfe.Core.Graphics.PdfFont CourierOblique(double size) { }
+        public static Pdfe.Core.Graphics.PdfFont FromFile(string path, double size) { }
+        public static Pdfe.Core.Graphics.PdfFont FromTrueType(System.IO.Stream fontStream, double size) { }
+        public static Pdfe.Core.Graphics.PdfFont FromTrueType(byte[] fontData, double size) { }
         public static Pdfe.Core.Graphics.PdfFont Helvetica(double size) { }
         public static Pdfe.Core.Graphics.PdfFont HelveticaBold(double size) { }
         public static Pdfe.Core.Graphics.PdfFont HelveticaOblique(double size) { }

--- a/Pdfe.Core/Document/PdfPage.cs
+++ b/Pdfe.Core/Document/PdfPage.cs
@@ -455,8 +455,12 @@ public class PdfPage
             fontName = $"F{counter++}";
         }
 
-        // Add the font dictionary
-        fontDict[fontName] = font.CreateFontDictionary();
+        // Add the font dictionary (embedded fonts register their own indirect
+        // stream objects in the document and return a Type0 dictionary).
+        var builtFont = font.BuildFontDictionary(_document);
+        fontDict[fontName] = font.PreferIndirectFontDictionary
+            ? _document.AddIndirectObject(builtFont)
+            : builtFont;
 
         return fontName;
     }

--- a/Pdfe.Core/Fonts/TrueTypeFontFile.cs
+++ b/Pdfe.Core/Fonts/TrueTypeFontFile.cs
@@ -1,0 +1,226 @@
+using System.Text;
+
+namespace Pdfe.Core.Fonts;
+
+/// <summary>
+/// Minimal read-only parser for a TrueType-outline (<c>glyf</c>-based) sfnt font,
+/// exposing exactly what's needed to <em>embed</em> the font and lay out Unicode
+/// text: units-per-em, glyph count, per-glyph advance widths, a Unicode→glyph
+/// (cmap) map, the font bounding box, and vertical metrics.
+///
+/// <para>Supports the common desktop TrueType files (sfnt version 0x00010000 or
+/// 'true'). CFF-based OpenType ('OTTO') is not handled here — that needs a
+/// CIDFontType0/CFF embedding path (tracked separately).</para>
+/// </summary>
+internal sealed class TrueTypeFontFile
+{
+    public byte[] Data { get; }
+    public ushort UnitsPerEm { get; }
+    public int GlyphCount { get; }
+    public string PostScriptName { get; }
+    public short XMin { get; }
+    public short YMin { get; }
+    public short XMax { get; }
+    public short YMax { get; }
+    public short Ascent { get; }
+    public short Descent { get; }
+    public bool IsBold { get; }
+    public bool IsItalic { get; }
+
+    private readonly ushort[] _advanceWidths;          // per glyph id, font units
+    private readonly Dictionary<int, int> _cmap;       // unicode codepoint -> gid
+
+    private TrueTypeFontFile(byte[] data, ushort unitsPerEm, int glyphCount, string psName,
+        short xMin, short yMin, short xMax, short yMax, short ascent, short descent,
+        bool bold, bool italic, ushort[] advanceWidths, Dictionary<int, int> cmap)
+    {
+        Data = data; UnitsPerEm = unitsPerEm; GlyphCount = glyphCount; PostScriptName = psName;
+        XMin = xMin; YMin = yMin; XMax = xMax; YMax = yMax; Ascent = ascent; Descent = descent;
+        IsBold = bold; IsItalic = italic; _advanceWidths = advanceWidths; _cmap = cmap;
+    }
+
+    /// <summary>Glyph id for a Unicode codepoint, or 0 (.notdef) if unmapped.</summary>
+    public int GidForCodepoint(int codepoint) => _cmap.TryGetValue(codepoint, out var g) ? g : 0;
+
+    /// <summary>Advance width of a glyph in font units (clamped to the table).</summary>
+    public int AdvanceWidth(int gid)
+    {
+        if (_advanceWidths.Length == 0) return 0;
+        return gid < _advanceWidths.Length ? _advanceWidths[gid] : _advanceWidths[^1];
+    }
+
+    /// <summary>codepoint → gid map (read-only), used to build /W and ToUnicode.</summary>
+    public IReadOnlyDictionary<int, int> Cmap => _cmap;
+
+    public static TrueTypeFontFile Parse(byte[] data)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+        var r = new BE(data);
+        uint sfnt = r.U32(0);
+        if (sfnt != 0x00010000 && sfnt != 0x74727565 /*'true'*/)
+            throw new NotSupportedException(
+                "Only TrueType-outline fonts are supported for embedding (not CFF/'OTTO').");
+
+        ushort numTables = r.U16(4);
+        var tables = new Dictionary<string, (int off, int len)>();
+        int p = 12;
+        for (int i = 0; i < numTables; i++, p += 16)
+        {
+            string tag = Encoding.ASCII.GetString(data, p, 4);
+            tables[tag] = ((int)r.U32(p + 8), (int)r.U32(p + 12));
+        }
+
+        (int off, int len) Req(string t) =>
+            tables.TryGetValue(t, out var v) ? v : throw new NotSupportedException($"Font missing required '{t}' table.");
+
+        var head = Req("head");
+        ushort unitsPerEm = r.U16(head.off + 18);
+        short xMin = r.S16(head.off + 36), yMin = r.S16(head.off + 38);
+        short xMax = r.S16(head.off + 40), yMax = r.S16(head.off + 42);
+        ushort macStyle = r.U16(head.off + 44);
+        short indexToLocFormat = r.S16(head.off + 50);
+        _ = indexToLocFormat;
+
+        var maxp = Req("maxp");
+        int numGlyphs = r.U16(maxp.off + 4);
+
+        var hhea = Req("hhea");
+        short ascent = r.S16(hhea.off + 4), descent = r.S16(hhea.off + 6);
+        int numberOfHMetrics = r.U16(hhea.off + 34);
+
+        var hmtx = Req("hmtx");
+        var adv = new ushort[numGlyphs];
+        ushort last = 0;
+        for (int i = 0; i < numGlyphs; i++)
+        {
+            if (i < numberOfHMetrics) last = r.U16(hmtx.off + i * 4);
+            adv[i] = last;
+        }
+
+        var cmap = ParseCmap(r, Req("cmap").off);
+        string psName = tables.TryGetValue("name", out var nameTbl)
+            ? (ReadPostScriptName(r, nameTbl.off) ?? "EmbeddedFont")
+            : "EmbeddedFont";
+
+        return new TrueTypeFontFile(data, unitsPerEm, numGlyphs, psName,
+            xMin, yMin, xMax, yMax, ascent, descent,
+            (macStyle & 0x1) != 0, (macStyle & 0x2) != 0, adv, cmap);
+    }
+
+    private static Dictionary<int, int> ParseCmap(BE r, int cmapOff)
+    {
+        ushort numSub = r.U16(cmapOff + 2);
+        // Prefer a full-Unicode (format 12) subtable, else BMP (format 4).
+        int best = -1, bestScore = -1;
+        for (int i = 0; i < numSub; i++)
+        {
+            int rec = cmapOff + 4 + i * 8;
+            ushort plat = r.U16(rec), enc = r.U16(rec + 2);
+            int sub = cmapOff + (int)r.U32(rec + 4);
+            ushort fmt = r.U16(sub);
+            int score = fmt switch
+            {
+                12 when plat == 3 && enc == 10 => 5,
+                4 when plat == 3 && enc == 1 => 4,
+                12 => 3,
+                4 => 2,
+                6 or 0 => 1,
+                _ => 0
+            };
+            if (score > bestScore) { bestScore = score; best = sub; }
+        }
+        var map = new Dictionary<int, int>();
+        if (best < 0) return map;
+
+        ushort format = r.U16(best);
+        if (format == 4)
+        {
+            ushort segX2 = r.U16(best + 6);
+            int segCount = segX2 / 2;
+            int endP = best + 14;
+            int startP = endP + segX2 + 2;            // +2 reservedPad
+            int deltaP = startP + segX2;
+            int rangeP = deltaP + segX2;
+            for (int s = 0; s < segCount; s++)
+            {
+                ushort end = r.U16(endP + s * 2);
+                ushort start = r.U16(startP + s * 2);
+                short delta = r.S16(deltaP + s * 2);
+                ushort rangeOff = r.U16(rangeP + s * 2);
+                for (int c = start; c <= end && c != 0xFFFF; c++)
+                {
+                    int gid;
+                    if (rangeOff == 0) gid = (c + delta) & 0xFFFF;
+                    else
+                    {
+                        int giAddr = rangeP + s * 2 + rangeOff + (c - start) * 2;
+                        ushort g = r.U16(giAddr);
+                        gid = g == 0 ? 0 : (g + delta) & 0xFFFF;
+                    }
+                    if (gid != 0) map[c] = gid;
+                }
+            }
+        }
+        else if (format == 12)
+        {
+            uint nGroups = r.U32(best + 12);
+            int gp = best + 16;
+            for (uint g = 0; g < nGroups; g++, gp += 12)
+            {
+                uint startC = r.U32(gp), endC = r.U32(gp + 4), startG = r.U32(gp + 8);
+                for (uint c = startC; c <= endC; c++)
+                    map[(int)c] = (int)(startG + (c - startC));
+            }
+        }
+        else if (format == 6)
+        {
+            ushort first = r.U16(best + 6), count = r.U16(best + 8);
+            for (int i = 0; i < count; i++)
+            {
+                int gid = r.U16(best + 10 + i * 2);
+                if (gid != 0) map[first + i] = gid;
+            }
+        }
+        else if (format == 0)
+        {
+            for (int c = 0; c < 256; c++)
+            {
+                int gid = r.Data[best + 6 + c];
+                if (gid != 0) map[c] = gid;
+            }
+        }
+        return map;
+    }
+
+    private static string? ReadPostScriptName(BE r, int nameOff)
+    {
+        ushort count = r.U16(nameOff + 2);
+        int storage = nameOff + r.U16(nameOff + 4);
+        string? fallback = null;
+        for (int i = 0; i < count; i++)
+        {
+            int rec = nameOff + 6 + i * 12;
+            ushort plat = r.U16(rec), enc = r.U16(rec + 2), nameId = r.U16(rec + 6);
+            ushort len = r.U16(rec + 8), off = r.U16(rec + 10);
+            if (nameId != 6) continue;                 // PostScript name
+            // Platform 3 (Windows) / 0 (Unicode) store UTF-16BE; 1 (Mac) Latin-1.
+            string val = (plat == 3 || plat == 0)
+                ? Encoding.BigEndianUnicode.GetString(r.Data, storage + off, len)
+                : Encoding.Latin1.GetString(r.Data, storage + off, len);
+            val = val.Trim();
+            if (plat == 3) return val;                  // prefer Windows record
+            fallback ??= val;
+        }
+        return fallback;
+    }
+
+    /// <summary>Big-endian byte reader over a font blob.</summary>
+    private readonly struct BE
+    {
+        public readonly byte[] Data;
+        public BE(byte[] data) => Data = data;
+        public ushort U16(int o) => (ushort)((Data[o] << 8) | Data[o + 1]);
+        public short S16(int o) => (short)U16(o);
+        public uint U32(int o) => (uint)((Data[o] << 24) | (Data[o + 1] << 16) | (Data[o + 2] << 8) | Data[o + 3]);
+    }
+}

--- a/Pdfe.Core/Graphics/PdfFont.cs
+++ b/Pdfe.Core/Graphics/PdfFont.cs
@@ -123,9 +123,37 @@ public class PdfFont
     public PdfFont WithName(string name) => new(name, BaseFont, Size);
 
     /// <summary>
+    /// Create an embedded font from a TrueType/OpenType file on disk. The font
+    /// is embedded (and the text encoded) so arbitrary Unicode renders and stays
+    /// extractable. See <see cref="FromTrueType(byte[], double)"/>.
+    /// </summary>
+    public static PdfFont FromFile(string path, double size) =>
+        FromTrueType(File.ReadAllBytes(path), size);
+
+    /// <summary>
+    /// Create an embedded font from TrueType/OpenType font bytes. Produces a
+    /// Type0/Identity-H font with a ToUnicode CMap; <see cref="EncodeString"/>
+    /// emits glyph ids and the whole font is embedded on first use.
+    /// (Subsetting is a future optimization — see #378.)
+    /// </summary>
+    public static PdfFont FromTrueType(byte[] fontData, double size) =>
+        new PdfTrueTypeFont(fontData, size);
+
+    /// <summary>
+    /// Create an embedded font from a TrueType/OpenType stream.
+    /// </summary>
+    public static PdfFont FromTrueType(Stream fontStream, double size)
+    {
+        ArgumentNullException.ThrowIfNull(fontStream);
+        using var ms = new MemoryStream();
+        fontStream.CopyTo(ms);
+        return FromTrueType(ms.ToArray(), size);
+    }
+
+    /// <summary>
     /// Measures the width of a string in points.
     /// </summary>
-    public double MeasureWidth(string text)
+    public virtual double MeasureWidth(string text)
     {
         if (string.IsNullOrEmpty(text))
             return 0;
@@ -143,17 +171,32 @@ public class PdfFont
     /// <summary>
     /// Gets the approximate line height (ascender + descender).
     /// </summary>
-    public double LineHeight => Size * 1.2; // Typical line height is ~1.2x font size
+    public virtual double LineHeight => Size * 1.2; // Typical line height is ~1.2x font size
 
     /// <summary>
     /// Gets the ascender height (distance from baseline to top).
     /// </summary>
-    public double Ascender => Size * 0.8; // Typical ascender is ~0.8x font size
+    public virtual double Ascender => Size * 0.8; // Typical ascender is ~0.8x font size
 
     /// <summary>
     /// Gets the descender depth (distance from baseline to bottom).
     /// </summary>
-    public double Descender => Size * 0.2; // Typical descender is ~0.2x font size
+    public virtual double Descender => Size * 0.2; // Typical descender is ~0.2x font size
+
+    /// <summary>
+    /// Build the font dictionary, registering any required indirect objects in
+    /// <paramref name="document"/> (embedded fonts add stream objects). The base
+    /// implementation returns the inline standard-font dictionary.
+    /// </summary>
+    internal virtual PdfDictionary BuildFontDictionary(PdfDocument document) => CreateFontDictionary();
+
+    /// <summary>
+    /// Whether the font dictionary should be stored as an indirect object in the
+    /// page resources rather than inline. Embedded composite fonts set this so
+    /// the font dict has its own object id (better tool compatibility); standard
+    /// fonts stay inline.
+    /// </summary>
+    internal virtual bool PreferIndirectFontDictionary => false;
 
     /// <summary>
     /// Creates a PDF font dictionary for embedding in resources.
@@ -177,7 +220,7 @@ public class PdfFont
     /// <summary>
     /// Encodes a string for use in PDF text operators.
     /// </summary>
-    public string EncodeString(string text)
+    public virtual string EncodeString(string text)
     {
         if (string.IsNullOrEmpty(text))
             return "()";

--- a/Pdfe.Core/Graphics/PdfTrueTypeFont.cs
+++ b/Pdfe.Core/Graphics/PdfTrueTypeFont.cs
@@ -1,0 +1,203 @@
+using System.Globalization;
+using System.IO.Compression;
+using System.Text;
+using Pdfe.Core.Document;
+using Pdfe.Core.Fonts;
+using Pdfe.Core.Primitives;
+
+namespace Pdfe.Core.Graphics;
+
+/// <summary>
+/// An embedded TrueType font drawn as a PDF <b>Type0 / Identity-H</b> composite
+/// font. Unlike the base-14 <see cref="PdfFont"/>, this embeds the actual font
+/// program so arbitrary Unicode (CJK, Arabic, accented Latin, …) renders, and
+/// attaches a ToUnicode CMap so the text stays selectable/extractable.
+///
+/// <para><see cref="EncodeString"/> emits 2-byte glyph ids (Identity-H), and
+/// <see cref="BuildFontDictionary"/> installs the FontFile2 / descendant font /
+/// descriptor / ToUnicode objects into the document. The full font is embedded
+/// (subsetting is a future optimization — see #378).</para>
+/// </summary>
+internal sealed class PdfTrueTypeFont : PdfFont
+{
+    private readonly TrueTypeFontFile _ttf;
+    private readonly double _scale;   // font units -> text space at 1 pt
+
+    internal override bool PreferIndirectFontDictionary => true;
+
+    public PdfTrueTypeFont(byte[] fontData, double size)
+        : base("F1", SafeBaseName(TrueTypeFontFile.Parse(fontData).PostScriptName), size)
+    {
+        _ttf = TrueTypeFontFile.Parse(fontData);
+        _scale = 1.0 / _ttf.UnitsPerEm;
+    }
+
+    public override double MeasureWidth(string text)
+    {
+        if (string.IsNullOrEmpty(text)) return 0;
+        long units = 0;
+        foreach (var cp in Codepoints(text))
+            units += _ttf.AdvanceWidth(_ttf.GidForCodepoint(cp));
+        return units * _scale * Size;
+    }
+
+    public override double Ascender => _ttf.Ascent * _scale * Size;
+    public override double Descender => -_ttf.Descent * _scale * Size;
+    public override double LineHeight => (_ttf.Ascent - _ttf.Descent) * _scale * Size;
+
+    /// <summary>Encode as a hex string of 2-byte glyph ids: <c>&lt;00410042&gt;</c>.</summary>
+    public override string EncodeString(string text)
+    {
+        var sb = new StringBuilder(text.Length * 4 + 2);
+        sb.Append('<');
+        foreach (var cp in Codepoints(text))
+        {
+            int gid = _ttf.GidForCodepoint(cp) & 0xFFFF;
+            sb.Append(gid.ToString("X4", CultureInfo.InvariantCulture));
+        }
+        sb.Append('>');
+        return sb.ToString();
+    }
+
+    internal override PdfDictionary BuildFontDictionary(PdfDocument document)
+    {
+        double toGlyphSpace = 1000.0 / _ttf.UnitsPerEm;   // PDF glyph space = 1000/em
+        int Scale(int fontUnits) => (int)Math.Round(fontUnits * toGlyphSpace);
+
+        // 1. FontFile2 — the embedded TTF, FlateDecode-compressed.
+        byte[] compressed = Deflate(_ttf.Data);
+        var ff2Dict = new PdfDictionary();
+        ff2Dict.SetInt("Length1", _ttf.Data.Length);
+        ff2Dict.SetName("Filter", "FlateDecode");
+        ff2Dict.SetInt("Length", compressed.Length);
+        var ff2Ref = document.AddIndirectObject(new PdfStream(ff2Dict, compressed));
+
+        // 2. FontDescriptor.
+        var fd = new PdfDictionary();
+        fd.SetName("Type", "FontDescriptor");
+        fd.SetName("FontName", BaseFont);
+        fd.SetInt("Flags", 4); // Symbolic — safe for an embedded CID font
+        var bbox = new PdfArray();
+        bbox.Add(Scale(_ttf.XMin)); bbox.Add(Scale(_ttf.YMin));
+        bbox.Add(Scale(_ttf.XMax)); bbox.Add(Scale(_ttf.YMax));
+        fd["FontBBox"] = bbox;
+        fd.SetInt("ItalicAngle", 0);
+        fd.SetInt("Ascent", Scale(_ttf.Ascent));
+        fd.SetInt("Descent", Scale(_ttf.Descent));
+        fd.SetInt("CapHeight", Scale(_ttf.Ascent));
+        fd.SetInt("StemV", _ttf.IsBold ? 140 : 80);
+        fd["FontFile2"] = ff2Ref;
+        var fdRef = document.AddIndirectObject(fd);
+
+        // 3. /W advance widths for every glyph: [0 [w0 w1 w2 …]].
+        var widths = new PdfArray();
+        for (int g = 0; g < _ttf.GlyphCount; g++)
+            widths.Add(Scale(_ttf.AdvanceWidth(g)));
+        var wArr = new PdfArray();
+        wArr.Add(0);
+        wArr.Add((PdfObject)widths);
+
+        // 4. CIDFontType2 descendant font.
+        var cid = new PdfDictionary();
+        cid.SetName("Type", "Font");
+        cid.SetName("Subtype", "CIDFontType2");
+        cid.SetName("BaseFont", BaseFont);
+        var csi = new PdfDictionary();
+        csi.SetString("Registry", "Adobe");
+        csi.SetString("Ordering", "Identity");
+        csi.SetInt("Supplement", 0);
+        cid["CIDSystemInfo"] = csi;
+        cid["FontDescriptor"] = fdRef;
+        cid.SetName("CIDToGIDMap", "Identity");
+        cid["W"] = wArr;
+        var cidRef = document.AddIndirectObject(cid);
+
+        // 5. ToUnicode CMap so extraction recovers the original text.
+        byte[] toUni = Encoding.ASCII.GetBytes(BuildToUnicodeCMap());
+        var tuDict = new PdfDictionary();
+        tuDict.SetInt("Length", toUni.Length);
+        var tuRef = document.AddIndirectObject(new PdfStream(tuDict, toUni));
+
+        // 6. Type0 root (returned; AddFont stores it inline in /Font).
+        var type0 = new PdfDictionary();
+        type0.SetName("Type", "Font");
+        type0.SetName("Subtype", "Type0");
+        type0.SetName("BaseFont", BaseFont);
+        type0.SetName("Encoding", "Identity-H");
+        var descendants = new PdfArray();
+        descendants.Add((PdfObject)cidRef);
+        type0["DescendantFonts"] = descendants;
+        type0["ToUnicode"] = tuRef;
+        return type0;
+    }
+
+    /// <summary>Build a ToUnicode CMap mapping each glyph id back to a codepoint.</summary>
+    private string BuildToUnicodeCMap()
+    {
+        // gid -> first codepoint that maps to it.
+        var gidToCp = new SortedDictionary<int, int>();
+        foreach (var (cp, gid) in _ttf.Cmap)
+            if (gid <= 0xFFFF && !gidToCp.ContainsKey(gid))
+                gidToCp[gid] = cp;
+
+        var sb = new StringBuilder();
+        sb.Append("/CIDInit /ProcSet findresource begin\n12 dict begin\nbegincmap\n");
+        sb.Append("/CIDSystemInfo << /Registry (Adobe) /Ordering (UCS) /Supplement 0 >> def\n");
+        sb.Append("/CMapName /Adobe-Identity-UCS def\n/CMapType 2 def\n");
+        sb.Append("1 begincodespacerange\n<0000> <FFFF>\nendcodespacerange\n");
+
+        var entries = gidToCp.ToList();
+        for (int i = 0; i < entries.Count; i += 100)
+        {
+            int n = Math.Min(100, entries.Count - i);
+            sb.Append(n).Append(" beginbfchar\n");
+            for (int j = i; j < i + n; j++)
+            {
+                sb.Append('<').Append(entries[j].Key.ToString("X4", CultureInfo.InvariantCulture)).Append("> <")
+                  .Append(Utf16BeHex(entries[j].Value)).Append(">\n");
+            }
+            sb.Append("endbfchar\n");
+        }
+
+        sb.Append("endcmap\nCMapName currentdict /CMap defineresource pop\nend\nend\n");
+        return sb.ToString();
+    }
+
+    private static string Utf16BeHex(int codepoint)
+    {
+        if (codepoint <= 0xFFFF)
+            return codepoint.ToString("X4", CultureInfo.InvariantCulture);
+        // Surrogate pair for supplementary planes.
+        int v = codepoint - 0x10000;
+        int hi = 0xD800 + (v >> 10), lo = 0xDC00 + (v & 0x3FF);
+        return hi.ToString("X4", CultureInfo.InvariantCulture) + lo.ToString("X4", CultureInfo.InvariantCulture);
+    }
+
+    private static IEnumerable<int> Codepoints(string text)
+    {
+        for (int i = 0; i < text.Length; i++)
+        {
+            if (char.IsHighSurrogate(text[i]) && i + 1 < text.Length && char.IsLowSurrogate(text[i + 1]))
+            {
+                yield return char.ConvertToUtf32(text[i], text[i + 1]);
+                i++;
+            }
+            else
+            {
+                yield return text[i];
+            }
+        }
+    }
+
+    private static byte[] Deflate(byte[] data)
+    {
+        using var outMs = new MemoryStream();
+        using (var z = new ZLibStream(outMs, CompressionLevel.SmallestSize, leaveOpen: true))
+            z.Write(data, 0, data.Length);
+        return outMs.ToArray();
+    }
+
+    // PDF names can't contain spaces; PostScript names normally don't, but be safe.
+    private static string SafeBaseName(string psName) =>
+        string.IsNullOrWhiteSpace(psName) ? "EmbeddedFont" : psName.Replace(' ', '-');
+}


### PR DESCRIPTION
Unblocks non-Latin / Unicode text authoring (the keystone Writer-MVP capability, epic #382). Pure-managed, zero new deps.

### What
- **`TrueTypeFontFile`** — a dependency-free sfnt reader (`head`/`maxp`/`hhea`/`hmtx`/`cmap` formats 0/4/6/12/`name`): units-per-em, glyph advances, Unicode→gid, font bbox, PostScript name.
- **`PdfTrueTypeFont`** (via `PdfFont.FromFile` / `FromTrueType(byte[]/Stream)`) — a **Type0 / Identity-H** composite font: emits 2-byte glyph ids, embeds the font as `FontFile2` (FlateDecode), builds the `CIDFontType2` descendant + `FontDescriptor` + `/W` widths + a **ToUnicode CMap** (text stays extractable). Real font metrics for `MeasureWidth`/`Ascender`.
- `PdfFont`: encode/measure/metrics made `virtual`; document-aware `BuildFontDictionary`; embedded font dicts stored as indirect objects.

### Verified (poppler)
`pdffonts` → `CID TrueType / Identity-H / emb=yes / uni=yes`; `pdftotext` recovers `Café résumé naïve — Ø ½ €`, Greek, Cyrillic. 6 new tests (skip if the system test font is absent); full `Pdfe.Core` suite green (**2760**), 0 warnings.

### Scope
Full-font embedding only. **Subsetting** (rebuilding `glyf`/`loca` for smaller output) and **CFF/'OTTO'** embedding are deferred — I'll file a follow-up. Complex-script **shaping/BiDi** (e.g. visual Arabic) is a separate text-layout concern; characters embed and extract correctly.

Closes #378.

🤖 Generated with [Claude Code](https://claude.com/claude-code)