### PR TITLE
release: v2.5.0 — Unicode authoring + writer-MVP features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,45 @@ All notable changes to pdfe are documented here. Format roughly follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this project uses
 semantic versioning.
 
+## [2.5.0] — 2026-06-06
+
+Completes the **PromptResponse writer epic (#382)** — pdfe can now author
+accessible, fillable, Unicode PDFs from structured content. All additive; the
+public-API gate confirms no breaking changes.
+
+### Added
+- **Unicode text + embedded fonts (#378).** `PdfFont.FromFile(path, size)` /
+  `FromTrueType(bytes|Stream, size)` embed a TrueType font as a Type0 /
+  Identity-H composite font with a ToUnicode CMap, so arbitrary Unicode (CJK,
+  Arabic, accented Latin, Greek, Cyrillic, …) both renders and stays
+  extractable. Backed by a new dependency-free sfnt reader
+  (`Pdfe.Core.Fonts.TrueTypeFontFile`). Full-font embedding; subsetting and CFF
+  ('OTTO') are tracked in #393.
+- **High-level text layout (#379).** `PdfGraphics.DrawText(text, font, brush,
+  PdfRectangle, …)` word-wraps into a box and returns a `TextLayoutResult`
+  (used height + overflow) for flowing across boxes/pages; `MeasureText(...)`
+  returns wrapped size.
+- **AcroForm field options (#380).** `/TU` tooltip (accessible name) on all
+  field types; `/MaxLen` + comb for text fields; `AddDateField` (Acrobat
+  `AFDate` format/keystroke actions); `SetTabOrder` (page `/Tabs`).
+- **Document metadata (#381).** `PdfDocument.SetTitle/SetAuthor/SetSubject/
+  SetKeywords/SetCreator/SetProducer` (creates the `/Info` dict on demand) and a
+  read/write `Language` property (catalog `/Lang`, required by PDF/UA).
+- **`PdfDocumentBuilder`** gains `Title/Author/Subject/Keywords/Language`,
+  `DateField`, and `tooltip`/`maxLength`/`comb` passthrough on fields (with
+  `/TU` defaulting to the visible label for screen readers).
+
+### Changed
+- `PdfFont` text-encoding/measurement/metrics members are now `virtual` so
+  embedded fonts can override them; standard-font behavior is unchanged.
+- Dependencies: bumped `FluentAvaloniaUI` to the latest preview (#340; full
+  de-preview is blocked on an upstream FluentAvalonia 3.x stable for Avalonia 12).
+
+### Tests / CI
+- Raised `Pdfe.Core` CI line coverage to ~93% and ratcheted the gate to 92.5%
+  (#351); CI installs `fonts-dejavu-core` so the embedding tests run
+  deterministically. The macOS `.app` is now built and attached by CI.
+
 ## [2.4.1] — 2026-06-06
 
 Packaging, API-stability, and CI hardening on top of v2.4.0. No public-API

--- a/Pdfe.Avalonia/Pdfe.Avalonia.csproj
+++ b/Pdfe.Avalonia/Pdfe.Avalonia.csproj
@@ -14,7 +14,7 @@
   <!-- NuGet package metadata (packed explicitly via `dotnet pack`, not on build). -->
   <PropertyGroup>
     <PackageId>Pdfe.Avalonia</PackageId>
-    <Version>2.4.1</Version>
+    <Version>2.5.0</Version>
     <Authors>Marc Jones</Authors>
     <Description>A reusable, pure-managed PDF viewer control for Avalonia. Renders with SkiaSharp (no native PDFium), supports zoom/pan, page navigation, text selection, search highlights, annotations, links, and form-field overlays. Built on Pdfe.Core + Pdfe.Rendering.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Pdfe.Core/Pdfe.Core.csproj
+++ b/Pdfe.Core/Pdfe.Core.csproj
@@ -10,7 +10,7 @@
 
   <PropertyGroup>
     <PackageId>Pdfe.Core</PackageId>
-    <Version>2.4.1</Version>
+    <Version>2.5.0</Version>
     <Authors>Marc Jones</Authors>
     <Description>Pure-managed PDF parser, document model, and writer for .NET. Open/edit/save PDFs, extract text/links/annotations/forms, and perform true glyph-level redaction. No native dependencies; cross-platform and trim/AOT-friendlier.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Pdfe.Rendering/Pdfe.Rendering.csproj
+++ b/Pdfe.Rendering/Pdfe.Rendering.csproj
@@ -10,7 +10,7 @@
 
   <PropertyGroup>
     <PackageId>Pdfe.Rendering</PackageId>
-    <Version>2.4.1</Version>
+    <Version>2.5.0</Version>
     <Authors>Marc Jones</Authors>
     <Description>Pure-managed, SkiaSharp-based PDF render API for .NET. Render pages to SKBitmap or PNG with DPI/clip/rotation support and cancellable rendering. Framework-neutral engine behind Pdfe.Avalonia; no native PDFium. Cross-platform, trim/AOT-friendlier.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
Cuts **v2.5.0** (MINOR — additive; the public-API gate confirms no breaking changes). Completes the PromptResponse writer epic #382:

- #378 — embedded TrueType + Unicode text (Type0/Identity-H + ToUnicode)
- #379 — `DrawText(rect)` + `MeasureText`
- #380 — AcroForm field options (`/TU`, `/MaxLen`+comb, date field, tab order)
- #381 — metadata setters + catalog `/Lang`
- #340 — FluentAvaloniaUI bumped to latest preview
- #351 — coverage raised, gate ratcheted to 92.5%

Trio bumped 2.4.1 → 2.5.0; CHANGELOG `[2.5.0]`. Library-only change (path-scoped CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)