### PR TITLE
release: v2.7.0 — FillableTable + PDF/UA hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ semantic versioning.
 
 ## [2.7.0] — 2026-06-06
 
-Fillable-table authoring. Additive; no breaking changes.
+Fillable-table authoring + PDF/UA accessibility hardening. Additive; no breaking
+changes (public-API gate confirmed).
 
 ### Added
 - **`PdfDocumentBuilder.FillableTable(...)`.** Renders a table whose body cells
@@ -15,6 +16,15 @@ Fillable-table authoring. Additive; no breaking changes.
   pagination) but places live fields instead of static text. The first column is a
   static row-header; each cell's `/TU` accessible name comes from its tooltip.
   New supporting types: `FillableTableRow`, `FillableTableCell`, `FillableCellKind`.
+- **PDF/UA hardening for tagged output (#407).**
+  - Decorative content (horizontal rules, form-field borders, table grid lines)
+    is wrapped in `/Artifact` so every piece of page content is tagged or an
+    artifact. New `PdfGraphics.BeginArtifact()`.
+  - Form-field widgets are added to the structure tree as `Form` elements via
+    `/OBJR`, with each widget carrying a `/StructParent` into the ParentTree.
+  - Tagged tables now nest `Table → TR → TD/TH` (header cells `TH`), each cell in
+    its own marked content, instead of one flat `Table` element;
+    `StructureTreeBuilder` models a general nested element tree.
 
 ## [2.6.0] — 2026-06-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to pdfe are documented here. Format roughly follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this project uses
 semantic versioning.
 
+## [2.7.0] — 2026-06-06
+
+Fillable-table authoring. Additive; no breaking changes.
+
+### Added
+- **`PdfDocumentBuilder.FillableTable(...)`.** Renders a table whose body cells
+  are interactive AcroForm fields (text input, checkbox, or dropdown per cell) —
+  a fillable grid. Mirrors `Table`'s layout (column weights, gridlines, automatic
+  pagination) but places live fields instead of static text. The first column is a
+  static row-header; each cell's `/TU` accessible name comes from its tooltip.
+  New supporting types: `FillableTableRow`, `FillableTableCell`, `FillableCellKind`.
+
 ## [2.6.0] — 2026-06-06
 
 Font, accessibility, and image-filter additions. All additive; the public-API

--- a/Pdfe.Avalonia/Pdfe.Avalonia.csproj
+++ b/Pdfe.Avalonia/Pdfe.Avalonia.csproj
@@ -14,7 +14,7 @@
   <!-- NuGet package metadata (packed explicitly via `dotnet pack`, not on build). -->
   <PropertyGroup>
     <PackageId>Pdfe.Avalonia</PackageId>
-    <Version>2.6.0</Version>
+    <Version>2.7.0</Version>
     <Authors>Marc Jones</Authors>
     <Description>A reusable, pure-managed PDF viewer control for Avalonia. Renders with SkiaSharp (no native PDFium), supports zoom/pan, page navigation, text selection, search highlights, annotations, links, and form-field overlays. Built on Pdfe.Core + Pdfe.Rendering.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Pdfe.Core.Tests/Authoring/FillableTableTests.cs
+++ b/Pdfe.Core.Tests/Authoring/FillableTableTests.cs
@@ -1,0 +1,71 @@
+using System.Linq;
+using AwesomeAssertions;
+using Pdfe.Core.Authoring;
+using Pdfe.Core.Document;
+using Pdfe.Core.Text;
+using Xunit;
+
+namespace Pdfe.Core.Tests.Authoring;
+
+/// <summary>
+/// Tests for <see cref="PdfDocumentBuilder.FillableTable"/> — a table whose body
+/// cells are interactive AcroForm fields.
+/// </summary>
+public class FillableTableTests
+{
+    private static byte[] SampleFillableTable(PdfDocumentBuilder builder)
+    {
+        var rows = new[]
+        {
+            new FillableTableRow("Alice", new[]
+            {
+                new FillableTableCell("alice_email", FillableCellKind.Text, Value: "a@x.com"),
+                new FillableTableCell("alice_ok", FillableCellKind.CheckBox),
+            }),
+            new FillableTableRow("Bob", new[]
+            {
+                new FillableTableCell("bob_email", FillableCellKind.Text),
+                new FillableTableCell("bob_tier", FillableCellKind.Choice,
+                    Options: new[] { "Basic", "Pro" }, Tooltip: "Bob's tier"),
+            }),
+        };
+        return builder.FillableTable(new[] { "Email", "Flag" }, rows).SaveToBytes();
+    }
+
+    [Fact]
+    public void FillableTable_CreatesLiveFieldsPerCellWithCorrectTypes()
+    {
+        var pdf = SampleFillableTable(PdfDocumentBuilder.Create());
+
+        using var doc = PdfDocument.Open(pdf);
+        var form = doc.GetAcroForm()!;
+        var names = form.Fields.Select(f => f.FullName).ToList();
+        names.Should().Contain(new[] { "alice_email", "alice_ok", "bob_email", "bob_tier" });
+
+        form.FindField("alice_email")!.FieldType.Should().Be(PdfFieldType.Text);
+        form.FindField("alice_ok")!.FieldType.Should().Be(PdfFieldType.Button);
+        form.FindField("bob_tier")!.FieldType.Should().Be(PdfFieldType.Choice);
+    }
+
+    [Fact]
+    public void FillableTable_RendersHeadersAndRowLabels()
+    {
+        var pdf = SampleFillableTable(PdfDocumentBuilder.Create());
+        using var doc = PdfDocument.Open(pdf);
+        var text = string.Join("\n", doc.GetPages().Select(p => new TextExtractor(p).ExtractText()));
+        foreach (var s in new[] { "Email", "Flag", "Alice", "Bob" })
+            text.Should().Contain(s);
+    }
+
+    [Fact]
+    public void FillableTable_WorksUnderTaggingAndRoundTrips()
+    {
+        var pdf = SampleFillableTable(PdfDocumentBuilder.Create().Tagged().Language("en-US"));
+        var act = () => PdfDocument.Open(pdf).Dispose();
+        act.Should().NotThrow();
+
+        using var doc = PdfDocument.Open(pdf);
+        doc.GetAcroForm()!.Fields.Should().NotBeEmpty();
+        doc.Catalog.GetOptional("StructTreeRoot").Should().NotBeNull();
+    }
+}

--- a/Pdfe.Core.Tests/PublicApi/Pdfe.Core.approved.txt
+++ b/Pdfe.Core.Tests/PublicApi/Pdfe.Core.approved.txt
@@ -1,5 +1,26 @@
 namespace Pdfe.Core.Authoring
 {
+    public enum FillableCellKind
+    {
+        Text = 0,
+        CheckBox = 1,
+        Choice = 2,
+    }
+    public sealed class FillableTableCell : System.IEquatable<Pdfe.Core.Authoring.FillableTableCell>
+    {
+        public FillableTableCell(string FieldName, Pdfe.Core.Authoring.FillableCellKind Kind = 0, string? Value = null, System.Collections.Generic.IReadOnlyList<string>? Options = null, string? Tooltip = null) { }
+        public string FieldName { get; init; }
+        public Pdfe.Core.Authoring.FillableCellKind Kind { get; init; }
+        public System.Collections.Generic.IReadOnlyList<string>? Options { get; init; }
+        public string? Tooltip { get; init; }
+        public string? Value { get; init; }
+    }
+    public sealed class FillableTableRow : System.IEquatable<Pdfe.Core.Authoring.FillableTableRow>
+    {
+        public FillableTableRow(string Label, System.Collections.Generic.IReadOnlyList<Pdfe.Core.Authoring.FillableTableCell> Cells) { }
+        public System.Collections.Generic.IReadOnlyList<Pdfe.Core.Authoring.FillableTableCell> Cells { get; init; }
+        public string Label { get; init; }
+    }
     public enum FontFamily
     {
         SansSerif = 0,
@@ -51,6 +72,7 @@ namespace Pdfe.Core.Authoring
         public Pdfe.Core.Authoring.PdfDocumentBuilder DateField(string label, string? fieldName = null, string format = "yyyy-mm-dd", bool required = false, string? tooltip = null) { }
         public Pdfe.Core.Authoring.PdfDocumentBuilder DefaultFont(Pdfe.Core.Graphics.PdfFont font) { }
         public Pdfe.Core.Authoring.PdfDocumentBuilder Dropdown(string label, System.Collections.Generic.IEnumerable<string> options, string? fieldName = null, string? defaultValue = null, string? tooltip = null) { }
+        public Pdfe.Core.Authoring.PdfDocumentBuilder FillableTable(System.Collections.Generic.IReadOnlyList<string> columnHeaders, System.Collections.Generic.IReadOnlyList<Pdfe.Core.Authoring.FillableTableRow> rows, double[]? columnWeights = null, double labelColumnWeight = 1) { }
         public Pdfe.Core.Authoring.PdfDocumentBuilder Heading(string text, int level = 1, Pdfe.Core.Authoring.TextStyle? style = null) { }
         public Pdfe.Core.Authoring.PdfDocumentBuilder HorizontalRule(double thickness = 0.5, Pdfe.Core.Graphics.PdfColor? color = default) { }
         public Pdfe.Core.Authoring.PdfDocumentBuilder KeyValue(string label, string value, double labelWidth = 0.3) { }

--- a/Pdfe.Core/Authoring/FillableTableModels.cs
+++ b/Pdfe.Core/Authoring/FillableTableModels.cs
@@ -1,0 +1,43 @@
+namespace Pdfe.Core.Authoring;
+
+/// <summary>
+/// The kind of interactive widget a <see cref="FillableTableCell"/> renders as
+/// inside <see cref="PdfDocumentBuilder.FillableTable"/>.
+/// </summary>
+public enum FillableCellKind
+{
+    /// <summary>A single-line text input.</summary>
+    Text,
+
+    /// <summary>A checkbox (checked when the cell's value is truthy).</summary>
+    CheckBox,
+
+    /// <summary>A dropdown (combo box) populated from <see cref="FillableTableCell.Options"/>.</summary>
+    Choice,
+}
+
+/// <summary>
+/// One cell of a <see cref="FillableTableRow"/>: an interactive form field placed
+/// within a table cell by <see cref="PdfDocumentBuilder.FillableTable"/>.
+/// </summary>
+/// <param name="FieldName">The AcroForm field name (must be unique in the document).</param>
+/// <param name="Kind">Which widget to render.</param>
+/// <param name="Value">The field's default value (for checkboxes, a truthy string checks it).</param>
+/// <param name="Options">The dropdown options when <see cref="Kind"/> is <see cref="FillableCellKind.Choice"/>.</param>
+/// <param name="Tooltip">The field's accessible name (<c>/TU</c>); shown by AT and on hover.</param>
+public sealed record FillableTableCell(
+    string FieldName,
+    FillableCellKind Kind = FillableCellKind.Text,
+    string? Value = null,
+    IReadOnlyList<string>? Options = null,
+    string? Tooltip = null);
+
+/// <summary>
+/// One body row of a <see cref="PdfDocumentBuilder.FillableTable"/>: a row header
+/// label plus an interactive field per data column.
+/// </summary>
+/// <param name="Label">The row header text (rendered in the first, non-editable column).</param>
+/// <param name="Cells">The editable cells, in column order.</param>
+public sealed record FillableTableRow(
+    string Label,
+    IReadOnlyList<FillableTableCell> Cells);

--- a/Pdfe.Core/Authoring/PdfDocumentBuilder.cs
+++ b/Pdfe.Core/Authoring/PdfDocumentBuilder.cs
@@ -417,6 +417,148 @@ public sealed class PdfDocumentBuilder
     }
 
     /// <summary>
+    /// Adds a table whose body cells are interactive AcroForm fields — a fillable
+    /// grid. The first column is a non-editable row header; each remaining column
+    /// holds a text input, checkbox, or dropdown (per <see cref="FillableTableCell.Kind"/>).
+    /// Mirrors <see cref="Table"/>'s layout (column weights, gridlines, pagination)
+    /// but places live fields instead of static text.
+    /// </summary>
+    /// <param name="columnHeaders">The data-column headers (excludes the row-label column).</param>
+    /// <param name="rows">The body rows.</param>
+    /// <param name="columnWeights">
+    /// Relative widths for the data columns; null distributes evenly. The row-label
+    /// column uses <paramref name="labelColumnWeight"/>.
+    /// </param>
+    /// <param name="labelColumnWeight">Relative width of the leading row-label column.</param>
+    public PdfDocumentBuilder FillableTable(
+        IReadOnlyList<string> columnHeaders,
+        IReadOnlyList<FillableTableRow> rows,
+        double[]? columnWeights = null,
+        double labelColumnWeight = 1.0)
+    {
+        ArgumentNullException.ThrowIfNull(columnHeaders);
+        ArgumentNullException.ThrowIfNull(rows);
+        EnsurePage();
+
+        int dataCols = columnHeaders.Count;
+        int cols = dataCols + 1; // leading row-label column
+
+        var rawWeights = new double[cols];
+        rawWeights[0] = labelColumnWeight <= 0 ? 1.0 : labelColumnWeight;
+        for (int c = 0; c < dataCols; c++)
+            rawWeights[c + 1] = (columnWeights != null && c < columnWeights.Length) ? columnWeights[c] : 1.0;
+        var weights = NormalizeWeights(rawWeights, cols);
+
+        var tableElem = _tagging?.AddElement("Table");
+
+        // Header row (static text): empty corner + the column headers.
+        var headerCells = new (string, TextStyle)[cols];
+        var headerStyle = TextStyle.Body.AsBold().WithSpaceAfter(0);
+        headerCells[0] = (string.Empty, headerStyle);
+        for (int c = 0; c < dataCols; c++)
+            headerCells[c + 1] = (columnHeaders[c] ?? string.Empty, headerStyle);
+        var headerTr = _tagging?.AddElement("TR", tableElem);
+        Row(headerCells, weights, cellPadding: 4, spaceAfter: 0, gridLines: true, rowParent: headerTr, cellStructType: "TH");
+
+        foreach (var row in rows)
+            FillableRow(row, weights, tableElem);
+
+        _cursorY -= TextStyle.Body.SpaceAfter;
+        return this;
+    }
+
+    /// <summary>Renders one body row of a <see cref="FillableTable"/>: a text row
+    /// header followed by an interactive field per data column.</summary>
+    private void FillableRow(
+        FillableTableRow row,
+        double[] weights,
+        Tagging.StructureTreeBuilder.StructElem? tableElem)
+    {
+        EnsurePage();
+
+        int cols = weights.Length;
+        var colWidths = new double[cols];
+        for (int c = 0; c < cols; c++) colWidths[c] = weights[c] * ContentWidth;
+
+        const double cellPadding = 4;
+        var labelFont = TextStyle.Body.AsBold().ResolveFont();
+        var fieldFont = TextStyle.Body.ResolveFont();
+        double fieldHeight = fieldFont.LineHeight + 6;
+        double rowHeight = fieldHeight + 2 * cellPadding;
+        EnsureSpace(rowHeight);
+
+        double top = _cursorY;
+        var gridPen = new PdfPen(PdfColor.FromGray(0.7), 0.5);
+        var trElem = _tagging?.AddElement("TR", tableElem);
+
+        // Column 0: the row header (static text, tagged TH).
+        double x = ContentLeft;
+        bool tagCell = _tagging != null && trElem != null;
+        if (tagCell)
+        {
+            var th = _tagging!.AddElement("TH", trElem);
+            int mcid = _tagging.AllocateMcid(th, _currentPageNumber);
+            _graphics!.BeginMarkedContent("TH", mcid);
+        }
+        double baseline = top - cellPadding - labelFont.Ascender;
+        _graphics!.DrawString(row.Label ?? string.Empty, labelFont, PdfBrush.Black, x + cellPadding, baseline);
+        if (tagCell) _graphics!.EndMarkedContent();
+        DrawCellBorder(x, top, colWidths[0], rowHeight, gridPen);
+        x += colWidths[0];
+
+        // Data columns: a live field per cell.
+        var cells = row.Cells;
+        for (int c = 0; c < cols - 1; c++)
+        {
+            double cw = colWidths[c + 1];
+            DrawCellBorder(x, top, cw, rowHeight, gridPen);
+
+            if (cells != null && c < cells.Count)
+            {
+                var cell = cells[c];
+                double fLeft = x + cellPadding;
+                double fRight = x + cw - cellPadding;
+                double fTop = top - cellPadding;
+                double fBottom = fTop - fieldHeight;
+
+                switch (cell.Kind)
+                {
+                    case FillableCellKind.CheckBox:
+                        double boxSize = fieldFont.Size;
+                        var boxRect = new PdfRectangle(fLeft, fTop - boxSize, fLeft + boxSize, fTop);
+                        TagFormField(_document.AddCheckBox(_currentPageNumber, boxRect, cell.FieldName,
+                            defaultChecked: IsCheckboxChecked(cell.Value), tooltip: cell.Tooltip));
+                        break;
+
+                    case FillableCellKind.Choice:
+                        var choiceRect = new PdfRectangle(fLeft, fBottom, fRight, fTop);
+                        TagFormField(_document.AddChoiceField(_currentPageNumber, choiceRect, cell.FieldName,
+                            cell.Options ?? Array.Empty<string>(), defaultValue: cell.Value, tooltip: cell.Tooltip));
+                        break;
+
+                    default:
+                        var textRect = new PdfRectangle(fLeft, fBottom, fRight, fTop);
+                        TagFormField(_document.AddTextField(_currentPageNumber, textRect, cell.FieldName,
+                            defaultValue: cell.Value, tooltip: cell.Tooltip));
+                        break;
+                }
+            }
+            x += cw;
+        }
+
+        _cursorY = top - rowHeight;
+    }
+
+    private void DrawCellBorder(double left, double top, double width, double height, PdfPen pen) =>
+        DrawArtifact(() => _graphics!.DrawRectangle(left, top - height, width, height, fill: null, stroke: pen));
+
+    private static readonly HashSet<string> CheckboxTruthy =
+        new(StringComparer.OrdinalIgnoreCase) { "true", "yes", "y", "1", "x", "checked", "on" };
+
+    private static bool IsCheckboxChecked(string? value) =>
+        value != null && CheckboxTruthy.Contains(value.Trim());
+
+    /// <summary>
     /// Escape hatch: draw directly with <see cref="PdfGraphics"/>. The callback
     /// receives the current page's graphics and a layout snapshot (content
     /// box + cursor). Advance the cursor yourself via the returned height by

--- a/Pdfe.Core/Pdfe.Core.csproj
+++ b/Pdfe.Core/Pdfe.Core.csproj
@@ -10,7 +10,7 @@
 
   <PropertyGroup>
     <PackageId>Pdfe.Core</PackageId>
-    <Version>2.6.0</Version>
+    <Version>2.7.0</Version>
     <Authors>Marc Jones</Authors>
     <Description>Pure-managed PDF parser, document model, and writer for .NET. Open/edit/save PDFs, extract text/links/annotations/forms, and perform true glyph-level redaction. No native dependencies; cross-platform and trim/AOT-friendlier.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Pdfe.Rendering/Pdfe.Rendering.csproj
+++ b/Pdfe.Rendering/Pdfe.Rendering.csproj
@@ -10,7 +10,7 @@
 
   <PropertyGroup>
     <PackageId>Pdfe.Rendering</PackageId>
-    <Version>2.6.0</Version>
+    <Version>2.7.0</Version>
     <Authors>Marc Jones</Authors>
     <Description>Pure-managed, SkiaSharp-based PDF render API for .NET. Render pages to SKBitmap or PNG with DPI/clip/rotation support and cancellable rendering. Framework-neutral engine behind Pdfe.Avalonia; no native PDFium. Cross-platform, trim/AOT-friendlier.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
Cuts **v2.7.0** (MINOR, additive). Bundles:
- **FillableTable** — table cells as interactive AcroForm fields (text/checkbox/dropdown).
- **PDF/UA hardening (#407)** — artifact marking (rules/borders/grid lines), form-field tagging via /OBJR, nested Table→TR→TD/TH.

Trio → 2.7.0; CHANGELOG [2.7.0]; FillableTable tests added; public-API baseline regenerated. Full suite green (**2887**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)