### PR TITLE
feat(authoring): bulleted/numbered lists with L/LI tagging (#407)

### DIFF
--- a/Pdfe.Core.Tests/Authoring/ListTests.cs
+++ b/Pdfe.Core.Tests/Authoring/ListTests.cs
@@ -1,0 +1,88 @@
+using System.Collections.Generic;
+using System.Linq;
+using AwesomeAssertions;
+using Pdfe.Core.Authoring;
+using Pdfe.Core.Document;
+using Pdfe.Core.Primitives;
+using Pdfe.Core.Text;
+using Xunit;
+
+namespace Pdfe.Core.Tests.Authoring;
+
+/// <summary>Tests for bulleted/numbered lists in the builder (#407).</summary>
+public class ListTests
+{
+    private static List<string> StructTypes(PdfDocument doc)
+    {
+        var types = new List<string>();
+        var rootObj = doc.Catalog.GetOptional("StructTreeRoot");
+        if (rootObj == null) return types;
+        void Walk(PdfObject? k)
+        {
+            if (k == null) return;
+            var r = doc.Resolve(k);
+            if (r is PdfArray arr) { foreach (var x in arr) Walk(x); return; }
+            if (r is PdfDictionary d)
+            {
+                var s = d.GetNameOrNull("S");
+                if (s != null) types.Add(s);
+                if (d.GetOptional("K") is { } kids) Walk(kids);
+            }
+        }
+        Walk((doc.Resolve(rootObj) as PdfDictionary)!.GetOptional("K"));
+        return types;
+    }
+
+    private static string Extract(byte[] pdf)
+    {
+        using var doc = PdfDocument.Open(pdf);
+        return string.Join("\n", doc.GetPages().Select(p => new TextExtractor(p).ExtractText()));
+    }
+
+    [Fact]
+    public void BulletList_RendersItems()
+    {
+        var pdf = PdfDocumentBuilder.Create()
+            .BulletList(new[] { "First item", "Second item", "Third item" })
+            .SaveToBytes();
+        var text = Extract(pdf);
+        foreach (var s in new[] { "First item", "Second item", "Third item" })
+            text.Should().Contain(s);
+    }
+
+    [Fact]
+    public void NumberedList_RendersMarkers()
+    {
+        var pdf = PdfDocumentBuilder.Create()
+            .NumberedList(new[] { "alpha", "beta" })
+            .SaveToBytes();
+        var text = Extract(pdf);
+        text.Should().Contain("1.");
+        text.Should().Contain("2.");
+        text.Should().Contain("alpha");
+    }
+
+    [Fact]
+    public void Tagged_List_EmitsLAndLi()
+    {
+        var pdf = PdfDocumentBuilder.Create().Tagged()
+            .BulletList(new[] { "one", "two" })
+            .SaveToBytes();
+        using var doc = PdfDocument.Open(pdf);
+        var types = StructTypes(doc);
+        types.Should().Contain("L");
+        types.Count(t => t == "LI").Should().Be(2);
+    }
+
+    [Fact]
+    public void List_LongItem_WrapsAndPaginates()
+    {
+        var longItem = string.Join(" ", Enumerable.Repeat("word", 400));
+        var pdf = PdfDocumentBuilder.Create()
+            .BulletList(new[] { longItem, "short" })
+            .SaveToBytes();
+        using var doc = PdfDocument.Open(pdf);
+        doc.PageCount.Should().BeGreaterThanOrEqualTo(1);
+        Extract(pdf).Should().Contain("short");
+    }
+}

--- a/Pdfe.Core.Tests/PublicApi/Pdfe.Core.approved.txt
+++ b/Pdfe.Core.Tests/PublicApi/Pdfe.Core.approved.txt
@@ -67,6 +67,7 @@ namespace Pdfe.Core.Authoring
         public int PageCount { get; }
         public Pdfe.Core.Authoring.PdfDocumentBuilder Author(string author) { }
         public Pdfe.Core.Document.PdfDocument Build() { }
+        public Pdfe.Core.Authoring.PdfDocumentBuilder BulletList(System.Collections.Generic.IEnumerable<string> items, string bullet = "•", Pdfe.Core.Authoring.TextStyle? style = null) { }
         public Pdfe.Core.Authoring.PdfDocumentBuilder CheckBox(string label, string? fieldName = null, bool checkedByDefault = false, string? tooltip = null) { }
         public Pdfe.Core.Authoring.PdfDocumentBuilder Custom(System.Action<Pdfe.Core.Graphics.PdfGraphics, Pdfe.Core.Authoring.LayoutContext> draw) { }
         public Pdfe.Core.Authoring.PdfDocumentBuilder DateField(string label, string? fieldName = null, string format = "yyyy-mm-dd", bool required = false, string? tooltip = null) { }
@@ -78,6 +79,7 @@ namespace Pdfe.Core.Authoring
         public Pdfe.Core.Authoring.PdfDocumentBuilder KeyValue(string label, string value, double labelWidth = 0.3) { }
         public Pdfe.Core.Authoring.PdfDocumentBuilder Keywords(string keywords) { }
         public Pdfe.Core.Authoring.PdfDocumentBuilder Language(string bcp47) { }
+        public Pdfe.Core.Authoring.PdfDocumentBuilder NumberedList(System.Collections.Generic.IEnumerable<string> items, Pdfe.Core.Authoring.TextStyle? style = null) { }
         public Pdfe.Core.Authoring.PdfDocumentBuilder PageBreak() { }
         public Pdfe.Core.Authoring.PdfDocumentBuilder Paragraph(string text, Pdfe.Core.Authoring.TextStyle? style = null) { }
         public void Save(System.IO.Stream stream) { }

--- a/Pdfe.Core/Authoring/PdfDocumentBuilder.cs
+++ b/Pdfe.Core/Authoring/PdfDocumentBuilder.cs
@@ -97,11 +97,11 @@ public sealed class PdfDocumentBuilder
         <= 1 => "H1", 2 => "H2", 3 => "H3", _ => "H4"
     };
 
-    private void BeginTag(string structType)
+    private void BeginTag(string structType, Tagging.StructureTreeBuilder.StructElem? parent = null)
     {
         if (_tagging == null) return;
         _openTag = structType;
-        _openElem = _tagging.AddElement(structType);
+        _openElem = _tagging.AddElement(structType, parent);
         OpenMarkedContent();
     }
 
@@ -280,6 +280,61 @@ public sealed class PdfDocumentBuilder
         }
 
         _cursorY -= TextStyle.Body.SpaceAfter;
+        return this;
+    }
+
+    /// <summary>Adds a bulleted list (one item per line, word-wrapped).</summary>
+    public PdfDocumentBuilder BulletList(IEnumerable<string> items, string bullet = "•", TextStyle? style = null)
+    {
+        ArgumentNullException.ThrowIfNull(items);
+        return ListCore(items, _ => bullet, style);
+    }
+
+    /// <summary>Adds a numbered list (1., 2., 3., …).</summary>
+    public PdfDocumentBuilder NumberedList(IEnumerable<string> items, TextStyle? style = null)
+    {
+        ArgumentNullException.ThrowIfNull(items);
+        return ListCore(items, i => $"{i + 1}.", style);
+    }
+
+    /// <summary>
+    /// Renders a list. Each item gets a marker (drawn at the left) and word-wrapped
+    /// body text indented past it. When tagging, emits L → LI per item.
+    /// </summary>
+    private PdfDocumentBuilder ListCore(IEnumerable<string> items, Func<int, string> marker, TextStyle? style)
+    {
+        var st = WithDefaultFont(style ?? TextStyle.Body);
+        var font = st.ResolveFont();
+        var brush = st.ResolveBrush();
+        double lineHeight = st.LineHeight;
+        const double indent = 18;
+
+        EnsurePage();
+        var listElem = _tagging?.AddElement("L");
+
+        int i = 0;
+        foreach (var item in items)
+        {
+            BeginTag("LI", listElem);          // opens marked content for this item
+            EnsureSpace(lineHeight);
+            double baseline = _cursorY - font.Ascender;
+            _graphics!.DrawString(marker(i), font, brush, ContentLeft, baseline);
+
+            var lines = WrapText(item ?? string.Empty, font, ContentWidth - indent).ToList();
+            bool firstLine = true;
+            foreach (var line in lines)
+            {
+                if (!firstLine) EnsureSpace(lineHeight);
+                double lineBaseline = _cursorY - font.Ascender;
+                _graphics!.DrawString(line, font, brush, ContentLeft + indent, lineBaseline);
+                _cursorY -= lineHeight;
+                firstLine = false;
+            }
+            EndTag();
+            i++;
+        }
+
+        _cursorY -= st.SpaceAfter;
         return this;
     }
 


### PR DESCRIPTION
`PdfDocumentBuilder.BulletList`/`NumberedList` — word-wrapped list items with a left marker + indented body; when `Tagged()`, emit `L → LI` per item (LI marked content reopens across page breaks). 4 new tests; full suite green (**2891**). Closes the list item of #407.

🤖 Generated with [Claude Code](https://claude.com/claude-code)