### PR TITLE
chore(deps): bump FluentAvaloniaUI to latest preview (#340)

### DIFF
--- a/PdfEditor/PdfEditor.csproj
+++ b/PdfEditor/PdfEditor.csproj
@@ -52,7 +52,7 @@
     <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.4" />
     <PackageReference Include="Avalonia.Fonts.Inter" Version="12.0.4" />
     <PackageReference Include="ReactiveUI.Avalonia" Version="12.0.1" />
-    <PackageReference Include="FluentAvaloniaUI" Version="3.0.0-preview2" />
+    <PackageReference Include="FluentAvaloniaUI" Version="3.0.0-preview4" />
     <!-- FluentIcons.Avalonia.Fluent dropped: not referenced anywhere
          in source/axaml. Page icons use emoji TextBlocks (📁💾🔍 etc.)
          not the FluentIcons component library. Removing unblocks


### PR DESCRIPTION
Investigated #340 ("move off preview packages"). Findings:

- **Only one** pre-release dependency exists: `FluentAvaloniaUI`. SkiaSharp (3.119.4), Avalonia (12.0.4 — stable GA), ReactiveUI (23.2.27), and .NET 10 are all already on stable.
- FluentAvalonia's **Avalonia-12 line (3.x) is preview-only upstream** — there is no stable `3.0.0` (stable tops out at `2.5.1`, which targets Avalonia 11). So we can't fully de-preview without downgrading the whole Avalonia stack to 11.

**This PR** bumps `3.0.0-preview2 → 3.0.0-preview4` (latest available) to reduce staleness. GUI build + `PdfEditor.Tests` green locally (755 passed).

#340 stays open, **blocked on upstream** FluentAvalonia 3.0.0 stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)