### PR TITLE
feat(tagging): nested Table>TR>TD/TH structure + artifact grid lines (#407)

### DIFF
--- a/Pdfe.Core.Tests/Authoring/TaggedPdfTests.cs
+++ b/Pdfe.Core.Tests/Authoring/TaggedPdfTests.cs
@@ -81,6 +81,21 @@ public class TaggedPdfTests
     }
 
     [Fact]
+    public void Tagged_TableNestsTableTrTdTh()
+    {
+        var pdf = PdfDocumentBuilder.Create().Tagged()
+            .Table(new[] { new[] { "H1", "H2" }, new[] { "a", "b" } }, headerRow: true)
+            .SaveToBytes();
+
+        using var doc = PdfDocument.Open(pdf);
+        var types = StructTypes(doc);
+        types.Should().Contain("Table");
+        types.Should().Contain("TR");
+        types.Should().Contain("TH", "header cells should be TH");
+        types.Should().Contain("TD", "body cells should be TD");
+    }
+
+    [Fact]
     public void Tagged_DecorativeContentIsMarkedAsArtifact()
     {
         var pdf = PdfDocumentBuilder.Create().Tagged()

--- a/Pdfe.Core/Authoring/PdfDocumentBuilder.cs
+++ b/Pdfe.Core/Authoring/PdfDocumentBuilder.cs
@@ -263,7 +263,8 @@ public sealed class PdfDocumentBuilder
         int cols = rowList.Max(r => r.Count);
         double[] weights = NormalizeWeights(columnWeights, cols);
 
-        BeginTag("Table");
+        // Tagging: Table → TR (per row) → TD (per cell, with its own marked content).
+        var tableElem = _tagging?.AddElement("Table");
         for (int i = 0; i < rowList.Count; i++)
         {
             var style = (headerRow && i == 0) ? TextStyle.Body.AsBold().WithSpaceAfter(0)
@@ -272,9 +273,11 @@ public sealed class PdfDocumentBuilder
             for (int c = 0; c < cols; c++)
                 cells[c] = (c < rowList[i].Count ? rowList[i][c] ?? string.Empty : string.Empty, style);
 
-            Row(cells, weights, cellPadding: 4, spaceAfter: 0, gridLines: gridLines);
+            var trElem = _tagging?.AddElement("TR", tableElem);
+            // Header cells are TH, body cells TD.
+            Row(cells, weights, cellPadding: 4, spaceAfter: 0, gridLines: gridLines,
+                rowParent: trElem, cellStructType: headerRow && i == 0 ? "TH" : "TD");
         }
-        EndTag();
 
         _cursorY -= TextStyle.Body.SpaceAfter;
         return this;
@@ -533,7 +536,9 @@ public sealed class PdfDocumentBuilder
         double[] weights,
         double cellPadding,
         double spaceAfter,
-        bool gridLines = false)
+        bool gridLines = false,
+        Tagging.StructureTreeBuilder.StructElem? rowParent = null,
+        string cellStructType = "TD")
     {
         EnsurePage();
 
@@ -567,18 +572,29 @@ public sealed class PdfDocumentBuilder
             var style = styles[c];
             var font = style.ResolveFont();
             var brush = style.ResolveBrush();
+
+            // Per-cell marked content tied to a TD/TH element (tables only).
+            bool tagCell = _tagging != null && rowParent != null;
+            if (tagCell)
+            {
+                var td = _tagging!.AddElement(cellStructType, rowParent);
+                int mcid = _tagging.AllocateMcid(td, _currentPageNumber);
+                _graphics!.BeginMarkedContent(cellStructType, mcid);
+            }
+
             double textTop = top - cellPadding;
             for (int li = 0; li < wrapped[c].Count; li++)
             {
                 double baseline = textTop - font.Ascender - li * lineHeight;
                 _graphics!.DrawString(wrapped[c][li], font, brush, x + cellPadding, baseline);
             }
+            if (tagCell) _graphics!.EndMarkedContent();
 
             if (gridLines)
             {
                 var rect = new PdfRectangle(x, top - rowHeight, x + colWidths[c], top);
                 var pen = new PdfPen(PdfColor.FromGray(0.7), 0.5);
-                _graphics!.DrawRectangle(rect.Left, rect.Bottom, rect.Width, rect.Height, fill: null, stroke: pen);
+                DrawArtifact(() => _graphics!.DrawRectangle(rect.Left, rect.Bottom, rect.Width, rect.Height, fill: null, stroke: pen));
             }
 
             x += colWidths[c];

--- a/Pdfe.Core/Tagging/StructureTreeBuilder.cs
+++ b/Pdfe.Core/Tagging/StructureTreeBuilder.cs
@@ -25,19 +25,24 @@ internal sealed class StructureTreeBuilder
 
     public StructureTreeBuilder(PdfDocument doc) => _doc = doc;
 
-    /// <summary>A structure element (e.g. H1, P, Table, Form) and its content.</summary>
+    /// <summary>A structure element (e.g. H1, P, Table, TR, TD, Form) and its content.</summary>
     internal sealed class StructElem
     {
         public string Type = "P";
+        public readonly List<StructElem> Children = new();                             // nested elems
         public readonly List<(int Page, int Mcid)> Content = new();                    // /MCR runs
         public readonly List<(int Page, PdfReference Obj, PdfDictionary Dict)> Objects = new(); // /OBJR widgets
     }
 
-    /// <summary>Register a new structure element of the given type (child of Document).</summary>
-    public StructElem AddElement(string structType)
+    /// <summary>
+    /// Register a new structure element. With no <paramref name="parent"/> it's a
+    /// child of Document; otherwise it nests under the parent (e.g. Table→TR→TD).
+    /// </summary>
+    public StructElem AddElement(string structType, StructElem? parent = null)
     {
         var e = new StructElem { Type = structType };
-        _elements.Add(e);
+        if (parent != null) parent.Children.Add(e);
+        else _elements.Add(e);
         return e;
     }
 
@@ -61,7 +66,51 @@ internal sealed class StructureTreeBuilder
         _elements.Add(e);
     }
 
-    public bool HasContent => _elements.Any(e => e.Content.Count > 0 || e.Objects.Count > 0);
+    private static bool ElemHasContent(StructElem e) =>
+        e.Content.Count > 0 || e.Objects.Count > 0 || e.Children.Any(ElemHasContent);
+
+    public bool HasContent => _elements.Any(ElemHasContent);
+
+    /// <summary>Recursively serialize an element (and its children); returns its ref.</summary>
+    private PdfReference WriteElem(StructElem e, PdfReference parentRef)
+    {
+        var se = new PdfDictionary();
+        se.SetName("Type", "StructElem");
+        se.SetName("S", e.Type);
+        se["P"] = parentRef;
+        var seRef = _doc.AddIndirectObject(se);
+
+        var kids = new PdfArray();
+        foreach (var child in e.Children.Where(ElemHasContent))
+            kids.Add((PdfObject)WriteElem(child, seRef));
+        foreach (var (page, mcid) in e.Content)
+        {
+            var pgRef = _doc.GetPageReference(page);
+            var mcr = new PdfDictionary();
+            mcr.SetName("Type", "MCR");
+            if (pgRef != null) mcr["Pg"] = pgRef;
+            mcr.SetInt("MCID", mcid);
+            kids.Add((PdfObject)mcr);
+            if (!_perPage.TryGetValue(page, out var map)) _perPage[page] = map = new();
+            map[mcid] = seRef;
+        }
+        foreach (var (page, obj, dict) in e.Objects)
+        {
+            var pgRef = _doc.GetPageReference(page);
+            var objr = new PdfDictionary();
+            objr.SetName("Type", "OBJR");
+            if (pgRef != null) objr["Pg"] = pgRef;
+            objr["Obj"] = obj;
+            kids.Add((PdfObject)objr);
+            _objectOwners.Add((dict, seRef));
+        }
+        se["K"] = kids.Count == 1 ? kids[0] : kids;
+        return seRef;
+    }
+
+    // Populated during Write() recursion.
+    private readonly Dictionary<int, Dictionary<int, PdfReference>> _perPage = new();
+    private readonly List<(PdfDictionary Dict, PdfReference Elem)> _objectOwners = new();
 
     /// <summary>Serialize the structure tree into the document. Idempotent.</summary>
     public void Write()
@@ -82,46 +131,13 @@ internal sealed class StructureTreeBuilder
         rootKids.Add((PdfObject)docRef);
         root["K"] = rootKids;
 
-        // pageNumber -> (mcid -> owning struct elem ref) for the ParentTree;
-        // and a flat list of (widgetDict -> owning struct elem ref) for objects.
-        var perPage = new Dictionary<int, Dictionary<int, PdfReference>>();
-        var objectOwners = new List<(PdfDictionary Dict, PdfReference Elem)>();
+        // Build the element tree recursively (populates _perPage + _objectOwners).
         var docKids = new PdfArray();
-
-        foreach (var e in _elements.Where(x => x.Content.Count > 0 || x.Objects.Count > 0))
-        {
-            var se = new PdfDictionary();
-            se.SetName("Type", "StructElem");
-            se.SetName("S", e.Type);
-            se["P"] = docRef;
-            var seRef = _doc.AddIndirectObject(se);
-
-            var kids = new PdfArray();
-            foreach (var (page, mcid) in e.Content)
-            {
-                var pgRef = _doc.GetPageReference(page);
-                var mcr = new PdfDictionary();
-                mcr.SetName("Type", "MCR");
-                if (pgRef != null) mcr["Pg"] = pgRef;
-                mcr.SetInt("MCID", mcid);
-                kids.Add((PdfObject)mcr);
-                if (!perPage.TryGetValue(page, out var map)) perPage[page] = map = new();
-                map[mcid] = seRef;
-            }
-            foreach (var (page, obj, dict) in e.Objects)
-            {
-                var pgRef = _doc.GetPageReference(page);
-                var objr = new PdfDictionary();
-                objr.SetName("Type", "OBJR");
-                if (pgRef != null) objr["Pg"] = pgRef;
-                objr["Obj"] = obj;
-                kids.Add((PdfObject)objr);
-                objectOwners.Add((dict, seRef));
-            }
-            se["K"] = kids.Count == 1 ? kids[0] : kids;
-            docKids.Add((PdfObject)seRef);
-        }
+        foreach (var e in _elements.Where(ElemHasContent))
+            docKids.Add((PdfObject)WriteElem(e, docRef));
         docElem["K"] = docKids;
+        var perPage = _perPage;
+        var objectOwners = _objectOwners;
 
         // ParentTree: one number-tree key per page (StructParents -> array by MCID)
         // and per widget (StructParent -> the owning element ref).


### PR DESCRIPTION
`StructureTreeBuilder` now supports nested elements (recursive Write). Tagged tables are emitted as **Table → TR → TD/TH** (header cells = TH), each cell in its own marked content, instead of a flat Table element; grid lines are now `/Artifact`. 2 new assertions; full suite green (**2884**); no public-API change. Advances #407 (table nesting + grid-line artifacting done; lists, role map, veraPDF remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)