### PR TITLE
feat(tagging): mark decorative content as PDF/UA artifacts (#407)

### DIFF
--- a/Pdfe.Core.Tests/Authoring/TaggedPdfTests.cs
+++ b/Pdfe.Core.Tests/Authoring/TaggedPdfTests.cs
@@ -81,6 +81,20 @@ public class TaggedPdfTests
     }
 
     [Fact]
+    public void Tagged_DecorativeContentIsMarkedAsArtifact()
+    {
+        var pdf = PdfDocumentBuilder.Create().Tagged()
+            .Paragraph("text")
+            .HorizontalRule()
+            .TextField("Name", "name")   // draws a box border
+            .SaveToBytes();
+
+        using var doc = PdfDocument.Open(pdf);
+        var content = Encoding.Latin1.GetString(doc.GetPage(1).GetContentStreamBytes());
+        content.Should().Contain("/Artifact BDC", "rules/borders must be artifacts under PDF/UA");
+    }
+
+    [Fact]
     public void NotTagged_HasNoStructTree()
     {
         var pdf = PdfDocumentBuilder.Create().Paragraph("hello").SaveToBytes();

--- a/Pdfe.Core.Tests/PublicApi/Pdfe.Core.approved.txt
+++ b/Pdfe.Core.Tests/PublicApi/Pdfe.Core.approved.txt
@@ -709,6 +709,7 @@ namespace Pdfe.Core.Graphics
     }
     public class PdfGraphics : System.IDisposable
     {
+        public void BeginArtifact() { }
         public void BeginMarkedContent(string tag, int mcid) { }
         public void BeginPath() { }
         public void ClosePath() { }

--- a/Pdfe.Core/Authoring/PdfDocumentBuilder.cs
+++ b/Pdfe.Core/Authoring/PdfDocumentBuilder.cs
@@ -203,7 +203,8 @@ public sealed class PdfDocumentBuilder
         EnsureSpace(thickness + 6);
         _cursorY -= 3;
         var pen = new PdfPen(color ?? PdfColor.FromGray(0.6), thickness);
-        _graphics!.DrawLine(ContentLeft, _cursorY, ContentLeft + ContentWidth, _cursorY, pen);
+        double ruleY = _cursorY;
+        DrawArtifact(() => _graphics!.DrawLine(ContentLeft, ruleY, ContentLeft + ContentWidth, ruleY, pen));
         _cursorY -= 3;
         return this;
     }
@@ -497,7 +498,18 @@ public sealed class PdfDocumentBuilder
     private void DrawBoxBorder(PdfRectangle rect)
     {
         var pen = new PdfPen(PdfColor.FromGray(0.5), 0.75);
-        _graphics!.DrawRectangle(rect.Left, rect.Bottom, rect.Width, rect.Height, fill: null, stroke: pen);
+        DrawArtifact(() => _graphics!.DrawRectangle(rect.Left, rect.Bottom, rect.Width, rect.Height, fill: null, stroke: pen));
+    }
+
+    /// <summary>
+    /// Draw decorative (non-content) graphics, wrapped as a PDF artifact when
+    /// tagging is on so it stays out of the structure tree (PDF/UA).
+    /// </summary>
+    private void DrawArtifact(Action draw)
+    {
+        if (_tagging != null) _graphics!.BeginArtifact();
+        draw();
+        if (_tagging != null) _graphics!.EndMarkedContent();
     }
 
     /// <summary>

--- a/Pdfe.Core/Graphics/PdfGraphics.cs
+++ b/Pdfe.Core/Graphics/PdfGraphics.cs
@@ -96,6 +96,18 @@ public class PdfGraphics : IDisposable
         _operators.AppendLine($"/{tag} <</MCID {mcid}>> BDC");
     }
 
+    /// <summary>
+    /// Open an artifact marked-content sequence (<c>/Artifact BDC</c>) for purely
+    /// decorative content that is excluded from the structure tree — required by
+    /// PDF/UA so every piece of content is either tagged or an artifact. Pair
+    /// with <see cref="EndMarkedContent"/>.
+    /// </summary>
+    public void BeginArtifact()
+    {
+        ThrowIfDisposed();
+        _operators.AppendLine("/Artifact BDC");
+    }
+
     /// <summary>Close the most recent marked-content sequence (<c>EMC</c>).</summary>
     public void EndMarkedContent()
     {


### PR DESCRIPTION
Toward full PDF/UA (follow-up to #275's tagging foundation): when `Tagged()` is on, decorative graphics (horizontal rules, form-field borders) are wrapped in `/Artifact BDC`…`EMC` so every page content op is either tagged or an artifact (PDF/UA requirement). Adds `PdfGraphics.BeginArtifact()`; builder routes rule/border drawing through a `DrawArtifact` helper. 1 new test; full suite green (2882). Part of #407.

🤖 Generated with [Claude Code](https://claude.com/claude-code)