### PR TITLE
feat(authoring): tagged-PDF (logical structure tree) authoring (#275)

### DIFF
--- a/Pdfe.Core.Tests/Authoring/TaggedPdfTests.cs
+++ b/Pdfe.Core.Tests/Authoring/TaggedPdfTests.cs
@@ -1,0 +1,108 @@
+using System.Linq;
+using System.Text;
+using AwesomeAssertions;
+using Pdfe.Core.Authoring;
+using Pdfe.Core.Document;
+using Pdfe.Core.Primitives;
+using Xunit;
+
+namespace Pdfe.Core.Tests.Authoring;
+
+/// <summary>
+/// Tests for tagged-PDF (logical structure tree) authoring via the builder (#275).
+/// </summary>
+public class TaggedPdfTests
+{
+    private static System.Collections.Generic.List<string> StructTypes(PdfDocument doc)
+    {
+        var types = new System.Collections.Generic.List<string>();
+        var rootObj = doc.Catalog.GetOptional("StructTreeRoot");
+        if (rootObj == null) return types;
+        var root = doc.Resolve(rootObj) as PdfDictionary;
+        // root /K -> Document elem(s) -> /K -> content elems
+        void Walk(PdfObject? k)
+        {
+            if (k == null) return;
+            var resolved = doc.Resolve(k);
+            if (resolved is PdfArray arr) { foreach (var x in arr) Walk(x); return; }
+            if (resolved is PdfDictionary d)
+            {
+                var s = d.GetNameOrNull("S");
+                if (s != null) types.Add(s);
+                if (d.GetOptional("K") is { } kids) Walk(kids);
+            }
+        }
+        Walk(root!.GetOptional("K"));
+        return types;
+    }
+
+    [Fact]
+    public void Tagged_SetsMarkInfoStructTreeAndViewerPrefs()
+    {
+        var pdf = PdfDocumentBuilder.Create().Tagged().Title("Doc").Language("en-US")
+            .Heading("Title").Paragraph("Body").SaveToBytes();
+
+        using var doc = PdfDocument.Open(pdf);
+        var markInfo = doc.Resolve(doc.Catalog.GetOptional("MarkInfo")!) as PdfDictionary;
+        (markInfo!.GetOptional("Marked") as PdfBoolean)!.Value.Should().BeTrue();
+        doc.Catalog.GetOptional("StructTreeRoot").Should().NotBeNull();
+        doc.Resolve(doc.Catalog.GetOptional("ViewerPreferences")!).Should().BeOfType<PdfDictionary>();
+    }
+
+    [Fact]
+    public void Tagged_PdfInfoReportsStructureForHeadingsParagraphsTables()
+    {
+        var pdf = PdfDocumentBuilder.Create().Tagged()
+            .Heading("H one", 1)
+            .Heading("H two", 2)
+            .Paragraph("para")
+            .KeyValue("k", "v")
+            .Table(new[] { new[] { "a", "b" }, new[] { "c", "d" } })
+            .SaveToBytes();
+
+        using var doc = PdfDocument.Open(pdf);
+        var types = StructTypes(doc);
+        types.Should().Contain("Document");
+        types.Should().Contain("H1");
+        types.Should().Contain("H2");
+        types.Should().Contain("P");
+        types.Should().Contain("Table");
+    }
+
+    [Fact]
+    public void Tagged_ContentStreamHasMarkedContent()
+    {
+        var pdf = PdfDocumentBuilder.Create().Tagged().Paragraph("hello").SaveToBytes();
+        using var doc = PdfDocument.Open(pdf);
+        var content = Encoding.Latin1.GetString(doc.GetPage(1).GetContentStreamBytes());
+        content.Should().Contain("BDC");
+        content.Should().Contain("EMC");
+        content.Should().Contain("/MCID");
+    }
+
+    [Fact]
+    public void NotTagged_HasNoStructTree()
+    {
+        var pdf = PdfDocumentBuilder.Create().Paragraph("hello").SaveToBytes();
+        using var doc = PdfDocument.Open(pdf);
+        doc.Catalog.GetOptional("StructTreeRoot").Should().BeNull();
+        var content = Encoding.Latin1.GetString(doc.GetPage(1).GetContentStreamBytes());
+        content.Should().NotContain("BDC");
+    }
+
+    [Fact]
+    public void Tagged_MultiPageParagraph_SpansPagesWithStructParents()
+    {
+        var builder = PdfDocumentBuilder.Create().Tagged();
+        // One very long paragraph that must flow across pages.
+        builder.Paragraph(string.Join(" ", Enumerable.Repeat("word", 1200)));
+        using var doc = PdfDocument.Open(builder.SaveToBytes());
+
+        doc.PageCount.Should().BeGreaterThan(1);
+        // Every page that carries tagged content gets a /StructParents key.
+        foreach (var p in doc.GetPages())
+            p.Dictionary.GetOptional("StructParents").Should().NotBeNull();
+        // The structure tree still parses and contains the paragraph.
+        StructTypes(doc).Should().Contain("P");
+    }
+}

--- a/Pdfe.Core.Tests/PublicApi/Pdfe.Core.approved.txt
+++ b/Pdfe.Core.Tests/PublicApi/Pdfe.Core.approved.txt
@@ -64,6 +64,7 @@ namespace Pdfe.Core.Authoring
         public Pdfe.Core.Authoring.PdfDocumentBuilder Spacer(double points) { }
         public Pdfe.Core.Authoring.PdfDocumentBuilder Subject(string subject) { }
         public Pdfe.Core.Authoring.PdfDocumentBuilder Table(System.Collections.Generic.IEnumerable<System.Collections.Generic.IReadOnlyList<string>> rows, double[]? columnWeights = null, bool headerRow = false, bool gridLines = true) { }
+        public Pdfe.Core.Authoring.PdfDocumentBuilder Tagged() { }
         public Pdfe.Core.Authoring.PdfDocumentBuilder TextField(string label, string? fieldName = null, bool multiline = false, bool required = false, int lines = 1, string? defaultValue = null, string? tooltip = null, int? maxLength = default, bool comb = false) { }
         public Pdfe.Core.Authoring.PdfDocumentBuilder Title(string title) { }
         public static Pdfe.Core.Authoring.PdfDocumentBuilder Create(Pdfe.Core.Authoring.PageSize? pageSize = default, Pdfe.Core.Authoring.PageMargins? margins = default) { }
@@ -708,6 +709,7 @@ namespace Pdfe.Core.Graphics
     }
     public class PdfGraphics : System.IDisposable
     {
+        public void BeginMarkedContent(string tag, int mcid) { }
         public void BeginPath() { }
         public void ClosePath() { }
         public void CurveTo(double x1, double y1, double x2, double y2, double x3, double y3) { }
@@ -718,6 +720,7 @@ namespace Pdfe.Core.Graphics
         public void DrawString(string text, Pdfe.Core.Graphics.PdfFont font, Pdfe.Core.Graphics.PdfBrush brush, double x, double y) { }
         public void DrawString(string text, Pdfe.Core.Graphics.PdfFont font, Pdfe.Core.Graphics.PdfBrush brush, double x, double y, Pdfe.Core.Graphics.TextAlignment alignment) { }
         public Pdfe.Core.Graphics.TextLayoutResult DrawText(string text, Pdfe.Core.Graphics.PdfFont font, Pdfe.Core.Graphics.PdfBrush brush, Pdfe.Core.Document.PdfRectangle bounds, Pdfe.Core.Graphics.TextAlignment alignment = 0, double lineSpacing = 1.2) { }
+        public void EndMarkedContent() { }
         public void Fill(Pdfe.Core.Graphics.PdfBrush brush) { }
         public void FillAndStroke(Pdfe.Core.Graphics.PdfBrush brush, Pdfe.Core.Graphics.PdfPen pen) { }
         public void Flush() { }

--- a/Pdfe.Core/Authoring/PdfDocumentBuilder.cs
+++ b/Pdfe.Core/Authoring/PdfDocumentBuilder.cs
@@ -46,6 +46,9 @@ public sealed class PdfDocumentBuilder
     private double _cursorY;          // PDF coords (bottom-left origin), top of next block
     private int _autoFieldSeq;
     private PdfFont? _defaultFont;    // embedded font applied to text blocks (#398)
+    private Tagging.StructureTreeBuilder? _tagging;                  // tagged-PDF tree (#275)
+    private Tagging.StructureTreeBuilder.StructElem? _openElem;      // currently-open tagged block
+    private string? _openTag;
 
     private PdfDocumentBuilder(PageSize pageSize, PageMargins margins)
     {
@@ -70,6 +73,52 @@ public sealed class PdfDocumentBuilder
     public int PageCount => _document.PageCount;
 
     // ── document metadata (#381) ─────────────────────────────────────────────
+
+    /// <summary>
+    /// Enable tagged-PDF output (a logical structure tree for accessibility /
+    /// PDF/UA, ISO 32000-2 §14.8): headings become H1-H4, paragraphs/key-values
+    /// become P, tables become Table, each wrapped in marked content. Combine
+    /// with <see cref="DefaultFont"/> (embedded fonts) and
+    /// <see cref="Language"/> for an accessible document. Call before adding
+    /// content.
+    /// </summary>
+    public PdfDocumentBuilder Tagged()
+    {
+        if (_tagging == null)
+        {
+            _tagging = new Tagging.StructureTreeBuilder(_document);
+            _document.RegisterPreSaveAction(() => _tagging!.Write());
+        }
+        return this;
+    }
+
+    private static string HeadingTag(int level) => level switch
+    {
+        <= 1 => "H1", 2 => "H2", 3 => "H3", _ => "H4"
+    };
+
+    private void BeginTag(string structType)
+    {
+        if (_tagging == null) return;
+        _openTag = structType;
+        _openElem = _tagging.AddElement(structType);
+        OpenMarkedContent();
+    }
+
+    private void OpenMarkedContent()
+    {
+        if (_tagging == null || _openElem == null) return;
+        int mcid = _tagging.AllocateMcid(_openElem, _currentPageNumber);
+        _graphics!.BeginMarkedContent(_openTag!, mcid);
+    }
+
+    private void EndTag()
+    {
+        if (_tagging == null || _openElem == null) return;
+        _graphics!.EndMarkedContent();
+        _openElem = null;
+        _openTag = null;
+    }
 
     /// <summary>
     /// Use an embedded font (e.g. <see cref="PdfFont.FromFile"/>) for all text
@@ -107,19 +156,19 @@ public sealed class PdfDocumentBuilder
     /// override the look entirely by passing a <paramref name="style"/>.
     /// </summary>
     public PdfDocumentBuilder Heading(string text, int level = 1, TextStyle? style = null)
-    {
-        style ??= HeadingStyle(level);
-        return Paragraph(text, style);
-    }
+        => ParagraphCore(text, WithDefaultFont(style ?? HeadingStyle(level)), HeadingTag(level));
 
     /// <summary>
     /// Adds a paragraph of text, word-wrapped to the content column and
     /// flowed across pages as needed. Honors hard line breaks in the input.
     /// </summary>
     public PdfDocumentBuilder Paragraph(string text, TextStyle? style = null)
+        => ParagraphCore(text, WithDefaultFont(style ?? TextStyle.Body), "P");
+
+    private PdfDocumentBuilder ParagraphCore(string text, TextStyle style, string structType)
     {
-        style = WithDefaultFont(style ?? TextStyle.Body);
         EnsurePage();
+        BeginTag(structType);
 
         var font = style.ResolveFont();
         var brush = style.ResolveBrush();
@@ -134,6 +183,7 @@ public sealed class PdfDocumentBuilder
             _cursorY -= lineHeight;
         }
 
+        EndTag();
         _cursorY -= style.SpaceAfter;
         return this;
     }
@@ -168,11 +218,15 @@ public sealed class PdfDocumentBuilder
         labelWidth = Math.Clamp(labelWidth, 0.1, 0.9);
         var labelStyle = TextStyle.Body.AsBold().WithSpaceAfter(0);
         var valueStyle = TextStyle.Body.WithSpaceAfter(0);
-        return Row(
+        EnsurePage();
+        BeginTag("P");
+        Row(
             new[] { (label ?? string.Empty, labelStyle), (value ?? string.Empty, valueStyle) },
             new[] { labelWidth, 1 - labelWidth },
             cellPadding: 2,
             spaceAfter: 4);
+        EndTag();
+        return this;
     }
 
     /// <summary>
@@ -196,6 +250,7 @@ public sealed class PdfDocumentBuilder
         int cols = rowList.Max(r => r.Count);
         double[] weights = NormalizeWeights(columnWeights, cols);
 
+        BeginTag("Table");
         for (int i = 0; i < rowList.Count; i++)
         {
             var style = (headerRow && i == 0) ? TextStyle.Body.AsBold().WithSpaceAfter(0)
@@ -206,6 +261,7 @@ public sealed class PdfDocumentBuilder
 
             Row(cells, weights, cellPadding: 4, spaceAfter: 0, gridLines: gridLines);
         }
+        EndTag();
 
         _cursorY -= TextStyle.Body.SpaceAfter;
         return this;
@@ -389,11 +445,18 @@ public sealed class PdfDocumentBuilder
 
     private void NewPage()
     {
+        // A marked-content sequence can't span pages: close it on the outgoing
+        // page and reopen a fresh MCID for the same element on the new page.
+        bool reopen = _tagging != null && _openElem != null && _graphics != null;
+        if (reopen) _graphics!.EndMarkedContent();
+
         _graphics?.Flush();
         _currentPage = _document.Pages.AddBlank(_pageSize.Width, _pageSize.Height);
         _currentPageNumber = _document.PageCount;
         _graphics = _currentPage.GetGraphics();
         _cursorY = _pageSize.Height - _margins.Top;
+
+        if (reopen) OpenMarkedContent();
     }
 
     /// <summary>Ensure at least <paramref name="height"/> remains; else paginate.</summary>

--- a/Pdfe.Core/Document/PdfDocument.cs
+++ b/Pdfe.Core/Document/PdfDocument.cs
@@ -478,6 +478,41 @@ public class PdfDocument : IDisposable
     }
 
     /// <summary>
+    /// Find the indirect reference of a page (1-based) by walking the /Pages
+    /// tree. Returns null if pages are inline rather than indirect (rare).
+    /// Used by tagged-PDF authoring (/Pg) and form authoring.
+    /// </summary>
+    internal PdfReference? GetPageReference(int pageNumber)
+    {
+        var pagesObj = Catalog.GetOptional("Pages");
+        if (pagesObj == null || Resolve(pagesObj) is not PdfDictionary pages) return null;
+        int target = pageNumber - 1, counter = 0;
+        return WalkPageKids(pages, ref counter, target);
+    }
+
+    private PdfReference? WalkPageKids(PdfDictionary node, ref int counter, int target)
+    {
+        var kidsObj = node.GetOptional("Kids");
+        if (kidsObj == null || Resolve(kidsObj) is not PdfArray kids) return null;
+        foreach (var kidObj in kids)
+        {
+            var kid = Resolve(kidObj) as PdfDictionary;
+            if (kid == null) continue;
+            if (kid.GetNameOrNull("Type") == "Pages")
+            {
+                var found = WalkPageKids(kid, ref counter, target);
+                if (found != null) return found;
+            }
+            else
+            {
+                if (counter == target) return kidObj as PdfReference;
+                counter++;
+            }
+        }
+        return null;
+    }
+
+    /// <summary>
     /// Get all pages.
     /// </summary>
     public IEnumerable<PdfPage> GetPages()

--- a/Pdfe.Core/Graphics/PdfGraphics.cs
+++ b/Pdfe.Core/Graphics/PdfGraphics.cs
@@ -83,6 +83,28 @@ public class PdfGraphics : IDisposable
 
     #endregion
 
+    #region Marked Content (tagged PDF)
+
+    /// <summary>
+    /// Open a marked-content sequence tagged for the structure tree:
+    /// <c>/Tag &lt;&lt;/MCID n&gt;&gt; BDC</c> (PDF §14.6 / §14.8). Pair with
+    /// <see cref="EndMarkedContent"/>.
+    /// </summary>
+    public void BeginMarkedContent(string tag, int mcid)
+    {
+        ThrowIfDisposed();
+        _operators.AppendLine($"/{tag} <</MCID {mcid}>> BDC");
+    }
+
+    /// <summary>Close the most recent marked-content sequence (<c>EMC</c>).</summary>
+    public void EndMarkedContent()
+    {
+        ThrowIfDisposed();
+        _operators.AppendLine("EMC");
+    }
+
+    #endregion
+
     #region Transformations
 
     /// <summary>

--- a/Pdfe.Core/Tagging/StructureTreeBuilder.cs
+++ b/Pdfe.Core/Tagging/StructureTreeBuilder.cs
@@ -1,0 +1,134 @@
+using System.Linq;
+using Pdfe.Core.Document;
+using Pdfe.Core.Primitives;
+
+namespace Pdfe.Core.Tagging;
+
+/// <summary>
+/// Builds a PDF logical structure tree (tagged PDF, ISO 32000-2 §14.7-14.8) for
+/// accessibility / PDF/UA. Callers allocate a marked-content id (MCID) per tagged
+/// run on a page and attach it to a structure element; <see cref="Write"/>
+/// serializes the StructTreeRoot, the element tree, the ParentTree number tree,
+/// and the catalog entries (/MarkInfo, /StructTreeRoot, /ViewerPreferences).
+///
+/// <para>Each element's kids are marked-content references (<c>/MCR</c> with an
+/// explicit <c>/Pg</c>), so a single logical element can span pages.</para>
+/// </summary>
+internal sealed class StructureTreeBuilder
+{
+    private readonly PdfDocument _doc;
+    private readonly List<StructElem> _elements = new();
+    private readonly Dictionary<int, int> _nextMcid = new();   // pageNumber -> next MCID
+    private bool _finalized;
+
+    public StructureTreeBuilder(PdfDocument doc) => _doc = doc;
+
+    /// <summary>A structure element (e.g. H1, P, Table) and its marked-content runs.</summary>
+    internal sealed class StructElem
+    {
+        public string Type = "P";
+        public readonly List<(int Page, int Mcid)> Content = new();
+    }
+
+    /// <summary>Register a new structure element of the given type (child of Document).</summary>
+    public StructElem AddElement(string structType)
+    {
+        var e = new StructElem { Type = structType };
+        _elements.Add(e);
+        return e;
+    }
+
+    /// <summary>Allocate the next MCID on a page and record it on the element.</summary>
+    public int AllocateMcid(StructElem element, int pageNumber)
+    {
+        int mcid = _nextMcid.TryGetValue(pageNumber, out var n) ? n : 0;
+        _nextMcid[pageNumber] = mcid + 1;
+        element.Content.Add((pageNumber, mcid));
+        return mcid;
+    }
+
+    public bool HasContent => _elements.Any(e => e.Content.Count > 0);
+
+    /// <summary>Serialize the structure tree into the document. Idempotent.</summary>
+    public void Write()
+    {
+        if (_finalized || !HasContent) return;
+        _finalized = true;
+
+        var root = new PdfDictionary();
+        root.SetName("Type", "StructTreeRoot");
+        var rootRef = _doc.AddIndirectObject(root);
+
+        var docElem = new PdfDictionary();
+        docElem.SetName("Type", "StructElem");
+        docElem.SetName("S", "Document");
+        docElem["P"] = rootRef;
+        var docRef = _doc.AddIndirectObject(docElem);
+        var rootKids = new PdfArray();
+        rootKids.Add((PdfObject)docRef);
+        root["K"] = rootKids;
+
+        // pageNumber -> (mcid -> owning struct elem ref), for the ParentTree.
+        var perPage = new Dictionary<int, Dictionary<int, PdfReference>>();
+        var docKids = new PdfArray();
+
+        foreach (var e in _elements.Where(e => e.Content.Count > 0))
+        {
+            var se = new PdfDictionary();
+            se.SetName("Type", "StructElem");
+            se.SetName("S", e.Type);
+            se["P"] = docRef;
+            var seRef = _doc.AddIndirectObject(se);
+
+            var kids = new PdfArray();
+            foreach (var (page, mcid) in e.Content)
+            {
+                var pgRef = _doc.GetPageReference(page);
+                var mcr = new PdfDictionary();
+                mcr.SetName("Type", "MCR");
+                if (pgRef != null) mcr["Pg"] = pgRef;
+                mcr.SetInt("MCID", mcid);
+                kids.Add((PdfObject)mcr);
+
+                if (!perPage.TryGetValue(page, out var map)) perPage[page] = map = new();
+                map[mcid] = seRef;
+            }
+            se["K"] = kids.Count == 1 ? kids[0] : kids;
+            docKids.Add((PdfObject)seRef);
+        }
+        docElem["K"] = docKids;
+
+        // ParentTree: number tree keyed by each page's /StructParents index;
+        // value is an array indexed by MCID -> owning struct element.
+        var nums = new PdfArray();
+        int nextKey = 0;
+        foreach (var page in perPage.Keys.OrderBy(p => p))
+        {
+            int key = nextKey++;
+            _doc.GetPage(page).Dictionary.SetInt("StructParents", key);
+            var map = perPage[page];
+            int maxMcid = map.Keys.Max();
+            var arr = new PdfArray();
+            for (int i = 0; i <= maxMcid; i++)
+                arr.Add(map.TryGetValue(i, out var r) ? (PdfObject)r : PdfNull.Instance);
+            nums.Add(key);
+            nums.Add((PdfObject)arr);
+        }
+        var parentTree = new PdfDictionary();
+        parentTree["Nums"] = nums;
+        root["ParentTree"] = _doc.AddIndirectObject(parentTree);
+        root.SetInt("ParentTreeNextKey", nextKey);
+
+        // Catalog: mark as tagged, link the tree, and (PDF/UA) show the doc title.
+        _doc.Catalog["StructTreeRoot"] = rootRef;
+        var markInfo = new PdfDictionary();
+        markInfo.SetBool("Marked", true);
+        _doc.Catalog["MarkInfo"] = markInfo;
+        if (!_doc.Catalog.ContainsKey("ViewerPreferences"))
+        {
+            var vp = new PdfDictionary();
+            vp.SetBool("DisplayDocTitle", true);
+            _doc.Catalog["ViewerPreferences"] = vp;
+        }
+    }
+}


### PR DESCRIPTION
Adds accessibility / PDF-UA structure authoring — the last writer item for PromptResponse.

- `PdfGraphics.BeginMarkedContent`/`EndMarkedContent` (BDC/EMC + MCID).
- **`StructureTreeBuilder`**: `StructTreeRoot` + `Document` root + per-block `StructElem`s whose kids are `/MCR` marked-content refs (with `/Pg`, so an element can span pages) + a `/ParentTree` number tree; sets catalog `/MarkInfo /Marked true`, `/StructTreeRoot`, `/ViewerPreferences /DisplayDocTitle`. Serialized at save. `PdfDocument.GetPageReference` added for `/Pg`.
- **`PdfDocumentBuilder.Tagged()`**: Heading→H1-H4, Paragraph/KeyValue→P, Table→Table, each wrapped in marked content; pagination closes/reopens the run cleanly.

With `DefaultFont` (embedded fonts, #398) + `Language` (`/Lang`) this yields genuinely accessible docs. **Verified**: `pdfinfo` → `Tagged: yes`, qpdf clean, tree = Document→H1/H2/P/Table. 5 new tests; full suite green (**2881**).

Substantially addresses #275 (authoring foundation). Full PDF/UA conformance (TR/TD nesting, lists, form-field tagging, artifact marking, veraPDF pass) → follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)