### PR TITLE
feat(authoring): use embedded Unicode fonts in the builder facade (#398)

### DIFF
--- a/Pdfe.Core.Tests/Authoring/BuilderEmbeddedFontTests.cs
+++ b/Pdfe.Core.Tests/Authoring/BuilderEmbeddedFontTests.cs
@@ -1,0 +1,103 @@
+using System.IO;
+using System.Linq;
+using AwesomeAssertions;
+using Pdfe.Core.Authoring;
+using Pdfe.Core.Document;
+using Pdfe.Core.Graphics;
+using Pdfe.Core.Text;
+using Xunit;
+
+namespace Pdfe.Core.Tests.Authoring;
+
+/// <summary>
+/// Tests for using embedded (Unicode) fonts through the high-level
+/// PdfDocumentBuilder / TextStyle facade (#398).
+/// </summary>
+public class BuilderEmbeddedFontTests
+{
+    private const string DejaVu = "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf";
+
+    private static string ExtractAll(byte[] pdf)
+    {
+        using var doc = PdfDocument.Open(pdf);
+        return string.Join("\n", doc.GetPages().Select(p => new TextExtractor(p).ExtractText()));
+    }
+
+    [Fact]
+    public void TextStyle_WithFont_ResolvesToThatFontAtStyleSize()
+    {
+        Assert.SkipUnless(File.Exists(DejaVu), "DejaVuSans not installed");
+        var embedded = PdfFont.FromFile(DejaVu, 10);
+        var style = TextStyle.Body.WithSize(20).WithFont(embedded);
+
+        var resolved = style.ResolveFont();
+        resolved.Should().BeOfType<PdfTrueTypeFont>("the embedded font overrides the base-14 family");
+        resolved.Size.Should().Be(20, "the style's size is applied to the embedded font");
+    }
+
+    [Fact]
+    public void Builder_DefaultFont_RendersUnicodeAndExtracts()
+    {
+        Assert.SkipUnless(File.Exists(DejaVu), "DejaVuSans not installed");
+        var pdf = PdfDocumentBuilder.Create()
+            .DefaultFont(PdfFont.FromFile(DejaVu, 11))
+            .Heading("Отчёт — Café")
+            .Paragraph("Ελληνικά, Кириллица, naïve, € ½ Ø")
+            .KeyValue("Имя", "Ada")
+            .SaveToBytes();
+
+        var text = ExtractAll(pdf);
+        text.Should().Contain("Отчёт");
+        text.Should().Contain("Ελληνικά");
+        text.Should().Contain("Кириллица");
+        text.Should().Contain("€");
+    }
+
+    [Fact]
+    public void Builder_DefaultFont_EmbedsOneSubsetAcrossSizes()
+    {
+        Assert.SkipUnless(File.Exists(DejaVu), "DejaVuSans not installed");
+        // Heading(18) + body(11) + bold key-value all use the one default font.
+        var pdf = PdfDocumentBuilder.Create()
+            .DefaultFont(PdfFont.FromFile(DejaVu, 11))
+            .Heading("Большой", 1)
+            .Paragraph("маленький")
+            .SaveToBytes();
+
+        using var doc = PdfDocument.Open(pdf);
+        // Exactly one embedded font object across the document (sizes share it).
+        var fontBaseNames = doc.GetPages()
+            .SelectMany(p => p.GetFonts())
+            .Select(f => f.Font.GetNameOrNull("BaseFont"))
+            .Distinct()
+            .ToList();
+        fontBaseNames.Should().HaveCount(1);
+        fontBaseNames[0].Should().MatchRegex("^[A-Z]{6}\\+DejaVuSans$", "one subset-tagged embedded font");
+    }
+
+    [Fact]
+    public void EmbeddedFont_WithSize_PreservesEmbeddingAndSharesGlyphSet()
+    {
+        Assert.SkipUnless(File.Exists(DejaVu), "DejaVuSans not installed");
+        var f11 = PdfFont.FromFile(DejaVu, 11);
+        var f22 = f11.WithSize(22);
+        f22.Should().BeOfType<PdfTrueTypeFont>("WithSize keeps the embedded type");
+
+        // Draw different glyphs at each size; the subset must contain both sets.
+        var doc = PdfDocument.CreateNew();
+        var page = doc.Pages.AddBlank(300, 200);
+        using (var g = page.GetGraphics())
+        {
+            g.DrawString("ABC", f11, PdfBrush.Black, 20, 150);
+            g.DrawString("xyz", f22, PdfBrush.Black, 20, 100);
+        }
+        var bytes = doc.SaveToBytes();
+
+        using var re = PdfDocument.Open(bytes);
+        // One embedded font, and both strings extract (proving both glyph sets embedded).
+        re.GetPage(1).GetFonts().Should().ContainSingle();
+        var text = new TextExtractor(re.GetPage(1)).ExtractText();
+        text.Should().Contain("ABC");
+        text.Should().Contain("xyz");
+    }
+}

--- a/Pdfe.Core.Tests/PublicApi/Pdfe.Core.approved.txt
+++ b/Pdfe.Core.Tests/PublicApi/Pdfe.Core.approved.txt
@@ -49,6 +49,7 @@ namespace Pdfe.Core.Authoring
         public Pdfe.Core.Authoring.PdfDocumentBuilder CheckBox(string label, string? fieldName = null, bool checkedByDefault = false, string? tooltip = null) { }
         public Pdfe.Core.Authoring.PdfDocumentBuilder Custom(System.Action<Pdfe.Core.Graphics.PdfGraphics, Pdfe.Core.Authoring.LayoutContext> draw) { }
         public Pdfe.Core.Authoring.PdfDocumentBuilder DateField(string label, string? fieldName = null, string format = "yyyy-mm-dd", bool required = false, string? tooltip = null) { }
+        public Pdfe.Core.Authoring.PdfDocumentBuilder DefaultFont(Pdfe.Core.Graphics.PdfFont font) { }
         public Pdfe.Core.Authoring.PdfDocumentBuilder Dropdown(string label, System.Collections.Generic.IEnumerable<string> options, string? fieldName = null, string? defaultValue = null, string? tooltip = null) { }
         public Pdfe.Core.Authoring.PdfDocumentBuilder Heading(string text, int level = 1, Pdfe.Core.Authoring.TextStyle? style = null) { }
         public Pdfe.Core.Authoring.PdfDocumentBuilder HorizontalRule(double thickness = 0.5, Pdfe.Core.Graphics.PdfColor? color = default) { }
@@ -74,6 +75,7 @@ namespace Pdfe.Core.Authoring
         public bool Bold { get; init; }
         public Pdfe.Core.Graphics.PdfColor Color { get; init; }
         public Pdfe.Core.Authoring.FontFamily Family { get; init; }
+        public Pdfe.Core.Graphics.PdfFont? Font { get; init; }
         public bool Italic { get; init; }
         public double LineHeight { get; }
         public double LineSpacing { get; init; }
@@ -86,6 +88,7 @@ namespace Pdfe.Core.Authoring
         public Pdfe.Core.Graphics.PdfFont ResolveFont() { }
         public Pdfe.Core.Authoring.TextStyle WithAlignment(Pdfe.Core.Graphics.TextAlignment alignment) { }
         public Pdfe.Core.Authoring.TextStyle WithColor(Pdfe.Core.Graphics.PdfColor color) { }
+        public Pdfe.Core.Authoring.TextStyle WithFont(Pdfe.Core.Graphics.PdfFont font) { }
         public Pdfe.Core.Authoring.TextStyle WithSize(double size) { }
         public Pdfe.Core.Authoring.TextStyle WithSpaceAfter(double points) { }
     }
@@ -672,7 +675,7 @@ namespace Pdfe.Core.Graphics
         public virtual double MeasureWidth(string text) { }
         public override string ToString() { }
         public Pdfe.Core.Graphics.PdfFont WithName(string name) { }
-        public Pdfe.Core.Graphics.PdfFont WithSize(double size) { }
+        public virtual Pdfe.Core.Graphics.PdfFont WithSize(double size) { }
         public static Pdfe.Core.Graphics.PdfFont Courier(double size) { }
         public static Pdfe.Core.Graphics.PdfFont CourierBold(double size) { }
         public static Pdfe.Core.Graphics.PdfFont CourierOblique(double size) { }

--- a/Pdfe.Core/Authoring/PdfDocumentBuilder.cs
+++ b/Pdfe.Core/Authoring/PdfDocumentBuilder.cs
@@ -45,6 +45,7 @@ public sealed class PdfDocumentBuilder
     private int _currentPageNumber;   // 1-based
     private double _cursorY;          // PDF coords (bottom-left origin), top of next block
     private int _autoFieldSeq;
+    private PdfFont? _defaultFont;    // embedded font applied to text blocks (#398)
 
     private PdfDocumentBuilder(PageSize pageSize, PageMargins margins)
     {
@@ -69,6 +70,17 @@ public sealed class PdfDocumentBuilder
     public int PageCount => _document.PageCount;
 
     // ── document metadata (#381) ─────────────────────────────────────────────
+
+    /// <summary>
+    /// Use an embedded font (e.g. <see cref="PdfFont.FromFile"/>) for all text
+    /// blocks that don't specify their own — lets the builder render Unicode
+    /// beyond the base-14 fonts (#398). The style's point size is applied to it.
+    /// </summary>
+    public PdfDocumentBuilder DefaultFont(PdfFont font) { _defaultFont = font; return this; }
+
+    /// <summary>Apply the builder's default font to a style that has none.</summary>
+    private TextStyle WithDefaultFont(TextStyle s) =>
+        _defaultFont != null && s.Font == null ? s.WithFont(_defaultFont) : s;
 
     /// <summary>Sets the document title (Info <c>/Title</c>).</summary>
     public PdfDocumentBuilder Title(string title) { _document.SetTitle(title); return this; }
@@ -106,7 +118,7 @@ public sealed class PdfDocumentBuilder
     /// </summary>
     public PdfDocumentBuilder Paragraph(string text, TextStyle? style = null)
     {
-        style ??= TextStyle.Body;
+        style = WithDefaultFont(style ?? TextStyle.Body);
         EnsurePage();
 
         var font = style.ResolveFont();
@@ -440,20 +452,24 @@ public sealed class PdfDocumentBuilder
 
         int cols = cells.Count;
         var colWidths = new double[cols];
+        var styles = new TextStyle[cols];
         for (int c = 0; c < cols; c++)
+        {
             colWidths[c] = weights[c] * ContentWidth;
+            styles[c] = WithDefaultFont(cells[c].Style);
+        }
 
         // Wrap each cell and find the tallest.
         var wrapped = new List<string>[cols];
         double maxLines = 1;
         for (int c = 0; c < cols; c++)
         {
-            var font = cells[c].Style.ResolveFont();
+            var font = styles[c].ResolveFont();
             wrapped[c] = WrapText(cells[c].Text ?? string.Empty, font, colWidths[c] - 2 * cellPadding).ToList();
             maxLines = Math.Max(maxLines, wrapped[c].Count);
         }
 
-        double lineHeight = cells.Count > 0 ? cells[0].Style.LineHeight : TextStyle.Body.LineHeight;
+        double lineHeight = cols > 0 ? styles[0].LineHeight : TextStyle.Body.LineHeight;
         double rowHeight = maxLines * lineHeight + 2 * cellPadding;
         EnsureSpace(rowHeight);
 
@@ -461,7 +477,7 @@ public sealed class PdfDocumentBuilder
         double x = ContentLeft;
         for (int c = 0; c < cols; c++)
         {
-            var style = cells[c].Style;
+            var style = styles[c];
             var font = style.ResolveFont();
             var brush = style.ResolveBrush();
             double textTop = top - cellPadding;

--- a/Pdfe.Core/Authoring/TextStyle.cs
+++ b/Pdfe.Core/Authoring/TextStyle.cs
@@ -47,6 +47,14 @@ public sealed record TextStyle
     /// <summary>Vertical gap left after the block, in points. Default 6.</summary>
     public double SpaceAfter { get; init; } = 6;
 
+    /// <summary>
+    /// An explicit font (e.g. an embedded Unicode font from
+    /// <see cref="PdfFont.FromFile"/>). When set it overrides
+    /// <see cref="Family"/>/<see cref="Bold"/>/<see cref="Italic"/>, and the
+    /// style's <see cref="Size"/> is applied to it. Null = the base-14 family.
+    /// </summary>
+    public PdfFont? Font { get; init; }
+
     /// <summary>The default body style (11-pt Helvetica, left, black).</summary>
     public static TextStyle Body => new();
 
@@ -68,8 +76,14 @@ public sealed record TextStyle
     /// <summary>Returns a copy with the given trailing gap (points).</summary>
     public TextStyle WithSpaceAfter(double points) => this with { SpaceAfter = points };
 
+    /// <summary>
+    /// Returns a copy that draws with <paramref name="font"/> (e.g. an embedded
+    /// Unicode font from <see cref="PdfFont.FromFile"/>) instead of a base-14 family.
+    /// </summary>
+    public TextStyle WithFont(PdfFont font) => this with { Font = font };
+
     /// <summary>Resolves this style to a concrete <see cref="PdfFont"/> at its size.</summary>
-    public PdfFont ResolveFont() => new("F1", ResolveBaseFont(), Size);
+    public PdfFont ResolveFont() => Font is not null ? Font.WithSize(Size) : new("F1", ResolveBaseFont(), Size);
 
     /// <summary>The brush matching this style's color.</summary>
     public PdfBrush ResolveBrush() => new(Color);

--- a/Pdfe.Core/Graphics/PdfFont.cs
+++ b/Pdfe.Core/Graphics/PdfFont.cs
@@ -115,7 +115,7 @@ public class PdfFont
     /// <summary>
     /// Create a new font with a different size.
     /// </summary>
-    public PdfFont WithSize(double size) => new(Name, BaseFont, size);
+    public virtual PdfFont WithSize(double size) => new(Name, BaseFont, size);
 
     /// <summary>
     /// Create a new font with a different resource name.

--- a/Pdfe.Core/Graphics/PdfTrueTypeFont.cs
+++ b/Pdfe.Core/Graphics/PdfTrueTypeFont.cs
@@ -22,17 +22,31 @@ namespace Pdfe.Core.Graphics;
 internal sealed class PdfTrueTypeFont : PdfFont
 {
     private readonly TrueTypeFontFile _ttf;
-    private readonly double _scale;   // font units -> text space at 1 pt
-    private readonly HashSet<int> _usedGids = new() { 0 };   // accumulated as text is drawn (#393)
+    private readonly double _scale;            // font units -> text space at 1 pt
+    private readonly HashSet<int> _usedGids;   // accumulated as text is drawn (#393)
 
     internal override bool PreferIndirectFontDictionary => true;
 
     public PdfTrueTypeFont(byte[] fontData, double size)
-        : base("F1", SafeBaseName(TrueTypeFontFile.Parse(fontData).PostScriptName), size)
+        : this(TrueTypeFontFile.Parse(fontData), new HashSet<int> { 0 }, size)
     {
-        _ttf = TrueTypeFontFile.Parse(fontData);
+    }
+
+    // Shares the parsed font + used-glyph set so the same typeface at different
+    // sizes (via WithSize) embeds/subsets as ONE font with one glyph set (#398).
+    private PdfTrueTypeFont(TrueTypeFontFile ttf, HashSet<int> usedGids, double size)
+        : base("F1", SafeBaseName(ttf.PostScriptName), size)
+    {
+        _ttf = ttf;
+        _usedGids = usedGids;
         _scale = 1.0 / _ttf.UnitsPerEm;
     }
+
+    /// <summary>
+    /// The same embedded typeface at a different point size — shares the parsed
+    /// font and accumulated glyph set so all sizes embed as one subsetted font.
+    /// </summary>
+    public override PdfFont WithSize(double size) => new PdfTrueTypeFont(_ttf, _usedGids, size);
 
     public override double MeasureWidth(string text)
     {


### PR DESCRIPTION
Closes the gap between #378 (embedded fonts) and #383 (the builder) — the high-level `PdfDocumentBuilder`/`TextStyle` were base-14 only, so PromptResponse couldn't emit Unicode through the facade.

- `TextStyle.Font` / `WithFont(font)` — an explicit font (e.g. `PdfFont.FromFile`) overrides the base-14 family; `ResolveFont` applies the style's size.
- `PdfDocumentBuilder.DefaultFont(font)` — applied to all text blocks (Heading/Paragraph/KeyValue/Table/labels) that don't set their own.
- `PdfFont.WithSize` is now `virtual`; `PdfTrueTypeFont.WithSize` shares the parsed font + accumulated glyph set, so the same typeface across many sizes/weights embeds as **one** subsetted font (and parses once).

**Verified** (poppler): a builder doc with `DefaultFont(DejaVu)` renders Cyrillic/Greek/accented Latin at heading+body+bold sizes as a single subset font (`emb=yes`), all extractable. 4 new tests; full suite green (**2876**). API additive.

Closes #398.

🤖 Generated with [Claude Code](https://claude.com/claude-code)