### PR TITLE
feat(authoring): subset embedded TrueType fonts (#393)

### DIFF
--- a/Pdfe.Core.Tests/Graphics/EmbeddedFontSubsetTests.cs
+++ b/Pdfe.Core.Tests/Graphics/EmbeddedFontSubsetTests.cs
@@ -1,0 +1,127 @@
+using System.IO;
+using System.Linq;
+using AwesomeAssertions;
+using Pdfe.Core.Document;
+using Pdfe.Core.Fonts;
+using Pdfe.Core.Graphics;
+using Pdfe.Core.Primitives;
+using Pdfe.Core.Text;
+using Xunit;
+
+namespace Pdfe.Core.Tests.Graphics;
+
+/// <summary>
+/// Tests for TrueType font subsetting (#393): only the drawn glyphs are embedded,
+/// the font is tagged as a subset, and text still renders/extracts.
+/// </summary>
+public class EmbeddedFontSubsetTests
+{
+    private const string DejaVu = "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf";
+
+    private static (PdfDictionary fd, long length1, string baseFont) DescriptorOf(PdfDocument doc)
+    {
+        var (_, font) = doc.GetPage(1).GetFonts().First();
+        var descendants = doc.Resolve(font.GetOptional("DescendantFonts")!) as PdfArray;
+        var cid = doc.Resolve(descendants![0]) as PdfDictionary;
+        var fd = doc.Resolve(cid!.GetOptional("FontDescriptor")!) as PdfDictionary;
+        var ff2 = doc.Resolve(fd!.GetOptional("FontFile2")!) as PdfStream;
+        long len1 = ((PdfInteger)ff2!.GetOptional("Length1")!).Value;
+        return (fd, len1, cid.GetNameOrNull("BaseFont")!);
+    }
+
+    [Fact]
+    public void Subset_EmbedsFarLessThanTheFullFont()
+    {
+        Assert.SkipUnless(File.Exists(DejaVu), "DejaVuSans not installed");
+        long fullSize = new FileInfo(DejaVu).Length;
+
+        var doc = PdfDocument.CreateNew();
+        var page = doc.Pages.AddBlank(300, 120);
+        using (var g = page.GetGraphics())
+            g.DrawString("Hello", PdfFont.FromFile(DejaVu, 20), PdfBrush.Black, 30, 70);
+        var bytes = doc.SaveToBytes();
+
+        using var re = PdfDocument.Open(bytes);
+        var (_, length1, baseFont) = DescriptorOf(re);
+        length1.Should().BeLessThan(fullSize / 4, "the embedded subset must be far smaller than the full font");
+        bytes.Length.Should().BeLessThan((int)fullSize / 2);
+    }
+
+    [Fact]
+    public void Subset_TagsTheFontName()
+    {
+        Assert.SkipUnless(File.Exists(DejaVu), "DejaVuSans not installed");
+        var doc = PdfDocument.CreateNew();
+        var page = doc.Pages.AddBlank(300, 120);
+        using (var g = page.GetGraphics())
+            g.DrawString("Hi", PdfFont.FromFile(DejaVu, 20), PdfBrush.Black, 30, 70);
+
+        using var re = PdfDocument.Open(doc.SaveToBytes());
+        var (_, _, baseFont) = DescriptorOf(re);
+        // Subset tag: six uppercase letters + '+' + the font name.
+        baseFont.Should().MatchRegex("^[A-Z]{6}\\+DejaVuSans$");
+    }
+
+    [Fact]
+    public void Subset_TextStillExtractsAndRoundTrips()
+    {
+        Assert.SkipUnless(File.Exists(DejaVu), "DejaVuSans not installed");
+        const string text = "Subset café résumé";
+        var doc = PdfDocument.CreateNew();
+        var page = doc.Pages.AddBlank(400, 120);
+        using (var g = page.GetGraphics())
+            g.DrawString(text, PdfFont.FromFile(DejaVu, 18), PdfBrush.Black, 30, 70);
+
+        var bytes = doc.SaveToBytes();
+        var act = () => PdfDocument.Open(bytes).Dispose();
+        act.Should().NotThrow();
+
+        using var re = PdfDocument.Open(bytes);
+        new TextExtractor(re.GetPage(1)).ExtractText().Should().Contain("Subset café résumé");
+    }
+
+    [Fact]
+    public void Subsetter_RetainsGidsAndProducesValidSfnt()
+    {
+        Assert.SkipUnless(File.Exists(DejaVu), "DejaVuSans not installed");
+        byte[] fullBytes = File.ReadAllBytes(DejaVu);
+        var full = TrueTypeFontFile.Parse(fullBytes);
+        int gidH = full.GidForCodepoint('H');
+
+        var subset = TrueTypeSubsetter.Subset(fullBytes,
+            new System.Collections.Generic.HashSet<int> { 0, gidH });
+
+        subset.Length.Should().BeLessThan(fullBytes.Length);
+
+        // Valid TrueType sfnt header (0x00010000). The subset intentionally drops
+        // cmap (a CID font addresses glyphs by GID), so we read maxp directly.
+        uint sfnt = (uint)((subset[0] << 24) | (subset[1] << 16) | (subset[2] << 8) | subset[3]);
+        sfnt.Should().Be(0x00010000u);
+
+        int numGlyphs = ReadMaxpNumGlyphs(subset);
+        numGlyphs.Should().Be(full.GlyphCount, "retain-gid keeps glyph ids stable");
+    }
+
+    private static int ReadMaxpNumGlyphs(byte[] sfntData)
+    {
+        int numTables = (sfntData[4] << 8) | sfntData[5];
+        for (int i = 0, p = 12; i < numTables; i++, p += 16)
+        {
+            if (System.Text.Encoding.ASCII.GetString(sfntData, p, 4) == "maxp")
+            {
+                int off = (sfntData[p + 8] << 24) | (sfntData[p + 9] << 16) | (sfntData[p + 10] << 8) | sfntData[p + 11];
+                return (sfntData[off + 4] << 8) | sfntData[off + 5];
+            }
+        }
+        return -1;
+    }
+
+    [Fact]
+    public void Subsetter_FallsBackOnNonGlyfData()
+    {
+        // Garbage that isn't a glyf font → return input unchanged (never throws).
+        var input = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 };
+        TrueTypeSubsetter.Subset(input, new System.Collections.Generic.HashSet<int> { 0 })
+            .Should().BeEquivalentTo(input);
+    }
+}

--- a/Pdfe.Core/Document/PdfDocument.cs
+++ b/Pdfe.Core/Document/PdfDocument.cs
@@ -964,11 +964,23 @@ public class PdfDocument : IDisposable
 
     #region Save Methods
 
+    // Actions run just before serialization — used by embedded fonts to finalize
+    // their FontFile2 subset once every glyph that will be drawn is known (#393).
+    private readonly List<Action> _preSaveActions = new();
+
+    /// <summary>
+    /// Register an action to run immediately before the document is serialized.
+    /// Idempotent actions only — it may run on each Save.
+    /// </summary>
+    internal void RegisterPreSaveAction(Action action) => _preSaveActions.Add(action);
+
     /// <summary>
     /// Save the document to a stream.
     /// </summary>
     public void Save(Stream outputStream)
     {
+        foreach (var action in _preSaveActions)
+            action();
         var writer = new PdfDocumentWriter(this);
         writer.Write(outputStream);
     }

--- a/Pdfe.Core/Fonts/TrueTypeSubsetter.cs
+++ b/Pdfe.Core/Fonts/TrueTypeSubsetter.cs
@@ -1,0 +1,221 @@
+namespace Pdfe.Core.Fonts;
+
+/// <summary>
+/// Produces a subset of a TrueType-outline font that keeps only the glyph
+/// outlines actually used, while preserving glyph ids ("retain-gid" subsetting).
+/// Because GIDs are unchanged, the font still works with Identity-H encoding and
+/// an Identity CIDToGIDMap — no cmap/encoding rewrite needed. The big <c>glyf</c>
+/// table (usually the bulk of a font) shrinks to the used outlines; other tables
+/// are copied verbatim.
+///
+/// <para>Composite glyphs pull in their component glyphs automatically.</para>
+/// </summary>
+internal static class TrueTypeSubsetter
+{
+    /// <summary>
+    /// Return a new sfnt containing only <paramref name="usedGids"/> (plus glyph 0
+    /// and any composite components). Falls back to the original bytes if the font
+    /// has no <c>glyf</c>/<c>loca</c> (e.g. CFF) or anything looks off.
+    /// </summary>
+    public static byte[] Subset(byte[] data, IReadOnlySet<int> usedGids)
+    {
+        try
+        {
+            return SubsetCore(data, usedGids);
+        }
+        catch
+        {
+            return data; // never break embedding because subsetting failed
+        }
+    }
+
+    private static byte[] SubsetCore(byte[] data, IReadOnlySet<int> usedGids)
+    {
+        var tables = ReadTableDirectory(data, out _);
+        if (!tables.ContainsKey("glyf") || !tables.ContainsKey("loca") ||
+            !tables.ContainsKey("head") || !tables.ContainsKey("maxp"))
+            return data;
+
+        var head = tables["head"];
+        short indexToLocFormat = S16(data, head.off + 50);
+        int numGlyphs = U16(data, tables["maxp"].off + 4);
+
+        // Read the original loca table → glyph data offsets within glyf.
+        var loca = tables["loca"];
+        int[] locaOffsets = new int[numGlyphs + 1];
+        for (int i = 0; i <= numGlyphs; i++)
+            locaOffsets[i] = indexToLocFormat == 0 ? U16(data, loca.off + i * 2) * 2
+                                                   : (int)U32(data, loca.off + i * 4);
+
+        int glyfBase = tables["glyf"].off;
+
+        // Closure: include used gids + glyph 0 + every component of a composite.
+        var keep = new HashSet<int> { 0 };
+        var queue = new Queue<int>();
+        foreach (var g in usedGids) if (g >= 0 && g < numGlyphs && keep.Add(g)) queue.Enqueue(g);
+        if (keep.Add(0)) queue.Enqueue(0);
+        while (queue.Count > 0)
+        {
+            int g = queue.Dequeue();
+            int start = locaOffsets[g], end = locaOffsets[g + 1];
+            if (end <= start) continue;                       // empty glyph
+            foreach (int comp in CompositeComponents(data, glyfBase + start, end - start))
+                if (comp >= 0 && comp < numGlyphs && keep.Add(comp)) queue.Enqueue(comp);
+        }
+
+        // Build the new glyf (kept outlines, 2-byte aligned) + long-format loca.
+        using var glyf = new MemoryStream();
+        var newLoca = new int[numGlyphs + 1];
+        for (int g = 0; g < numGlyphs; g++)
+        {
+            newLoca[g] = (int)glyf.Length;
+            if (keep.Contains(g))
+            {
+                int start = locaOffsets[g], end = locaOffsets[g + 1];
+                int len = end - start;
+                if (len > 0) glyf.Write(data, glyfBase + start, len);
+                while (glyf.Length % 2 != 0) glyf.WriteByte(0);   // pad to even
+            }
+        }
+        newLoca[numGlyphs] = (int)glyf.Length;
+        byte[] newGlyf = glyf.ToArray();
+
+        byte[] newLocaBytes = new byte[(numGlyphs + 1) * 4];     // long format
+        for (int i = 0; i <= numGlyphs; i++) WriteU32(newLocaBytes, i * 4, (uint)newLoca[i]);
+
+        // Assemble a fresh sfnt with only the tables a FontFile2 CID font needs.
+        // cmap/GSUB/GPOS/GDEF/kern/name/post/OS2 are unnecessary under Identity-H
+        // + Identity CIDToGIDMap (the PDF addresses glyphs by GID directly), so
+        // dropping them shrinks the subset dramatically.
+        var keepTables = new[] { "head", "hhea", "hmtx", "maxp", "cvt ", "fpgm", "prep", "glyf", "loca" };
+        var outTables = new SortedDictionary<string, byte[]>(StringComparer.Ordinal);
+        foreach (var tag in keepTables)
+        {
+            if (tag is "glyf" or "loca") continue;            // substituted below
+            if (!tables.TryGetValue(tag, out var t)) continue; // optional (cvt/fpgm/prep)
+            byte[] body = new byte[t.len];
+            Array.Copy(data, t.off, body, 0, t.len);
+            outTables[tag] = body;
+        }
+        outTables["glyf"] = newGlyf;
+        outTables["loca"] = newLocaBytes;
+        // head.indexToLocFormat = 1 (long). head is at outTables["head"], offset 50.
+        WriteS16(outTables["head"], 50, 1);
+        // Zero head.checkSumAdjustment (offset 8) before computing the file checksum.
+        WriteU32(outTables["head"], 8, 0);
+
+        return BuildSfnt(outTables);
+    }
+
+    private static IEnumerable<int> CompositeComponents(byte[] data, int glyphOff, int glyphLen)
+    {
+        short numberOfContours = S16(data, glyphOff);
+        if (numberOfContours >= 0) yield break;                 // simple glyph
+
+        int p = glyphOff + 10;                                  // skip numContours + bbox(8)
+        const int ARG_1_AND_2_ARE_WORDS = 0x0001;
+        const int WE_HAVE_A_SCALE = 0x0008;
+        const int MORE_COMPONENTS = 0x0020;
+        const int WE_HAVE_AN_X_AND_Y_SCALE = 0x0040;
+        const int WE_HAVE_A_TWO_BY_TWO = 0x0080;
+        while (true)
+        {
+            if (p + 4 > glyphOff + glyphLen) yield break;
+            int flags = U16(data, p);
+            int glyphIndex = U16(data, p + 2);
+            p += 4;
+            yield return glyphIndex;
+            p += (flags & ARG_1_AND_2_ARE_WORDS) != 0 ? 4 : 2;
+            if ((flags & WE_HAVE_A_SCALE) != 0) p += 2;
+            else if ((flags & WE_HAVE_AN_X_AND_Y_SCALE) != 0) p += 4;
+            else if ((flags & WE_HAVE_A_TWO_BY_TWO) != 0) p += 8;
+            if ((flags & MORE_COMPONENTS) == 0) yield break;
+        }
+    }
+
+    private static byte[] BuildSfnt(SortedDictionary<string, byte[]> tables)
+    {
+        int n = tables.Count;
+        int entrySelector = (int)Math.Floor(Math.Log2(n));
+        int searchRange = (1 << entrySelector) * 16;
+        int rangeShift = n * 16 - searchRange;
+
+        int dirSize = 12 + n * 16;
+        int offset = dirSize;
+        var layout = new List<(string tag, int off, int len, byte[] body)>();
+        foreach (var (tag, body) in tables)
+        {
+            layout.Add((tag, offset, body.Length, body));
+            offset += (body.Length + 3) & ~3;                   // 4-byte aligned
+        }
+        int total = offset;
+        byte[] outv = new byte[total];
+
+        WriteU32(outv, 0, 0x00010000);                          // sfnt version
+        WriteU16(outv, 4, (ushort)n);
+        WriteU16(outv, 6, (ushort)searchRange);
+        WriteU16(outv, 8, (ushort)entrySelector);
+        WriteU16(outv, 10, (ushort)rangeShift);
+
+        int dir = 12;
+        foreach (var (tag, off, len, body) in layout)
+        {
+            for (int i = 0; i < 4; i++) outv[dir + i] = (byte)tag[i];
+            WriteU32(outv, dir + 4, TableChecksum(body));
+            WriteU32(outv, dir + 8, (uint)off);
+            WriteU32(outv, dir + 12, (uint)len);
+            Array.Copy(body, 0, outv, off, body.Length);
+            dir += 16;
+        }
+
+        // head.checkSumAdjustment = 0xB1B0AFBA - checksum(whole file).
+        if (TryFindTable(layout, "head", out int headOff))
+        {
+            uint fileChecksum = TableChecksum(outv);
+            WriteU32(outv, headOff + 8, unchecked(0xB1B0AFBA - fileChecksum));
+        }
+        return outv;
+    }
+
+    private static bool TryFindTable(List<(string tag, int off, int len, byte[] body)> layout, string tag, out int off)
+    {
+        foreach (var t in layout) if (t.tag == tag) { off = t.off; return true; }
+        off = 0; return false;
+    }
+
+    private static uint TableChecksum(byte[] data)
+    {
+        uint sum = 0;
+        int n = data.Length;
+        for (int i = 0; i < n; i += 4)
+        {
+            uint w = (uint)(data[i] << 24);
+            if (i + 1 < n) w |= (uint)(data[i + 1] << 16);
+            if (i + 2 < n) w |= (uint)(data[i + 2] << 8);
+            if (i + 3 < n) w |= data[i + 3];
+            sum = unchecked(sum + w);
+        }
+        return sum;
+    }
+
+    private static Dictionary<string, (int off, int len)> ReadTableDirectory(byte[] data, out uint sfnt)
+    {
+        sfnt = U32(data, 0);
+        ushort numTables = U16(data, 4);
+        var tables = new Dictionary<string, (int, int)>();
+        int p = 12;
+        for (int i = 0; i < numTables; i++, p += 16)
+        {
+            string tag = System.Text.Encoding.ASCII.GetString(data, p, 4);
+            tables[tag] = ((int)U32(data, p + 8), (int)U32(data, p + 12));
+        }
+        return tables;
+    }
+
+    private static ushort U16(byte[] d, int o) => (ushort)((d[o] << 8) | d[o + 1]);
+    private static short S16(byte[] d, int o) => (short)U16(d, o);
+    private static uint U32(byte[] d, int o) => (uint)((d[o] << 24) | (d[o + 1] << 16) | (d[o + 2] << 8) | d[o + 3]);
+    private static void WriteU16(byte[] d, int o, ushort v) { d[o] = (byte)(v >> 8); d[o + 1] = (byte)v; }
+    private static void WriteS16(byte[] d, int o, short v) => WriteU16(d, o, (ushort)v);
+    private static void WriteU32(byte[] d, int o, uint v) { d[o] = (byte)(v >> 24); d[o + 1] = (byte)(v >> 16); d[o + 2] = (byte)(v >> 8); d[o + 3] = (byte)v; }
+}

--- a/Pdfe.Core/Graphics/PdfTrueTypeFont.cs
+++ b/Pdfe.Core/Graphics/PdfTrueTypeFont.cs
@@ -22,6 +22,7 @@ internal sealed class PdfTrueTypeFont : PdfFont
 {
     private readonly TrueTypeFontFile _ttf;
     private readonly double _scale;   // font units -> text space at 1 pt
+    private readonly HashSet<int> _usedGids = new() { 0 };   // accumulated as text is drawn (#393)
 
     internal override bool PreferIndirectFontDictionary => true;
 
@@ -53,6 +54,7 @@ internal sealed class PdfTrueTypeFont : PdfFont
         foreach (var cp in Codepoints(text))
         {
             int gid = _ttf.GidForCodepoint(cp) & 0xFFFF;
+            _usedGids.Add(gid);
             sb.Append(gid.ToString("X4", CultureInfo.InvariantCulture));
         }
         sb.Append('>');
@@ -64,13 +66,16 @@ internal sealed class PdfTrueTypeFont : PdfFont
         double toGlyphSpace = 1000.0 / _ttf.UnitsPerEm;   // PDF glyph space = 1000/em
         int Scale(int fontUnits) => (int)Math.Round(fontUnits * toGlyphSpace);
 
-        // 1. FontFile2 — the embedded TTF, FlateDecode-compressed.
+        // 1. FontFile2 — the embedded TTF, FlateDecode-compressed. Built with the
+        // full font now; a pre-save action (registered below) replaces it with a
+        // subset once every drawn glyph is known.
         byte[] compressed = Deflate(_ttf.Data);
         var ff2Dict = new PdfDictionary();
         ff2Dict.SetInt("Length1", _ttf.Data.Length);
         ff2Dict.SetName("Filter", "FlateDecode");
         ff2Dict.SetInt("Length", compressed.Length);
-        var ff2Ref = document.AddIndirectObject(new PdfStream(ff2Dict, compressed));
+        var ff2 = new PdfStream(ff2Dict, compressed);
+        var ff2Ref = document.AddIndirectObject(ff2);
 
         // 2. FontDescriptor.
         var fd = new PdfDictionary();
@@ -112,11 +117,10 @@ internal sealed class PdfTrueTypeFont : PdfFont
         cid["W"] = wArr;
         var cidRef = document.AddIndirectObject(cid);
 
-        // 5. ToUnicode CMap so extraction recovers the original text.
-        byte[] toUni = Encoding.ASCII.GetBytes(BuildToUnicodeCMap());
-        var tuDict = new PdfDictionary();
-        tuDict.SetInt("Length", toUni.Length);
-        var tuRef = document.AddIndirectObject(new PdfStream(tuDict, toUni));
+        // 5. ToUnicode CMap (placeholder; filled with only the used glyphs,
+        //    compressed, by the pre-save action).
+        var tu = new PdfStream(new PdfDictionary(), Array.Empty<byte>());
+        var tuRef = document.AddIndirectObject(tu);
 
         // 6. Type0 root (returned; AddFont stores it inline in /Font).
         var type0 = new PdfDictionary();
@@ -128,17 +132,76 @@ internal sealed class PdfTrueTypeFont : PdfFont
         descendants.Add((PdfObject)cidRef);
         type0["DescendantFonts"] = descendants;
         type0["ToUnicode"] = tuRef;
+
+        // Defer subsetting to save time (when _usedGids is complete).
+        document.RegisterPreSaveAction(() => FinalizeSubset(ff2, fd, cid, type0, tu, toGlyphSpace));
         return type0;
     }
 
-    /// <summary>Build a ToUnicode CMap mapping each glyph id back to a codepoint.</summary>
+    /// <summary>
+    /// At save time: replace FontFile2 with a glyph subset, fill the ToUnicode
+    /// CMap for the used glyphs (compressed), trim /W to used glyphs, and apply a
+    /// 6-letter subset tag to the font names. Idempotent.
+    /// </summary>
+    private void FinalizeSubset(PdfStream fontFile2, PdfDictionary fd, PdfDictionary cid,
+        PdfDictionary type0, PdfStream toUnicode, double toGlyphSpace)
+    {
+        byte[] subset = TrueTypeSubsetter.Subset(_ttf.Data, _usedGids);
+        byte[] comp = Deflate(subset);
+        fontFile2.SetEncodedData(comp);
+        fontFile2.SetInt("Length1", subset.Length);
+        fontFile2.SetInt("Length", comp.Length);
+
+        // ToUnicode for just the used glyphs, FlateDecode-compressed.
+        byte[] cmap = Deflate(Encoding.ASCII.GetBytes(BuildToUnicodeCMap()));
+        toUnicode.SetEncodedData(cmap);
+        toUnicode.SetName("Filter", "FlateDecode");
+        toUnicode.SetInt("Length", cmap.Length);
+
+        // Subset tag: 6 uppercase letters derived from the used-gid set.
+        string tagged = SubsetTag() + "+" + BaseFont;
+        fd.SetName("FontName", tagged);
+        cid.SetName("BaseFont", tagged);
+        type0.SetName("BaseFont", tagged);
+
+        // Trim /W to only used glyphs: [ gid [w] gid2 [w2] … ].
+        int Scale(int fu) => (int)Math.Round(fu * toGlyphSpace);
+        var w = new PdfArray();
+        foreach (int g in _usedGids.Where(g => g > 0).OrderBy(g => g))
+        {
+            w.Add(g);
+            var one = new PdfArray();
+            one.Add(Scale(_ttf.AdvanceWidth(g)));
+            w.Add((PdfObject)one);
+        }
+        cid["W"] = w;
+    }
+
+    /// <summary>Deterministic 6-uppercase-letter subset tag from the used glyphs.</summary>
+    private string SubsetTag()
+    {
+        unchecked
+        {
+            uint h = 2166136261;
+            foreach (int g in _usedGids.OrderBy(x => x)) { h = (h ^ (uint)g) * 16777619; }
+            var c = new char[6];
+            for (int i = 0; i < 6; i++) { c[i] = (char)('A' + (int)(h % 26)); h /= 26; }
+            return new string(c);
+        }
+    }
+
+    /// <summary>Build a ToUnicode CMap mapping each <em>used</em> glyph id to a codepoint.</summary>
     private string BuildToUnicodeCMap()
     {
-        // gid -> first codepoint that maps to it.
-        var gidToCp = new SortedDictionary<int, int>();
+        // Reverse the cmap (cp -> gid) once, then map only the glyphs we drew.
+        var reverse = new Dictionary<int, int>();
         foreach (var (cp, gid) in _ttf.Cmap)
-            if (gid <= 0xFFFF && !gidToCp.ContainsKey(gid))
-                gidToCp[gid] = cp;
+            if (gid <= 0xFFFF && !reverse.ContainsKey(gid))
+                reverse[gid] = cp;
+        var gidToCp = new SortedDictionary<int, int>();
+        foreach (int g in _usedGids)
+            if (g > 0 && g <= 0xFFFF && reverse.TryGetValue(g, out var cp))
+                gidToCp[g] = cp;
 
         var sb = new StringBuilder();
         sb.Append("/CIDInit /ProcSet findresource begin\n12 dict begin\nbegincmap\n");


### PR DESCRIPTION
Embeds only the glyphs actually drawn (retain-GID subsetting) instead of the whole font.

- **`TrueTypeSubsetter`** — rebuilds `glyf`/`loca` with just the used outlines (+ composite components), keeps GIDs stable (so Identity-H + Identity CIDToGIDMap still work), drops tables a CID `FontFile2` doesn't need (`cmap`/`GSUB`/`GPOS`/`kern`/`name`/`post`/`OS2`), recomputes sfnt checksums. Falls back to the full font on any anomaly.
- **`PdfTrueTypeFont`** accumulates used GIDs while drawing and finalizes at save via a new `PdfDocument` pre-save hook: swaps in the subset `FontFile2`, trims `/W`, subsets + compresses the ToUnicode CMap, and tags the font name (`ABCDEF+Name`).

**Result** (DejaVuSans, "Hello, Café!"): PDF **759 KB → 14 KB**; poppler reports `CID TrueType / Identity-H / sub=yes`; text renders + extracts. All changes internal — **no public-API change**. Full `Pdfe.Core` suite green (2795).

Closes #393 (TrueType subsetting). CFF/'OTTO' embedding follows in a companion change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)