### PR TITLE
feat(tagging): tag form fields in the structure tree via /OBJR (#407)

### DIFF
--- a/Pdfe.Core.Tests/Authoring/TaggedPdfTests.cs
+++ b/Pdfe.Core.Tests/Authoring/TaggedPdfTests.cs
@@ -95,6 +95,21 @@ public class TaggedPdfTests
     }
 
     [Fact]
+    public void Tagged_FormFields_AppearInStructureTreeAsForm()
+    {
+        var pdf = PdfDocumentBuilder.Create().Tagged()
+            .TextField("Name", "name")
+            .CheckBox("Agree", "agree")
+            .SaveToBytes();
+
+        using var doc = PdfDocument.Open(pdf);
+        StructTypes(doc).Should().Contain("Form", "form widgets must be in the structure tree (PDF/UA)");
+        // The widget annotation gets a /StructParent linking it into the ParentTree.
+        var field = doc.GetAcroForm()!.FindField("name")!;
+        field.RawDictionary.GetOptional("StructParent").Should().NotBeNull();
+    }
+
+    [Fact]
     public void NotTagged_HasNoStructTree()
     {
         var pdf = PdfDocumentBuilder.Create().Paragraph("hello").SaveToBytes();

--- a/Pdfe.Core/Authoring/PdfDocumentBuilder.cs
+++ b/Pdfe.Core/Authoring/PdfDocumentBuilder.cs
@@ -121,6 +121,18 @@ public sealed class PdfDocumentBuilder
     }
 
     /// <summary>
+    /// When tagging, add a Form structure element referencing the field's widget
+    /// annotation (/OBJR) so the control appears in the accessibility tree (#407).
+    /// </summary>
+    private void TagFormField(Document.PdfField field)
+    {
+        if (_tagging == null) return;
+        var widgetRef = _document.GetReferenceTo(field.RawDictionary);
+        if (widgetRef != null)
+            _tagging.AddObjectElement("Form", _currentPageNumber, widgetRef, field.RawDictionary);
+    }
+
+    /// <summary>
     /// Use an embedded font (e.g. <see cref="PdfFont.FromFile"/>) for all text
     /// blocks that don't specify their own — lets the builder render Unicode
     /// beyond the base-14 fonts (#398). The style's point size is applied to it.
@@ -305,9 +317,9 @@ public sealed class PdfDocumentBuilder
         DrawBoxBorder(rect);
         // Default the accessible name (/TU) to the visible label so screen
         // readers announce the field even when no explicit tooltip is given.
-        _document.AddTextField(_currentPageNumber, rect, fieldName,
+        TagFormField(_document.AddTextField(_currentPageNumber, rect, fieldName,
             defaultValue: defaultValue, multiline: multiline, required: required,
-            tooltip: tooltip ?? label, maxLength: maxLength, comb: comb);
+            tooltip: tooltip ?? label, maxLength: maxLength, comb: comb));
 
         _cursorY -= TextStyle.Body.SpaceAfter;
         return this;
@@ -334,8 +346,8 @@ public sealed class PdfDocumentBuilder
         double boxHeight = bodyFont.LineHeight + 6;
         var rect = ReserveBox(boxHeight);
         DrawBoxBorder(rect);
-        _document.AddDateField(_currentPageNumber, rect, fieldName,
-            format: format, required: required, tooltip: tooltip ?? $"{label} ({format})");
+        TagFormField(_document.AddDateField(_currentPageNumber, rect, fieldName,
+            format: format, required: required, tooltip: tooltip ?? $"{label} ({format})"));
 
         _cursorY -= TextStyle.Body.SpaceAfter;
         return this;
@@ -362,8 +374,8 @@ public sealed class PdfDocumentBuilder
         double bottom = top - box;
         var rect = new PdfRectangle(ContentLeft, bottom, ContentLeft + box, top);
         DrawBoxBorder(rect);
-        _document.AddCheckBox(_currentPageNumber, rect, fieldName,
-            defaultChecked: checkedByDefault, tooltip: tooltip ?? label);
+        TagFormField(_document.AddCheckBox(_currentPageNumber, rect, fieldName,
+            defaultChecked: checkedByDefault, tooltip: tooltip ?? label));
 
         // Label baseline aligned to the checkbox.
         double baseline = top - font.Ascender;
@@ -394,8 +406,8 @@ public sealed class PdfDocumentBuilder
         double boxHeight = bodyFont.LineHeight + 6;
         var rect = ReserveBox(boxHeight);
         DrawBoxBorder(rect);
-        _document.AddChoiceField(_currentPageNumber, rect, fieldName, options,
-            defaultValue: defaultValue, tooltip: tooltip ?? label);
+        TagFormField(_document.AddChoiceField(_currentPageNumber, rect, fieldName, options,
+            defaultValue: defaultValue, tooltip: tooltip ?? label));
 
         _cursorY -= TextStyle.Body.SpaceAfter;
         return this;

--- a/Pdfe.Core/Document/PdfDocument.cs
+++ b/Pdfe.Core/Document/PdfDocument.cs
@@ -1010,6 +1010,19 @@ public class PdfDocument : IDisposable
     internal void RegisterPreSaveAction(Action action) => _preSaveActions.Add(action);
 
     /// <summary>
+    /// Find the indirect reference of a cached object instance (by identity), or
+    /// null if it isn't a top-level indirect object. Used by tagged-PDF authoring
+    /// to reference a widget annotation from the structure tree (/OBJR).
+    /// </summary>
+    internal PdfReference? GetReferenceTo(PdfObject obj)
+    {
+        foreach (var (num, cached) in _objectCache)
+            if (ReferenceEquals(cached, obj))
+                return new PdfReference(num, 0);
+        return null;
+    }
+
+    /// <summary>
     /// Save the document to a stream.
     /// </summary>
     public void Save(Stream outputStream)

--- a/Pdfe.Core/Tagging/StructureTreeBuilder.cs
+++ b/Pdfe.Core/Tagging/StructureTreeBuilder.cs
@@ -6,13 +6,15 @@ namespace Pdfe.Core.Tagging;
 
 /// <summary>
 /// Builds a PDF logical structure tree (tagged PDF, ISO 32000-2 §14.7-14.8) for
-/// accessibility / PDF/UA. Callers allocate a marked-content id (MCID) per tagged
-/// run on a page and attach it to a structure element; <see cref="Write"/>
-/// serializes the StructTreeRoot, the element tree, the ParentTree number tree,
-/// and the catalog entries (/MarkInfo, /StructTreeRoot, /ViewerPreferences).
+/// accessibility / PDF/UA. Callers either allocate a marked-content id (MCID) per
+/// tagged run on a page (text content) or attach an object reference (a widget
+/// annotation), and <see cref="Write"/> serializes the StructTreeRoot, the element
+/// tree, the ParentTree number tree, and the catalog entries (/MarkInfo,
+/// /StructTreeRoot, /ViewerPreferences).
 ///
-/// <para>Each element's kids are marked-content references (<c>/MCR</c> with an
-/// explicit <c>/Pg</c>), so a single logical element can span pages.</para>
+/// <para>Element kids are marked-content references (<c>/MCR</c> with explicit
+/// <c>/Pg</c>, so an element can span pages) and/or object references
+/// (<c>/OBJR</c> for form-field widgets).</para>
 /// </summary>
 internal sealed class StructureTreeBuilder
 {
@@ -23,11 +25,12 @@ internal sealed class StructureTreeBuilder
 
     public StructureTreeBuilder(PdfDocument doc) => _doc = doc;
 
-    /// <summary>A structure element (e.g. H1, P, Table) and its marked-content runs.</summary>
+    /// <summary>A structure element (e.g. H1, P, Table, Form) and its content.</summary>
     internal sealed class StructElem
     {
         public string Type = "P";
-        public readonly List<(int Page, int Mcid)> Content = new();
+        public readonly List<(int Page, int Mcid)> Content = new();                    // /MCR runs
+        public readonly List<(int Page, PdfReference Obj, PdfDictionary Dict)> Objects = new(); // /OBJR widgets
     }
 
     /// <summary>Register a new structure element of the given type (child of Document).</summary>
@@ -47,7 +50,18 @@ internal sealed class StructureTreeBuilder
         return mcid;
     }
 
-    public bool HasContent => _elements.Any(e => e.Content.Count > 0);
+    /// <summary>
+    /// Register a structure element that references a widget annotation (e.g. a
+    /// form field) via /OBJR. The widget gets a /StructParent at <see cref="Write"/>.
+    /// </summary>
+    public void AddObjectElement(string structType, int pageNumber, PdfReference widgetRef, PdfDictionary widgetDict)
+    {
+        var e = new StructElem { Type = structType };
+        e.Objects.Add((pageNumber, widgetRef, widgetDict));
+        _elements.Add(e);
+    }
+
+    public bool HasContent => _elements.Any(e => e.Content.Count > 0 || e.Objects.Count > 0);
 
     /// <summary>Serialize the structure tree into the document. Idempotent.</summary>
     public void Write()
@@ -68,11 +82,13 @@ internal sealed class StructureTreeBuilder
         rootKids.Add((PdfObject)docRef);
         root["K"] = rootKids;
 
-        // pageNumber -> (mcid -> owning struct elem ref), for the ParentTree.
+        // pageNumber -> (mcid -> owning struct elem ref) for the ParentTree;
+        // and a flat list of (widgetDict -> owning struct elem ref) for objects.
         var perPage = new Dictionary<int, Dictionary<int, PdfReference>>();
+        var objectOwners = new List<(PdfDictionary Dict, PdfReference Elem)>();
         var docKids = new PdfArray();
 
-        foreach (var e in _elements.Where(e => e.Content.Count > 0))
+        foreach (var e in _elements.Where(x => x.Content.Count > 0 || x.Objects.Count > 0))
         {
             var se = new PdfDictionary();
             se.SetName("Type", "StructElem");
@@ -89,18 +105,27 @@ internal sealed class StructureTreeBuilder
                 if (pgRef != null) mcr["Pg"] = pgRef;
                 mcr.SetInt("MCID", mcid);
                 kids.Add((PdfObject)mcr);
-
                 if (!perPage.TryGetValue(page, out var map)) perPage[page] = map = new();
                 map[mcid] = seRef;
+            }
+            foreach (var (page, obj, dict) in e.Objects)
+            {
+                var pgRef = _doc.GetPageReference(page);
+                var objr = new PdfDictionary();
+                objr.SetName("Type", "OBJR");
+                if (pgRef != null) objr["Pg"] = pgRef;
+                objr["Obj"] = obj;
+                kids.Add((PdfObject)objr);
+                objectOwners.Add((dict, seRef));
             }
             se["K"] = kids.Count == 1 ? kids[0] : kids;
             docKids.Add((PdfObject)seRef);
         }
         docElem["K"] = docKids;
 
-        // ParentTree: number tree keyed by each page's /StructParents index;
-        // value is an array indexed by MCID -> owning struct element.
-        var nums = new PdfArray();
+        // ParentTree: one number-tree key per page (StructParents -> array by MCID)
+        // and per widget (StructParent -> the owning element ref).
+        var entries = new List<(int Key, PdfObject Value)>();
         int nextKey = 0;
         foreach (var page in perPage.Keys.OrderBy(p => p))
         {
@@ -111,8 +136,20 @@ internal sealed class StructureTreeBuilder
             var arr = new PdfArray();
             for (int i = 0; i <= maxMcid; i++)
                 arr.Add(map.TryGetValue(i, out var r) ? (PdfObject)r : PdfNull.Instance);
+            entries.Add((key, arr));
+        }
+        foreach (var (dict, elem) in objectOwners)
+        {
+            int key = nextKey++;
+            dict.SetInt("StructParent", key);
+            entries.Add((key, elem));
+        }
+
+        var nums = new PdfArray();
+        foreach (var (key, value) in entries.OrderBy(e => e.Key))
+        {
             nums.Add(key);
-            nums.Add((PdfObject)arr);
+            nums.Add(value);
         }
         var parentTree = new PdfDictionary();
         parentTree["Nums"] = nums;


### PR DESCRIPTION
For PDF/UA, form widgets must be in the structure tree. When `Tagged()` is on, each builder field adds a **Form** struct element with an **/OBJR** to the widget annotation, and the widget gets a **/StructParent** into the ParentTree. `StructureTreeBuilder` now supports object elements (OBJR) alongside content (MCR); `PdfDocument.GetReferenceTo` resolves the widget ref. `/TU` supplies the accessible name. 1 new test; full suite green (**2883**); no public-API change. Part of #407.

🤖 Generated with [Claude Code](https://claude.com/claude-code)