### PR TITLE
test(#350): in-memory operator + stream-filter coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
             -targetdir:coverage/report \
             -reporttypes:Cobertura
 
-      - name: Coverage Gate (Pdfe.Core >= 92.5%)
+      - name: Coverage Gate (Pdfe.Core >= 93%)
         # Ratcheted 92% -> 92.5% (#351) after adding in-memory authoring/font/
         # graphics tests (CI now measures ~93.0%, up from ~92.8%). CI installs
         # fonts-dejavu-core above so the embedding tests run deterministically.
@@ -142,7 +142,7 @@ jobs:
         #
         # reportgenerator's Cobertura output is named Cobertura.xml (not
         # coverage.cobertura.xml — that's coverlet's raw collector name).
-        run: scripts/check-coverage.sh coverage/report/Cobertura.xml 0.925 Pdfe.Core
+        run: scripts/check-coverage.sh coverage/report/Cobertura.xml 0.93 Pdfe.Core
 
       - name: Run Pdfe.Cli.Tests
         run: |

--- a/Pdfe.Core.Tests/Content/OperatorCoverageTests.cs
+++ b/Pdfe.Core.Tests/Content/OperatorCoverageTests.cs
@@ -1,0 +1,87 @@
+using System.Text;
+using AwesomeAssertions;
+using Pdfe.Core.Content;
+using Xunit;
+
+namespace Pdfe.Core.Tests.Content;
+
+/// <summary>
+/// Exercises every content-stream operator branch in ContentStreamParser (#350) —
+/// shading, clipping, marked content, compatibility, Type 3, color spaces — by
+/// parsing in-memory streams that contain them (these paths are otherwise only
+/// hit by the corpus tests that skip in CI).
+/// </summary>
+public class OperatorCoverageTests
+{
+    private static ContentStream Parse(string content) =>
+        new ContentStreamParser(Encoding.Latin1.GetBytes(content)).Parse();
+
+    [Fact]
+    public void Clipping_And_Shading_Operators_Parse()
+    {
+        // Clip both even-odd and nonzero, then a shading paint.
+        var cs = Parse("q 0 0 100 100 re W n /Sh1 sh Q\nq 0 0 50 50 re W* n Q\n");
+        cs.Operators.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public void Type3_GlyphMetrics_d0_d1_Parse()
+    {
+        // d0 (width only) and d1 (width + bbox).
+        var cs = Parse("750 0 d0\n750 0 0 0 700 700 d1\n");
+        cs.Operators.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public void MarkedContent_Operators_Parse()
+    {
+        var cs = Parse(
+            "/P <</MCID 0>> BDC BT /F1 12 Tf (hi) Tj ET EMC\n" +
+            "/Span BMC (x) Tj EMC\n" +
+            "/Pdfe /Tag DP\n/Pt 1 MP\n");
+        cs.Operators.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public void Compatibility_BX_EX_Parse()
+    {
+        var cs = Parse("BX /Unknown someop EX\nq Q\n");
+        cs.Operators.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public void ColorSpace_And_Color_Operators_Parse()
+    {
+        var cs = Parse(
+            "/CS0 CS /CS1 cs\n" +
+            "0.1 G 0.2 g\n0.1 0.2 0.3 RG 0.4 0.5 0.6 rg\n" +
+            "0 0 0 1 K 0 0 0 1 k\n" +
+            "0.5 SC 0.5 SCN 0.5 sc 0.5 scn\n");
+        cs.Operators.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public void GraphicsState_And_PathPaint_Operators_Parse()
+    {
+        var cs = Parse(
+            "q 1 0 0 1 10 10 cm 2 w 1 J 1 j 10 M [3 2] 0 d 1.0 ri 1 i /GS1 gs\n" +
+            "10 10 m 20 20 l 30 0 40 10 50 20 c 5 5 v 6 6 y h re\n" +
+            "0 0 10 10 re S s f F f* B B* b b* n Q\n");
+        cs.Operators.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public void Text_Operators_Parse()
+    {
+        var cs = Parse(
+            "BT /F1 12 Tf 14 TL 1 Tc 2 Tw 100 Tz 0 Tr 1 Ts 10 20 Td 5 6 TD " +
+            "1 0 0 1 7 8 Tm T* (a) Tj [(b) -10 (c)] TJ (d) ' 1 2 (e) \" ET\n");
+        cs.Operators.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public void XObject_Do_Parses()
+    {
+        Parse("q /Im1 Do Q\n").Operators.Should().NotBeEmpty();
+    }
+}

--- a/Pdfe.Core.Tests/Parsing/StreamFilterCoverageTests.cs
+++ b/Pdfe.Core.Tests/Parsing/StreamFilterCoverageTests.cs
@@ -1,0 +1,119 @@
+using System.IO;
+using System.IO.Compression;
+using System.Text;
+using AwesomeAssertions;
+using Pdfe.Core.Parsing;
+using Pdfe.Core.Primitives;
+using Xunit;
+
+namespace Pdfe.Core.Tests.Parsing;
+
+/// <summary>
+/// In-memory coverage for StreamDecompressor's filters and predictors (#350/#351)
+/// — these are otherwise mostly exercised only by the corpus, which skips in CI.
+/// </summary>
+public class StreamFilterCoverageTests
+{
+    private static byte[] Decode(string filter, byte[] data, PdfDictionary? parms = null)
+    {
+        var dict = new PdfDictionary();
+        dict.SetName("Filter", filter);
+        if (parms != null) dict["DecodeParms"] = parms;
+        dict.SetInt("Length", data.Length);
+        var s = new PdfStream(dict, data);
+        new StreamDecompressor().Decompress(s);
+        return s.DecodedData;
+    }
+
+    private static byte[] Zlib(byte[] data)
+    {
+        using var ms = new MemoryStream();
+        using (var z = new ZLibStream(ms, CompressionLevel.Optimal, true)) z.Write(data, 0, data.Length);
+        return ms.ToArray();
+    }
+
+    [Fact]
+    public void FlateDecode_RoundTrips()
+    {
+        var original = Encoding.ASCII.GetBytes("Hello, FlateDecode world! " + new string('x', 500));
+        Decode("FlateDecode", Zlib(original)).Should().Equal(original);
+        Decode("Fl", Zlib(original)).Should().Equal(original); // abbreviation
+    }
+
+    [Fact]
+    public void FlateDecode_WithPngPredictor_RoundTrips()
+    {
+        // 3 rows x 4 columns, 1 byte/sample, PNG predictor 12 (Up) on row data.
+        int columns = 4, rows = 3;
+        var raw = new byte[rows * (columns + 1)];
+        for (int r = 0; r < rows; r++)
+        {
+            raw[r * (columns + 1)] = 2; // PNG filter type "Up"
+            for (int c = 0; c < columns; c++) raw[r * (columns + 1) + 1 + c] = (byte)(r == 0 ? c : 1);
+        }
+        var parms = new PdfDictionary();
+        parms.SetInt("Predictor", 12);
+        parms.SetInt("Columns", columns);
+        var outp = Decode("FlateDecode", Zlib(raw), parms);
+        outp.Length.Should().Be(columns * rows);
+    }
+
+    [Fact]
+    public void FlateDecode_WithTiffPredictor_RoundTrips()
+    {
+        int columns = 4, rows = 2;
+        var raw = new byte[columns * rows];
+        for (int i = 0; i < raw.Length; i++) raw[i] = (byte)(i % columns);
+        var parms = new PdfDictionary();
+        parms.SetInt("Predictor", 2);
+        parms.SetInt("Columns", columns);
+        parms.SetInt("Colors", 1);
+        parms.SetInt("BitsPerComponent", 8);
+        Decode("FlateDecode", Zlib(raw), parms).Length.Should().Be(raw.Length);
+    }
+
+    [Fact]
+    public void ASCIIHexDecode_Works()
+    {
+        Decode("ASCIIHexDecode", Encoding.ASCII.GetBytes("48 65 6C 6C 6F>"))
+            .Should().Equal(Encoding.ASCII.GetBytes("Hello"));
+        Decode("AHx", Encoding.ASCII.GetBytes("4869>"))
+            .Should().Equal(Encoding.ASCII.GetBytes("Hi"));
+    }
+
+    [Fact]
+    public void RunLengthDecode_Works()
+    {
+        // 0x02 => copy next 3 literal bytes; 0x80 => EOD.
+        var data = new byte[] { 0x02, (byte)'A', (byte)'B', (byte)'C', 0x80 };
+        Decode("RunLengthDecode", data).Should().Equal(Encoding.ASCII.GetBytes("ABC"));
+        // 0xFE (257-254=3) => repeat next byte 3 times.
+        var rep = new byte[] { 0xFE, (byte)'Z', 0x80 };
+        Decode("RL", rep).Should().Equal(Encoding.ASCII.GetBytes("ZZZ"));
+    }
+
+    [Fact]
+    public void BrotliDecode_RoundTrips()
+    {
+        var original = Encoding.ASCII.GetBytes("brotli " + new string('y', 300));
+        using var ms = new MemoryStream();
+        using (var b = new BrotliStream(ms, CompressionLevel.Optimal, true)) b.Write(original, 0, original.Length);
+        Decode("BrotliDecode", ms.ToArray()).Should().Equal(original);
+    }
+
+    [Fact]
+    public void MultipleFilters_ChainInOrder()
+    {
+        // ASCIIHex then Flate: data is hex-encoded zlib of "chained".
+        var inner = Zlib(Encoding.ASCII.GetBytes("chained"));
+        var hex = new StringBuilder();
+        foreach (var b in inner) hex.Append(b.ToString("X2"));
+        hex.Append('>');
+        var dict = new PdfDictionary();
+        var filters = new PdfArray(); filters.Add((PdfObject)new PdfName("ASCIIHexDecode")); filters.Add((PdfObject)new PdfName("FlateDecode"));
+        dict["Filter"] = filters;
+        var s = new PdfStream(dict, Encoding.ASCII.GetBytes(hex.ToString()));
+        new StreamDecompressor().Decompress(s);
+        s.DecodedData.Should().Equal(Encoding.ASCII.GetBytes("chained"));
+    }
+}


### PR DESCRIPTION
Covers content-stream operators (shading/clipping/marked-content/compatibility/Type 3/colour) and StreamDecompressor filters/predictors with in-memory tests (these were corpus-only, and the corpus skips in CI). 15 new tests; full suite green (**2906**). Aimed at lifting CI coverage toward the 94% gate (#350/#351).

🤖 Generated with [Claude Code](https://claude.com/claude-code)