### PR TITLE
feat(authoring): embed CFF / OpenType ('OTTO') fonts (#393)

### DIFF
--- a/Pdfe.Core.Tests/Fonts/TrueTypeFontFileTests.cs
+++ b/Pdfe.Core.Tests/Fonts/TrueTypeFontFileTests.cs
@@ -27,6 +27,7 @@ public class TrueTypeFontFileTests
         ttf.Descent.Should().BeLessThan(0);
         ttf.XMax.Should().BeGreaterThan(ttf.XMin);
         ttf.Cmap.Count.Should().BeGreaterThan(100);
+        ttf.IsCff.Should().Be(false, "DejaVuSans is a TrueType (glyf) font");
 
         int gidA = ttf.GidForCodepoint('A');
         gidA.Should().BeGreaterThan(0);
@@ -38,16 +39,39 @@ public class TrueTypeFontFileTests
     }
 
     [Fact]
-    public void Parse_RejectsCffOpenType_AndGarbage()
+    public void Parse_AcceptsCffOpenType_ButRejectsBogusData()
     {
-        // 'OTTO' sfnt tag → CFF OpenType, unsupported here.
+        // 'OTTO' sfnt tag is now accepted (CFF-based OpenType), but the minimal
+        // OTTO header will fail because it lacks required tables.
         var otto = new byte[] { (byte)'O', (byte)'T', (byte)'T', (byte)'O', 0, 0, 0, 0, 0, 0, 0, 0 };
-        FluentActAssert(() => TrueTypeFontFile.Parse(otto));
+        FluentActAssert(() => TrueTypeFontFile.Parse(otto),
+            "Minimal OTTO lacks required tables");
 
         // Random bytes → not a font.
-        FluentActAssert(() => TrueTypeFontFile.Parse(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 }));
+        FluentActAssert(() => TrueTypeFontFile.Parse(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 }),
+            "Random bytes are not a valid sfnt");
     }
 
-    private static void FluentActAssert(System.Action act) =>
-        act.Should().Throw<System.Exception>();
+    [Fact]
+    public void Parse_CffFont_ExposesCffFlag()
+    {
+        const string linLibertineOtf = "/usr/share/fonts/opentype/linux-libertine/LinLibertine_RB.otf";
+        const string cantarellOtf = "/usr/share/fonts/opentype/cantarell/Cantarell-VF.otf";
+
+        string? fontPath = File.Exists(linLibertineOtf) ? linLibertineOtf
+                         : File.Exists(cantarellOtf) ? cantarellOtf
+                         : null;
+
+        Assert.SkipUnless(fontPath != null, "No CFF OpenType font found on system");
+
+        var cff = TrueTypeFontFile.Parse(File.ReadAllBytes(fontPath));
+        cff.IsCff.Should().Be(true, "LinLibertine/Cantarell are CFF-based OpenType");
+        cff.UnitsPerEm.Should().BeGreaterThan(0);
+        cff.GlyphCount.Should().BeGreaterThan(0);
+        cff.Cmap.Count.Should().BeGreaterThan(0);
+    }
+
+    private static void FluentActAssert(System.Action act, string? reason = null) =>
+        act.Should().Throw<System.Exception>(reason);
+
 }

--- a/Pdfe.Core.Tests/Graphics/CffOpenTypeEmbeddingTests.cs
+++ b/Pdfe.Core.Tests/Graphics/CffOpenTypeEmbeddingTests.cs
@@ -1,0 +1,170 @@
+using System.IO;
+using System.Linq;
+using AwesomeAssertions;
+using Pdfe.Core.Document;
+using Pdfe.Core.Graphics;
+using Pdfe.Core.Primitives;
+using Pdfe.Core.Text;
+using Xunit;
+
+namespace Pdfe.Core.Tests.Graphics;
+
+/// <summary>
+/// Tests for CFF-based OpenType ('OTTO') font embedding + Unicode text (#393).
+/// CFF fonts are embedded as a complete OTTO sfnt with a CIDFontType0 descendant
+/// and FontFile3 stream (unlike TrueType which uses FontFile2 + CIDFontType2).
+/// Tests use real system OpenType fonts, skipping cleanly if unavailable.
+/// </summary>
+public class CffOpenTypeEmbeddingTests
+{
+    // Prefer LinLibertine (more common in development), fallback to Cantarell
+    private const string LinLibertineOtf = "/usr/share/fonts/opentype/linux-libertine/LinLibertine_RB.otf";
+    private const string CantarellOtf = "/usr/share/fonts/opentype/cantarell/Cantarell-VF.otf";
+
+    private static string FindCffFont()
+    {
+        if (File.Exists(LinLibertineOtf)) return LinLibertineOtf;
+        if (File.Exists(CantarellOtf)) return CantarellOtf;
+        return null!;
+    }
+
+    private static string ExtractAll(byte[] pdf)
+    {
+        using var doc = PdfDocument.Open(pdf);
+        return string.Join("\n", doc.GetPages().Select(p => new TextExtractor(p).ExtractText()));
+    }
+
+    private static byte[] AuthorWith(string text, out PdfFont font, string? fontPath = null)
+    {
+        fontPath ??= FindCffFont();
+        font = PdfFont.FromFile(fontPath, 18);
+        var doc = PdfDocument.CreateNew();
+        var page = doc.Pages.AddBlank(400, 200);
+        using (var g = page.GetGraphics())
+            g.DrawString(text, font, PdfBrush.Black, 40, 120);
+        return doc.SaveToBytes();
+    }
+
+    [Fact]
+    public void FromFile_CffFont_ProducesType0EmbeddedFont()
+    {
+        var fontPath = FindCffFont();
+        Assert.SkipUnless(!string.IsNullOrEmpty(fontPath), "No CFF OpenType font found on system");
+
+        var font = PdfFont.FromFile(fontPath!, 12);
+        font.Should().BeOfType<PdfTrueTypeFont>();
+        // Identity-H encodes 2-byte glyph ids as a hex string.
+        font.EncodeString("AB").Should().StartWith("<").And.EndWith(">");
+        font.EncodeString("AB").Should().HaveLength(10); // <XXXXXXXX>
+    }
+
+    [Fact]
+    public void CffFont_DictionaryUsesCIDFontType0AndFontFile3()
+    {
+        var fontPath = FindCffFont();
+        Assert.SkipUnless(!string.IsNullOrEmpty(fontPath), "No CFF OpenType font found on system");
+
+        var pdf = AuthorWith("Hello CFF", out _, fontPath!);
+        using var doc = PdfDocument.Open(pdf);
+        var page = doc.GetPage(1);
+
+        var (_, fontDict) = page.GetFonts().First();
+        fontDict.GetNameOrNull("Subtype").Should().Be("Type0");
+        fontDict.GetNameOrNull("Encoding").Should().Be("Identity-H");
+        doc.Resolve(fontDict.GetOptional("ToUnicode")!).Should().BeOfType<PdfStream>();
+
+        var descendants = doc.Resolve(fontDict.GetOptional("DescendantFonts")!) as PdfArray;
+        var cid = doc.Resolve(descendants![0]) as PdfDictionary;
+        cid!.GetNameOrNull("Subtype").Should().Be("CIDFontType0", "CFF uses CIDFontType0, not CIDFontType2");
+        var fd = doc.Resolve(cid.GetOptional("FontDescriptor")!) as PdfDictionary;
+        doc.Resolve(fd!.GetOptional("FontFile3")!).Should().BeOfType<PdfStream>("CFF is embedded in FontFile3");
+    }
+
+    [Fact]
+    public void CffFont_FontFile3HasOpenTypeSubtype()
+    {
+        var fontPath = FindCffFont();
+        Assert.SkipUnless(!string.IsNullOrEmpty(fontPath), "No CFF OpenType font found on system");
+
+        var pdf = AuthorWith("OpenType Test", out _, fontPath!);
+        using var doc = PdfDocument.Open(pdf);
+        var page = doc.GetPage(1);
+
+        var (_, fontDict) = page.GetFonts().First();
+        var descendants = doc.Resolve(fontDict.GetOptional("DescendantFonts")!) as PdfArray;
+        var cid = doc.Resolve(descendants![0]) as PdfDictionary;
+        var fd = doc.Resolve(cid.GetOptional("FontDescriptor")!) as PdfDictionary;
+        var ff3Stream = doc.Resolve(fd!.GetOptional("FontFile3")!) as PdfStream;
+
+        // PdfStream is a PdfDictionary, so we can call GetNameOrNull directly on it.
+        ff3Stream!.GetNameOrNull("Subtype").Should().Be("OpenType",
+            "FontFile3 with /Subtype /OpenType signals CFF/OpenType embedding");
+    }
+
+    [Fact]
+    public void CffFont_UnicodeText_RoundTripsThroughExtraction()
+    {
+        var fontPath = FindCffFont();
+        Assert.SkipUnless(!string.IsNullOrEmpty(fontPath), "No CFF OpenType font found on system");
+
+        const string text = "Café résumé — Ø € ½";
+        var pdf = AuthorWith(text, out _, fontPath!);
+
+        var extracted = ExtractAll(pdf);
+        extracted.Should().Contain("Café résumé");
+        extracted.Should().Contain("Ø");
+        extracted.Should().Contain("€");
+    }
+
+    [Fact]
+    public void CffFont_RoundTripsThroughOpen_NoErrors()
+    {
+        var fontPath = FindCffFont();
+        Assert.SkipUnless(!string.IsNullOrEmpty(fontPath), "No CFF OpenType font found on system");
+
+        var pdf = AuthorWith("CFF round trip Ω", out _, fontPath!);
+        var act = () => PdfDocument.Open(pdf).Dispose();
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void CffFont_MeasureWidth_IsPositiveAndScalesWithText()
+    {
+        var fontPath = FindCffFont();
+        Assert.SkipUnless(!string.IsNullOrEmpty(fontPath), "No CFF OpenType font found on system");
+
+        var font = PdfFont.FromFile(fontPath!, 20);
+        double w1 = font.MeasureWidth("i");
+        double wLong = font.MeasureWidth("WWWWW");
+        w1.Should().BeGreaterThan(0);
+        wLong.Should().BeGreaterThan(w1);
+    }
+
+    [Fact]
+    public void CffFont_MultiplePages_AllEmbedWithCIDFontType0()
+    {
+        var fontPath = FindCffFont();
+        Assert.SkipUnless(!string.IsNullOrEmpty(fontPath), "No CFF OpenType font found on system");
+
+        var font = PdfFont.FromFile(fontPath, 14);
+        var doc = PdfDocument.CreateNew();
+
+        for (int i = 0; i < 3; i++)
+        {
+            var page = doc.Pages.AddBlank(300, 200);
+            using (var g = page.GetGraphics())
+                g.DrawString($"Page {i + 1} with CFF font", font, PdfBrush.Black, 20, 100);
+        }
+
+        var pdf = doc.SaveToBytes();
+
+        using var reopened = PdfDocument.Open(pdf);
+        foreach (var page in reopened.GetPages())
+        {
+            var (_, fontDict) = page.GetFonts().First();
+            var descendants = reopened.Resolve(fontDict.GetOptional("DescendantFonts")!) as PdfArray;
+            var cid = reopened.Resolve(descendants![0]) as PdfDictionary;
+            cid!.GetNameOrNull("Subtype").Should().Be("CIDFontType0");
+        }
+    }
+}

--- a/Pdfe.Core/Fonts/TrueTypeFontFile.cs
+++ b/Pdfe.Core/Fonts/TrueTypeFontFile.cs
@@ -3,14 +3,14 @@ using System.Text;
 namespace Pdfe.Core.Fonts;
 
 /// <summary>
-/// Minimal read-only parser for a TrueType-outline (<c>glyf</c>-based) sfnt font,
-/// exposing exactly what's needed to <em>embed</em> the font and lay out Unicode
-/// text: units-per-em, glyph count, per-glyph advance widths, a Unicode→glyph
-/// (cmap) map, the font bounding box, and vertical metrics.
+/// Minimal read-only parser for a TrueType-outline (<c>glyf</c>-based) or CFF-outline
+/// OpenType sfnt font, exposing exactly what's needed to <em>embed</em> the font and
+/// lay out Unicode text: units-per-em, glyph count, per-glyph advance widths, a
+/// Unicode→glyph (cmap) map, the font bounding box, and vertical metrics.
 ///
-/// <para>Supports the common desktop TrueType files (sfnt version 0x00010000 or
-/// 'true'). CFF-based OpenType ('OTTO') is not handled here — that needs a
-/// CIDFontType0/CFF embedding path (tracked separately).</para>
+/// <para>Supports TrueType files (sfnt version 0x00010000 or 'true') and CFF-based
+/// OpenType ('OTTO'). Both use the same sfnt wrapper with cmap/hmtx/head/hhea/maxp
+/// tables; the only difference is the outline format (glyf vs CFF).</para>
 /// </summary>
 internal sealed class TrueTypeFontFile
 {
@@ -26,17 +26,18 @@ internal sealed class TrueTypeFontFile
     public short Descent { get; }
     public bool IsBold { get; }
     public bool IsItalic { get; }
+    public bool IsCff { get; }
 
     private readonly ushort[] _advanceWidths;          // per glyph id, font units
     private readonly Dictionary<int, int> _cmap;       // unicode codepoint -> gid
 
     private TrueTypeFontFile(byte[] data, ushort unitsPerEm, int glyphCount, string psName,
         short xMin, short yMin, short xMax, short yMax, short ascent, short descent,
-        bool bold, bool italic, ushort[] advanceWidths, Dictionary<int, int> cmap)
+        bool bold, bool italic, bool isCff, ushort[] advanceWidths, Dictionary<int, int> cmap)
     {
         Data = data; UnitsPerEm = unitsPerEm; GlyphCount = glyphCount; PostScriptName = psName;
         XMin = xMin; YMin = yMin; XMax = xMax; YMax = yMax; Ascent = ascent; Descent = descent;
-        IsBold = bold; IsItalic = italic; _advanceWidths = advanceWidths; _cmap = cmap;
+        IsBold = bold; IsItalic = italic; IsCff = isCff; _advanceWidths = advanceWidths; _cmap = cmap;
     }
 
     /// <summary>Glyph id for a Unicode codepoint, or 0 (.notdef) if unmapped.</summary>
@@ -57,9 +58,12 @@ internal sealed class TrueTypeFontFile
         ArgumentNullException.ThrowIfNull(data);
         var r = new BE(data);
         uint sfnt = r.U32(0);
-        if (sfnt != 0x00010000 && sfnt != 0x74727565 /*'true'*/)
+        bool isCff = sfnt == 0x4F54544F; // 'OTTO'
+        bool isTrueType = sfnt == 0x00010000 || sfnt == 0x74727565; // 0x00010000 or 'true'
+
+        if (!isCff && !isTrueType)
             throw new NotSupportedException(
-                "Only TrueType-outline fonts are supported for embedding (not CFF/'OTTO').");
+                "Only TrueType-outline (sfnt 0x00010000 or 'true') and CFF-based OpenType ('OTTO') fonts are supported for embedding.");
 
         ushort numTables = r.U16(4);
         var tables = new Dictionary<string, (int off, int len)>();
@@ -104,7 +108,7 @@ internal sealed class TrueTypeFontFile
 
         return new TrueTypeFontFile(data, unitsPerEm, numGlyphs, psName,
             xMin, yMin, xMax, yMax, ascent, descent,
-            (macStyle & 0x1) != 0, (macStyle & 0x2) != 0, adv, cmap);
+            (macStyle & 0x1) != 0, (macStyle & 0x2) != 0, isCff, adv, cmap);
     }
 
     private static Dictionary<int, int> ParseCmap(BE r, int cmapOff)

--- a/Pdfe.Core/Graphics/PdfTrueTypeFont.cs
+++ b/Pdfe.Core/Graphics/PdfTrueTypeFont.cs
@@ -8,15 +8,16 @@ using Pdfe.Core.Primitives;
 namespace Pdfe.Core.Graphics;
 
 /// <summary>
-/// An embedded TrueType font drawn as a PDF <b>Type0 / Identity-H</b> composite
+/// An embedded TrueType or OpenType font drawn as a PDF <b>Type0 / Identity-H</b> composite
 /// font. Unlike the base-14 <see cref="PdfFont"/>, this embeds the actual font
 /// program so arbitrary Unicode (CJK, Arabic, accented Latin, …) renders, and
 /// attaches a ToUnicode CMap so the text stays selectable/extractable.
 ///
-/// <para><see cref="EncodeString"/> emits 2-byte glyph ids (Identity-H), and
-/// <see cref="BuildFontDictionary"/> installs the FontFile2 / descendant font /
-/// descriptor / ToUnicode objects into the document. The full font is embedded
-/// (subsetting is a future optimization — see #378).</para>
+/// <para><see cref="EncodeString"/> emits 2-byte glyph ids (Identity-H). For TrueType
+/// (glyf) fonts, <see cref="BuildFontDictionary"/> installs a CIDFontType2 / FontFile2.
+/// For CFF-based OpenType ('OTTO'), it installs a CIDFontType0 / FontFile3 with /Subtype
+/// /OpenType, embedding the full OTTO bytes. Both use Identity cmap and ToUnicode for
+/// extraction. The full font is embedded for CFF; TrueType is subsetted (see #378).</para>
 /// </summary>
 internal sealed class PdfTrueTypeFont : PdfFont
 {
@@ -66,16 +67,31 @@ internal sealed class PdfTrueTypeFont : PdfFont
         double toGlyphSpace = 1000.0 / _ttf.UnitsPerEm;   // PDF glyph space = 1000/em
         int Scale(int fontUnits) => (int)Math.Round(fontUnits * toGlyphSpace);
 
-        // 1. FontFile2 — the embedded TTF, FlateDecode-compressed. Built with the
-        // full font now; a pre-save action (registered below) replaces it with a
-        // subset once every drawn glyph is known.
+        // 1. Font program stream: FontFile2 for TrueType (glyf), FontFile3 for CFF.
         byte[] compressed = Deflate(_ttf.Data);
-        var ff2Dict = new PdfDictionary();
-        ff2Dict.SetInt("Length1", _ttf.Data.Length);
-        ff2Dict.SetName("Filter", "FlateDecode");
-        ff2Dict.SetInt("Length", compressed.Length);
-        var ff2 = new PdfStream(ff2Dict, compressed);
-        var ff2Ref = document.AddIndirectObject(ff2);
+        PdfStream fontFileStream;
+        PdfReference fontFileRef;
+
+        if (_ttf.IsCff)
+        {
+            // CFF/OpenType ('OTTO'): FontFile3 with /Subtype /OpenType, embed full OTTO.
+            var ff3Dict = new PdfDictionary();
+            ff3Dict.SetName("Subtype", "OpenType");
+            ff3Dict.SetName("Filter", "FlateDecode");
+            ff3Dict.SetInt("Length", compressed.Length);
+            fontFileStream = new PdfStream(ff3Dict, compressed);
+            fontFileRef = document.AddIndirectObject(fontFileStream);
+        }
+        else
+        {
+            // TrueType (glyf): FontFile2, full font now; pre-save action replaces with subset.
+            var ff2Dict = new PdfDictionary();
+            ff2Dict.SetInt("Length1", _ttf.Data.Length);
+            ff2Dict.SetName("Filter", "FlateDecode");
+            ff2Dict.SetInt("Length", compressed.Length);
+            fontFileStream = new PdfStream(ff2Dict, compressed);
+            fontFileRef = document.AddIndirectObject(fontFileStream);
+        }
 
         // 2. FontDescriptor.
         var fd = new PdfDictionary();
@@ -91,7 +107,12 @@ internal sealed class PdfTrueTypeFont : PdfFont
         fd.SetInt("Descent", Scale(_ttf.Descent));
         fd.SetInt("CapHeight", Scale(_ttf.Ascent));
         fd.SetInt("StemV", _ttf.IsBold ? 140 : 80);
-        fd["FontFile2"] = ff2Ref;
+
+        // Use correct font program reference based on outline format.
+        if (_ttf.IsCff)
+            fd["FontFile3"] = fontFileRef;
+        else
+            fd["FontFile2"] = fontFileRef;
         var fdRef = document.AddIndirectObject(fd);
 
         // 3. /W advance widths for every glyph: [0 [w0 w1 w2 …]].
@@ -102,10 +123,10 @@ internal sealed class PdfTrueTypeFont : PdfFont
         wArr.Add(0);
         wArr.Add((PdfObject)widths);
 
-        // 4. CIDFontType2 descendant font.
+        // 4. CID descendant font: CIDFontType0 for CFF, CIDFontType2 for TrueType.
         var cid = new PdfDictionary();
         cid.SetName("Type", "Font");
-        cid.SetName("Subtype", "CIDFontType2");
+        cid.SetName("Subtype", _ttf.IsCff ? "CIDFontType0" : "CIDFontType2");
         cid.SetName("BaseFont", BaseFont);
         var csi = new PdfDictionary();
         csi.SetString("Registry", "Adobe");
@@ -134,23 +155,30 @@ internal sealed class PdfTrueTypeFont : PdfFont
         type0["ToUnicode"] = tuRef;
 
         // Defer subsetting to save time (when _usedGids is complete).
-        document.RegisterPreSaveAction(() => FinalizeSubset(ff2, fd, cid, type0, tu, toGlyphSpace));
+        // For CFF, TrueTypeSubsetter will return the original unchanged, which is fine
+        // (full OTTO embedded). For TrueType, it subsets to used glyphs.
+        document.RegisterPreSaveAction(() => FinalizeSubset(fontFileStream, fd, cid, type0, tu, toGlyphSpace));
         return type0;
     }
 
     /// <summary>
-    /// At save time: replace FontFile2 with a glyph subset, fill the ToUnicode
-    /// CMap for the used glyphs (compressed), trim /W to used glyphs, and apply a
-    /// 6-letter subset tag to the font names. Idempotent.
+    /// At save time: for TrueType, replace FontFile2 with a glyph subset; for CFF,
+    /// keep the full font. Fill the ToUnicode CMap for the used glyphs (compressed),
+    /// trim /W to used glyphs, and apply a 6-letter subset tag to the font names.
+    /// Idempotent.
     /// </summary>
-    private void FinalizeSubset(PdfStream fontFile2, PdfDictionary fd, PdfDictionary cid,
+    private void FinalizeSubset(PdfStream fontFileStream, PdfDictionary fd, PdfDictionary cid,
         PdfDictionary type0, PdfStream toUnicode, double toGlyphSpace)
     {
+        // For TrueType, subset to used glyphs. For CFF, TrueTypeSubsetter returns original.
         byte[] subset = TrueTypeSubsetter.Subset(_ttf.Data, _usedGids);
         byte[] comp = Deflate(subset);
-        fontFile2.SetEncodedData(comp);
-        fontFile2.SetInt("Length1", subset.Length);
-        fontFile2.SetInt("Length", comp.Length);
+        fontFileStream.SetEncodedData(comp);
+
+        // Only set Length1 for FontFile2 (TrueType); FontFile3 doesn't use it.
+        if (!_ttf.IsCff)
+            fontFileStream.SetInt("Length1", subset.Length);
+        fontFileStream.SetInt("Length", comp.Length);
 
         // ToUnicode for just the used glyphs, FlateDecode-compressed.
         byte[] cmap = Deflate(Encoding.ASCII.GetBytes(BuildToUnicodeCMap()));


### PR DESCRIPTION
Completes #393: `PdfFont.FromFile`/`FromTrueType` now embed CFF-outline OpenType (`'OTTO'`) fonts too, not just glyf TrueType.

- `TrueTypeFontFile` accepts the `'OTTO'` sfnt version (`IsCff`); cmap/hmtx/metrics read identically (only the outline table differs).
- `PdfTrueTypeFont` branches for CFF: `/CIDFontType0` descendant + `/FontFile3` (`/Subtype /OpenType`, full font embedded) vs the TrueType path's `/CIDFontType2` + subsetted `/FontFile2`. Shared Identity-H, `/W`, ToUnicode.
- CFF glyph subsetting deferred (full OTTO embedded).

**Verified** (poppler): `pdffonts` → `CID Type 0C (OT) / Identity-H / emb=yes`; `pdftotext` recovers the text. 7 new tests; full suite green (**2872**); internal-only (no public-API change).

Built by a background agent in an isolated worktree (concurrently with #325), reviewed + integrated by me.

Closes #393.

🤖 Generated with [Claude Code](https://claude.com/claude-code)