### PR TITLE
release: v2.6.0 — font subsetting/CFF, builder fonts, tagged PDF, JBIG2/JPX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,39 @@ All notable changes to pdfe are documented here. Format roughly follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this project uses
 semantic versioning.
 
+## [2.6.0] — 2026-06-06
+
+Font, accessibility, and image-filter additions. All additive; the public-API
+gate confirms no breaking changes.
+
+### Added
+- **Font subsetting + CFF/OpenType embedding (#393).** Embedded TrueType fonts
+  are now subsetted to the glyphs actually drawn (retain-GID `glyf`/`loca`,
+  composite-glyph closure, subset tag) — e.g. DejaVu drawing a short string went
+  from ~759 KB to ~14 KB embedded. CFF-outline OpenType (`'OTTO'`) fonts can now
+  be embedded too (`/CIDFontType0` + `/FontFile3 /Subtype /OpenType`).
+- **Embedded fonts in the high-level builder (#398).** `TextStyle.WithFont(...)`
+  and `PdfDocumentBuilder.DefaultFont(...)` let the friendly facade render
+  arbitrary Unicode (not just base-14); the same typeface across sizes/weights
+  embeds as one subset. `PdfFont.WithSize` is now `virtual`.
+- **Tagged-PDF authoring / PDF-UA (#275).** `PdfDocumentBuilder.Tagged()` emits a
+  logical structure tree (StructTreeRoot + Document→H1-H4/P/Table), marked
+  content (`BDC`/`EMC` + MCID, `/MCR` with `/Pg`, `/ParentTree`), and catalog
+  `/MarkInfo`, `/ViewerPreferences /DisplayDocTitle`. Plus
+  `PdfGraphics.BeginMarkedContent`/`EndMarkedContent`. Combined with embedded
+  fonts + `/Lang`, the builder now produces genuinely accessible documents
+  (`pdfinfo` reports `Tagged: yes`).
+- **Image filters: JBIG2 + JPEG2000 (#325).** Pure-managed JBIG2 decoder
+  (MQ arithmetic + generic region, template 0) wired into the stream
+  decompressor with strict decode-or-passthrough fallback (no silently-wrong
+  images). JPEG2000 (`JPXDecode`) codestream/marker parsing (full pixel decode
+  deferred). JPEG/PNG remain delegated to the SkiaSharp renderer.
+
+### Notes
+- Remaining tracked follow-ups: full PDF/UA conformance (artifacts, TR/TD,
+  form-field tagging), CFF glyph subsetting, JBIG2 symbol/text regions, full
+  JPEG2000 decode.
+
 ## [2.5.0] — 2026-06-06
 
 Completes the **PromptResponse writer epic (#382)** — pdfe can now author

--- a/Pdfe.Avalonia/Pdfe.Avalonia.csproj
+++ b/Pdfe.Avalonia/Pdfe.Avalonia.csproj
@@ -14,7 +14,7 @@
   <!-- NuGet package metadata (packed explicitly via `dotnet pack`, not on build). -->
   <PropertyGroup>
     <PackageId>Pdfe.Avalonia</PackageId>
-    <Version>2.5.0</Version>
+    <Version>2.6.0</Version>
     <Authors>Marc Jones</Authors>
     <Description>A reusable, pure-managed PDF viewer control for Avalonia. Renders with SkiaSharp (no native PDFium), supports zoom/pan, page navigation, text selection, search highlights, annotations, links, and form-field overlays. Built on Pdfe.Core + Pdfe.Rendering.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Pdfe.Core/Pdfe.Core.csproj
+++ b/Pdfe.Core/Pdfe.Core.csproj
@@ -10,7 +10,7 @@
 
   <PropertyGroup>
     <PackageId>Pdfe.Core</PackageId>
-    <Version>2.5.0</Version>
+    <Version>2.6.0</Version>
     <Authors>Marc Jones</Authors>
     <Description>Pure-managed PDF parser, document model, and writer for .NET. Open/edit/save PDFs, extract text/links/annotations/forms, and perform true glyph-level redaction. No native dependencies; cross-platform and trim/AOT-friendlier.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Pdfe.Rendering/Pdfe.Rendering.csproj
+++ b/Pdfe.Rendering/Pdfe.Rendering.csproj
@@ -10,7 +10,7 @@
 
   <PropertyGroup>
     <PackageId>Pdfe.Rendering</PackageId>
-    <Version>2.5.0</Version>
+    <Version>2.6.0</Version>
     <Authors>Marc Jones</Authors>
     <Description>Pure-managed, SkiaSharp-based PDF render API for .NET. Render pages to SKBitmap or PNG with DPI/clip/rotation support and cancellable rendering. Framework-neutral engine behind Pdfe.Avalonia; no native PDFium. Cross-platform, trim/AOT-friendlier.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
Cuts **v2.6.0** (MINOR, additive). Bundles #393 (subsetting + CFF/OTTO), #398 (embedded fonts in the builder), #275 (tagged-PDF/PDF-UA authoring), #325 (JBIG2 + JPEG2000 parsing). Trio 2.5.0→2.6.0; CHANGELOG [2.6.0].

🤖 Generated with [Claude Code](https://claude.com/claude-code)