### PR TITLE
fix(tests): stop chronic headless GUI host crash (#363)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,9 +183,21 @@ jobs:
         # Skipped for library-only changes (see "Detect changed areas"); always
         # runs on main. Library changes that affect the GUI are caught by the
         # main run before any release is cut.
+        #
+        # Excludes the *_MatchesBaseline visual-regression tests: they render a
+        # heavy real-world PDF through the real Skia backend (UseHeadlessDrawing
+        # =false) and, after the rest of the suite's accumulated dispatcher load,
+        # reliably crash the headless test host — the root cause of the chronic
+        # #363 "host process exited unexpectedly" failures (the blame collector
+        # named whichever test happened to be on the dispatcher, e.g.
+        # CtrlS_SavesFile, which is why it looked random). They are
+        # environment-sensitive pixel-baseline tests, the same category excluded
+        # from the Pdfe.Rendering PR gate, and are owned by the nightly
+        # visual-regression job (visual-regression-nightly.yml), not this gate.
         if: steps.changes.outputs.gui == 'true' || github.ref == 'refs/heads/main'
         run: |
           xvfb-run -a dotnet test PdfEditor.Tests --no-build -c Debug \
+            --filter "FullyQualifiedName!~MatchesBaseline" \
             --logger "console;verbosity=normal" \
             --blame-hang-timeout 120000
 

--- a/.github/workflows/visual-regression-nightly.yml
+++ b/.github/workflows/visual-regression-nightly.yml
@@ -66,10 +66,17 @@ jobs:
             --filter "FullyQualifiedName~Visual" \
             --logger "console;verbosity=normal" || true
 
-      - name: Run PdfEditor AvaloniaFact Baseline Tests (headless)
+      - name: Run PdfEditor visual-regression baseline tests (headless)
+        # These pixel-baseline render tests (PdfViewerHeadlessRenderTests.*_
+        # MatchesBaseline) are excluded from the PR gate in ci.yml because they
+        # crash the headless host under the full suite's accumulated load (#363);
+        # this nightly job is their owner. NOTE: the filter matches the test
+        # name, not the [FixedAvaloniaFact] attribute — the old
+        # "FullyQualifiedName~AvaloniaFact" filter matched zero tests, so these
+        # had silently not been running at all.
         run: |
           xvfb-run -a dotnet test PdfEditor.Tests --no-build -c Release \
-            --filter "FullyQualifiedName~AvaloniaFact" \
+            --filter "FullyQualifiedName~MatchesBaseline" \
             --logger "console;verbosity=normal" \
             --blame-hang-timeout 180000 || true
 

--- a/PdfEditor.Tests/UI/KeyboardShortcutTests.cs
+++ b/PdfEditor.Tests/UI/KeyboardShortcutTests.cs
@@ -75,20 +75,16 @@ public class KeyboardShortcutTests
     /// <summary>
     /// Ctrl+S: Save file (only works when document is loaded).
     /// </summary>
-    // Quarantined on headless CI (#363) via framework-level SkipWhen, which is
-    // evaluated BEFORE the body runs (an in-body Assert.SkipWhen was too late —
-    // the test had already started on the dispatcher). This test uniquely drives
-    // a save -> success-toast whose auto-dismiss dispatcher activity can deadlock
-    // the Avalonia headless dispatcher under CI load; when it does, the dispatcher
-    // thread is starved so neither the per-test Timeout nor FlushDispatcherAsync
-    // can recover and the blame-hang collector kills the entire test host,
-    // failing unrelated changes. Flaky, not a real product failure; the
-    // Ctrl+S/save path is covered by RedactionServiceTests + automation-script
-    // tests. Still runs locally where it doesn't hang.
-    [FixedAvaloniaFact(Timeout = 15000,
-        Skip = "Flaky dispatcher deadlock under headless CI; covered by RedactionServiceTests + automation tests (#363).",
-        SkipWhen = nameof(IsHeadlessCi),
-        SkipType = typeof(KeyboardShortcutTests))]
+    // Previously quarantined on headless CI (#363): this test uniquely drives a
+    // save -> success-toast, and the toast's auto-dismiss used a wall-clock
+    // System.Timers.Timer whose Elapsed callback (on a ThreadPool thread, 5s
+    // later — often after the test had finished) marshaled a Dispatcher.InvokeAsync
+    // continuation into the headless dispatcher, deadlocking it under
+    // --blame-hang-timeout. Root-caused and fixed in MainWindow.OnToastRequested:
+    // the auto-dismiss now uses a single reusable UI-thread DispatcherTimer that
+    // cannot leak work past the dispatcher's lifetime, so this test is no longer
+    // flaky and runs on CI again.
+    [FixedAvaloniaFact(Timeout = 15000)]
     public async Task CtrlS_SavesFile()
     {
         // Arrange

--- a/PdfEditor/Views/MainWindow.axaml.cs
+++ b/PdfEditor/Views/MainWindow.axaml.cs
@@ -20,6 +20,16 @@ public partial class MainWindow : Window
     private PdfViewerControl? _pdfViewerControl;
     private readonly WindowSettings _windowSettings;
 
+    // Single reusable UI-thread timer for toast auto-dismiss. A DispatcherTimer
+    // (vs System.Timers.Timer) ticks on the dispatcher itself, so it stops when
+    // the dispatcher stops and never marshals a callback (Dispatcher.InvokeAsync)
+    // into a torn-down/foreign dispatcher. The old per-toast wall-clock timer
+    // posted its dismiss continuation 5s later from a ThreadPool thread — often
+    // after the owning test had finished — which deadlocked the headless
+    // dispatcher under --blame-hang-timeout and made GUI tests (e.g.
+    // CtrlS_SavesFile) flaky. See the KeyboardShortcutTests quarantine.
+    private DispatcherTimer? _toastTimer;
+
     public MainWindow()
     {
         InitializeComponent();
@@ -33,6 +43,9 @@ public partial class MainWindow : Window
         {
             _windowSettings.CaptureFrom(this);
             _windowSettings.Save();
+            // Cancel any pending toast auto-dismiss so nothing is left queued on
+            // the dispatcher when the window/test tears down.
+            _toastTimer?.Stop();
         };
 
         // Add keyboard handler for Ctrl+C
@@ -572,24 +585,35 @@ public partial class MainWindow : Window
             // Show the InfoBar
             infoBar.IsOpen = true;
 
-            // Auto-dismiss after 5 seconds
-            var timer = new System.Timers.Timer(5000)
-            {
-                AutoReset = false
-            };
-            timer.Elapsed += (s, args) =>
-            {
-                Dispatcher.UIThread.InvokeAsync(() =>
-                {
-                    infoBar.IsOpen = false;
-                    timer.Dispose();
-                });
-            };
-            timer.Start();
+            // Auto-dismiss after 5 seconds using a single reusable UI-thread
+            // timer. Restarting an existing timer (rather than spawning a new
+            // System.Timers.Timer per toast) means at most one pending dismiss
+            // exists, it runs on the dispatcher, and it cannot leak a callback
+            // past the dispatcher's lifetime — which is what made headless GUI
+            // tests flaky.
+            _toastTimer ??= CreateToastTimer(infoBar);
+            _toastTimer.Stop();
+            _toastTimer.Start();
         }
         catch (Exception ex)
         {
             System.Console.WriteLine($"Error displaying toast: {ex.Message}");
         }
+    }
+
+    /// <summary>
+    /// Build the reusable toast auto-dismiss timer. Ticks once (Stop() in the
+    /// handler), on the UI thread, so it is inherently bound to the dispatcher's
+    /// lifetime — no cross-thread marshaling, nothing left to drain at teardown.
+    /// </summary>
+    private DispatcherTimer CreateToastTimer(FluentAvalonia.UI.Controls.FAInfoBar infoBar)
+    {
+        var timer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(5) };
+        timer.Tick += (s, args) =>
+        {
+            timer.Stop();
+            infoBar.IsOpen = false;
+        };
+        return timer;
     }
 }


### PR DESCRIPTION
## Summary
Fixes the chronic #363 headless `PdfEditor.Tests` host crash ("host process exited unexpectedly"). The blame-hang collector named whichever test was on the dispatcher when the host tipped over — usually `CtrlS_SavesFile` — which disguised it as a flaky save test. There were **two independent causes**:

### 1. Real toast bug (the `CtrlS_SavesFile` culprit)
`MainWindow.OnToastRequested` auto-dismissed the success InfoBar with a wall-clock `System.Timers.Timer`. Its `Elapsed` callback fired on a **ThreadPool thread 5s later** (often after the owning test had finished) and marshaled a `Dispatcher.InvokeAsync` continuation into the headless dispatcher, deadlocking it under `--blame-hang-timeout`.

**Fix:** a single reusable **UI-thread `DispatcherTimer`** that ticks on the dispatcher and is stopped on window close — it can't leak work past the dispatcher's lifetime. `CtrlS_SavesFile` is **un-quarantined** and now runs + passes on CI.

### 2. The actual host-crash source
The `*_MatchesBaseline` visual-regression tests render a heavy real-world PDF through the **real Skia backend** (`UseHeadlessDrawing=false`) and, after the suite's accumulated dispatcher load, reliably crash the host (reproduced 2-for-2 locally, even at a 300s hang timeout). They're environment-sensitive pixel-baseline tests — the same category already excluded from the `Pdfe.Rendering` PR gate — so they're now **excluded from the `PdfEditor.Tests` PR gate** too.

They belong to the nightly visual-regression job, whose filter `FullyQualifiedName~AvaloniaFact` matched **zero** tests (it targeted the attribute name, not any FQN), so the baseline tests had silently never run nightly. **Fixed** the nightly filter to `~MatchesBaseline`.

## Verification
- `CtrlS_SavesFile` under CI conditions (`CI=true GITHUB_ACTIONS=true` + xvfb + blame-hang): **Passed [2 s]**, no longer skipped.
- Full GUI suite excluding `*_MatchesBaseline`: **753 passed, 0 failed, 6 skipped**, host intact.
- Full GUI suite *including* them: host crash at `PdfViewer_RendersBirthCertificate_MatchesBaseline` (2/2 runs).

Closes #363.

🤖 Generated with [Claude Code](https://claude.com/claude-code)