### PR TITLE
feat(authoring): high-level text layout — DrawText(rect) + MeasureText (#379)

### DIFF
--- a/Pdfe.Core.Tests/Graphics/TextLayoutTests.cs
+++ b/Pdfe.Core.Tests/Graphics/TextLayoutTests.cs
@@ -1,0 +1,89 @@
+using System.Linq;
+using AwesomeAssertions;
+using Pdfe.Core.Document;
+using Pdfe.Core.Graphics;
+using Pdfe.Core.Text;
+using Xunit;
+
+namespace Pdfe.Core.Tests.Graphics;
+
+/// <summary>
+/// Tests for the high-level text-layout helpers (#379): MeasureText (wrapped)
+/// and PdfGraphics.DrawText(rect) with word-wrap + overflow.
+/// </summary>
+public class TextLayoutTests
+{
+    private static string ExtractAll(byte[] pdf)
+    {
+        using var doc = PdfDocument.Open(pdf);
+        return string.Join("\n", doc.GetPages().Select(p => new TextExtractor(p).ExtractText()));
+    }
+
+    [Fact]
+    public void MeasureText_TallerWithMoreWrappedLines()
+    {
+        var font = PdfFont.Helvetica(12);
+        var one = PdfGraphics.MeasureText("short", font, 400);
+        var many = PdfGraphics.MeasureText(string.Join(" ", Enumerable.Repeat("word", 200)), font, 100);
+        many.Height.Should().BeGreaterThan(one.Height);
+        many.Width.Should().BeLessThanOrEqualTo(100 + 0.01);
+    }
+
+    [Fact]
+    public void DrawText_WrapsAndIsExtractable()
+    {
+        var doc = PdfDocument.CreateNew();
+        var page = doc.Pages.AddBlank(300, 400);
+        var font = PdfFont.Helvetica(12);
+        TextLayoutResult result;
+        using (var g = page.GetGraphics())
+        {
+            var bounds = new PdfRectangle(50, 50, 250, 350); // L,B,R,T → 200 wide, 300 tall
+            result = g.DrawText(
+                "The quick brown fox jumps over the lazy dog several times in a fixed column.",
+                font, PdfBrush.Black, bounds);
+        }
+        result.HasOverflow.Should().BeFalse("the paragraph fits the tall box");
+        result.UsedHeight.Should().BeGreaterThan(0);
+
+        var text = ExtractAll(doc.SaveToBytes());
+        text.Should().Contain("quick brown fox");
+        text.Should().Contain("lazy dog");
+    }
+
+    [Fact]
+    public void DrawText_ReturnsOverflowWhenBoxTooShort()
+    {
+        var doc = PdfDocument.CreateNew();
+        var page = doc.Pages.AddBlank(300, 400);
+        var font = PdfFont.Helvetica(12);
+        using var g = page.GetGraphics();
+        // A 1-line-tall box can't hold a long wrapped paragraph.
+        var bounds = new PdfRectangle(50, 350, 250, 366);
+        var result = g.DrawText(
+            string.Join(" ", Enumerable.Repeat("overflow", 80)),
+            font, PdfBrush.Black, bounds);
+
+        result.HasOverflow.Should().BeTrue();
+        result.Overflow!.Should().Contain("overflow");
+    }
+
+    [Fact]
+    public void DrawText_OverflowCanFlowToAnotherBox()
+    {
+        var doc = PdfDocument.CreateNew();
+        var page = doc.Pages.AddBlank(300, 400);
+        var font = PdfFont.Helvetica(12);
+        var longText = string.Join(" ", Enumerable.Repeat("flow", 40));
+
+        using var g = page.GetGraphics();
+        var box1 = new PdfRectangle(20, 330, 140, 380);   // short left column (~3 lines)
+        var r1 = g.DrawText(longText, font, PdfBrush.Black, box1);
+        r1.HasOverflow.Should().BeTrue();
+
+        var box2 = new PdfRectangle(160, 20, 280, 380);   // tall right column (~25 lines)
+        var r2 = g.DrawText(r1.Overflow!, font, PdfBrush.Black, box2);
+        // The remainder is short; the tall second column absorbs it.
+        r2.HasOverflow.Should().BeFalse();
+    }
+}

--- a/Pdfe.Core.Tests/PublicApi/Pdfe.Core.approved.txt
+++ b/Pdfe.Core.Tests/PublicApi/Pdfe.Core.approved.txt
@@ -714,6 +714,7 @@ namespace Pdfe.Core.Graphics
         public void DrawRectangle(double x, double y, double width, double height, Pdfe.Core.Graphics.PdfBrush? fill, Pdfe.Core.Graphics.PdfPen? stroke) { }
         public void DrawString(string text, Pdfe.Core.Graphics.PdfFont font, Pdfe.Core.Graphics.PdfBrush brush, double x, double y) { }
         public void DrawString(string text, Pdfe.Core.Graphics.PdfFont font, Pdfe.Core.Graphics.PdfBrush brush, double x, double y, Pdfe.Core.Graphics.TextAlignment alignment) { }
+        public Pdfe.Core.Graphics.TextLayoutResult DrawText(string text, Pdfe.Core.Graphics.PdfFont font, Pdfe.Core.Graphics.PdfBrush brush, Pdfe.Core.Document.PdfRectangle bounds, Pdfe.Core.Graphics.TextAlignment alignment = 0, double lineSpacing = 1.2) { }
         public void Fill(Pdfe.Core.Graphics.PdfBrush brush) { }
         public void FillAndStroke(Pdfe.Core.Graphics.PdfBrush brush, Pdfe.Core.Graphics.PdfPen pen) { }
         public void Flush() { }
@@ -728,6 +729,7 @@ namespace Pdfe.Core.Graphics
         public void Transform(double a, double b, double c, double d, double e, double f) { }
         public void Translate(double tx, double ty) { }
         public static Pdfe.Core.Graphics.PdfSize MeasureString(string text, Pdfe.Core.Graphics.PdfFont font) { }
+        public static Pdfe.Core.Graphics.PdfSize MeasureText(string text, Pdfe.Core.Graphics.PdfFont font, double maxWidth, double lineSpacing = 1.2) { }
     }
     public class PdfPen
     {
@@ -751,6 +753,13 @@ namespace Pdfe.Core.Graphics
         Left = 0,
         Center = 1,
         Right = 2,
+    }
+    public readonly struct TextLayoutResult : System.IEquatable<Pdfe.Core.Graphics.TextLayoutResult>
+    {
+        public TextLayoutResult(double UsedHeight, string? Overflow) { }
+        public bool HasOverflow { get; }
+        public string? Overflow { get; init; }
+        public double UsedHeight { get; init; }
     }
 }
 namespace Pdfe.Core.Operations

--- a/Pdfe.Core/Authoring/PdfDocumentBuilder.cs
+++ b/Pdfe.Core/Authoring/PdfDocumentBuilder.cs
@@ -526,53 +526,10 @@ public sealed class PdfDocumentBuilder
 
     /// <summary>
     /// Greedy word-wrap to <paramref name="maxWidth"/> points using the font's
-    /// own metrics. Hard line breaks (\n, \r\n) in the input are preserved; a
-    /// single word longer than the column is emitted on its own (over)long line.
+    /// own metrics (delegates to the shared <see cref="TextWrapper"/>).
     /// </summary>
     internal static IEnumerable<string> WrapText(string text, PdfFont font, double maxWidth)
-    {
-        if (string.IsNullOrEmpty(text))
-        {
-            yield return string.Empty;
-            yield break;
-        }
-
-        var hardLines = text.Replace("\r\n", "\n").Replace('\r', '\n').Split('\n');
-        foreach (var hardLine in hardLines)
-        {
-            if (hardLine.Length == 0)
-            {
-                yield return string.Empty;
-                continue;
-            }
-
-            var words = hardLine.Split(' ');
-            var current = new System.Text.StringBuilder();
-            foreach (var word in words)
-            {
-                if (current.Length == 0)
-                {
-                    current.Append(word);
-                    continue;
-                }
-
-                var candidate = current.ToString() + " " + word;
-                if (maxWidth > 0 && font.MeasureWidth(candidate) > maxWidth)
-                {
-                    yield return current.ToString();
-                    current.Clear();
-                    current.Append(word);
-                }
-                else
-                {
-                    current.Append(' ').Append(word);
-                }
-            }
-
-            if (current.Length > 0)
-                yield return current.ToString();
-        }
-    }
+        => TextWrapper.Wrap(text, font, maxWidth);
 }
 
 /// <summary>

--- a/Pdfe.Core/Graphics/PdfGraphics.cs
+++ b/Pdfe.Core/Graphics/PdfGraphics.cs
@@ -31,6 +31,18 @@ public readonly record struct PdfSize(double Width, double Height)
 }
 
 /// <summary>
+/// Result of <see cref="PdfGraphics.DrawText"/>: how much vertical space the
+/// drawn text consumed, and any text that did not fit the box.
+/// </summary>
+/// <param name="UsedHeight">Vertical space consumed, in points.</param>
+/// <param name="Overflow">Text that didn't fit (newline-joined), or <c>null</c> if all fit.</param>
+public readonly record struct TextLayoutResult(double UsedHeight, string? Overflow)
+{
+    /// <summary>True when some text didn't fit the box.</summary>
+    public bool HasOverflow => Overflow != null;
+}
+
+/// <summary>
 /// Provides graphics drawing operations for a PDF page.
 /// Generates PDF content stream operators for drawing shapes, text, and images.
 /// </summary>
@@ -342,6 +354,74 @@ public class PdfGraphics : IDisposable
             return new PdfSize(0, 0);
 
         return new PdfSize(font.MeasureWidth(text), font.LineHeight);
+    }
+
+    /// <summary>
+    /// Measures <paramref name="text"/> when word-wrapped to <paramref name="maxWidth"/>
+    /// points: width is the widest resulting line (≤ maxWidth), height is the total
+    /// stacked line height. <paramref name="lineSpacing"/> is a multiple of the font
+    /// size (default 1.2).
+    /// </summary>
+    public static PdfSize MeasureText(string text, PdfFont font, double maxWidth, double lineSpacing = 1.2)
+    {
+        ArgumentNullException.ThrowIfNull(font);
+        var lines = TextWrapper.Wrap(text ?? string.Empty, font, maxWidth).ToList();
+        double w = 0;
+        foreach (var line in lines)
+            w = Math.Max(w, font.MeasureWidth(line));
+        return new PdfSize(w, lines.Count * font.Size * lineSpacing);
+    }
+
+    /// <summary>
+    /// Draws word-wrapped, multi-line text inside <paramref name="bounds"/> (PDF
+    /// coordinates, bottom-left origin). Lines flow from the top of the box; any
+    /// that don't fit vertically are returned as overflow so a caller can
+    /// continue on the next page. Honors hard line breaks and embedded fonts.
+    /// </summary>
+    /// <returns>
+    /// The height actually used and the overflow text that didn't fit
+    /// (<c>null</c> when everything fit).
+    /// </returns>
+    public TextLayoutResult DrawText(
+        string text,
+        PdfFont font,
+        PdfBrush brush,
+        PdfRectangle bounds,
+        TextAlignment alignment = TextAlignment.Left,
+        double lineSpacing = 1.2)
+    {
+        ThrowIfDisposed();
+        ArgumentNullException.ThrowIfNull(font);
+        ArgumentNullException.ThrowIfNull(brush);
+
+        double lineHeight = font.Size * lineSpacing;
+        var lines = TextWrapper.Wrap(text ?? string.Empty, font, bounds.Width).ToList();
+
+        double x = alignment switch
+        {
+            TextAlignment.Center => bounds.Left + bounds.Width / 2,
+            TextAlignment.Right => bounds.Left + bounds.Width,
+            _ => bounds.Left
+        };
+
+        double y = bounds.Top;            // top of the text box (PDF coords)
+        double used = 0;
+        int drawn = 0;
+        foreach (var line in lines)
+        {
+            if (y - lineHeight < bounds.Bottom)
+                break;                    // no vertical room for another line
+            double baseline = y - font.Ascender;
+            DrawString(line, font, brush, x, baseline, alignment);
+            y -= lineHeight;
+            used += lineHeight;
+            drawn++;
+        }
+
+        string? overflow = drawn < lines.Count
+            ? string.Join("\n", lines.Skip(drawn))
+            : null;
+        return new TextLayoutResult(used, overflow);
     }
 
     #endregion

--- a/Pdfe.Core/Graphics/TextWrapper.cs
+++ b/Pdfe.Core/Graphics/TextWrapper.cs
@@ -1,0 +1,60 @@
+namespace Pdfe.Core.Graphics;
+
+/// <summary>
+/// Greedy word-wrapping shared by the low-level <see cref="PdfGraphics.DrawText"/>
+/// and the high-level authoring facade. Measures with the font's own metrics, so
+/// it works for both base-14 and embedded fonts.
+/// </summary>
+internal static class TextWrapper
+{
+    /// <summary>
+    /// Wrap <paramref name="text"/> to <paramref name="maxWidth"/> points. Hard
+    /// line breaks (<c>\n</c>, <c>\r\n</c>) are preserved; a single word wider
+    /// than the column is emitted on its own (over-long) line. A non-positive
+    /// <paramref name="maxWidth"/> disables wrapping (hard breaks only).
+    /// </summary>
+    public static IEnumerable<string> Wrap(string text, PdfFont font, double maxWidth)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            yield return string.Empty;
+            yield break;
+        }
+
+        var hardLines = text.Replace("\r\n", "\n").Replace('\r', '\n').Split('\n');
+        foreach (var hardLine in hardLines)
+        {
+            if (hardLine.Length == 0)
+            {
+                yield return string.Empty;
+                continue;
+            }
+
+            var words = hardLine.Split(' ');
+            var current = new System.Text.StringBuilder();
+            foreach (var word in words)
+            {
+                if (current.Length == 0)
+                {
+                    current.Append(word);
+                    continue;
+                }
+
+                var candidate = current.ToString() + " " + word;
+                if (maxWidth > 0 && font.MeasureWidth(candidate) > maxWidth)
+                {
+                    yield return current.ToString();
+                    current.Clear();
+                    current.Append(word);
+                }
+                else
+                {
+                    current.Append(' ').Append(word);
+                }
+            }
+
+            if (current.Length > 0)
+                yield return current.ToString();
+        }
+    }
+}


### PR DESCRIPTION
- **`PdfGraphics.DrawText(text, font, brush, PdfRectangle, alignment, lineSpacing)`** — word-wraps into the box, flows top-down, and returns **`TextLayoutResult`** (`UsedHeight` + `Overflow`) so a caller can continue the remainder in another box or page.
- **`PdfGraphics.MeasureText(text, font, maxWidth, lineSpacing)`** — wrapped size.
- Shared greedy wrapping extracted into `TextWrapper`, reused by `DrawText` and the `PdfDocumentBuilder` facade (which already flows/paginates). Works with embedded fonts (#378) since it measures via font metrics.

4 new tests (wrap, fit vs overflow, flow across columns, extractable). Full `Pdfe.Core` suite green (**2764**), 0 warnings.

Closes #379.

🤖 Generated with [Claude Code](https://claude.com/claude-code)