### PR TITLE
feat(rendering): implement dash + cover shading/operator render paths (#350)

### DIFF
--- a/Pdfe.Core.Tests/Content/OperatorCoverageTests.cs
+++ b/Pdfe.Core.Tests/Content/OperatorCoverageTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Text;
 using AwesomeAssertions;
 using Pdfe.Core.Content;
@@ -83,5 +84,54 @@ public class OperatorCoverageTests
     public void XObject_Do_Parses()
     {
         Parse("q /Im1 Do Q\n").Operators.Should().NotBeEmpty();
+    }
+
+    /// <summary>
+    /// The authoritative operator inventory (#350): a single stream exercising
+    /// every standard content-stream operator. Each must (a) survive parsing as a
+    /// <see cref="ContentOperator"/> and (b) survive a parse -> write -> parse
+    /// round-trip through <see cref="ContentStreamWriter"/>. This is the
+    /// regression guard that no operator is silently dropped on read or write.
+    /// </summary>
+    [Fact]
+    public void AuthoritativeOperatorInventory_AllStandardOperators_ParseAndRoundTrip()
+    {
+        var content = string.Join("\n", new[]
+        {
+            "q 1 0 0 1 10 10 cm 2 w 1 J 1 j 10 M [3 2] 0 d 1.0 ri 1 i /GS1 gs",
+            "10 10 m 20 20 l 30 0 40 10 50 20 c 5 5 v 6 6 y h 0 0 10 10 re",
+            "S s f F f* B B* b b* W n W*",
+            "/CS0 CS /CS1 cs 0.1 G 0.2 g 0.1 0.2 0.3 RG 0.4 0.5 0.6 rg " +
+            "0 0 0 1 K 0 0 0 1 k 0.5 SC 0.5 SCN 0.5 sc 0.5 scn",
+            "/Sh1 sh",
+            "BT /F1 12 Tf 14 TL 1 Tc 2 Tw 100 Tz 0 Tr 1 Ts 10 20 Td 5 6 TD " +
+            "1 0 0 1 7 8 Tm T* (a) Tj [(b) -10 (c)] TJ (d) ' 1 2 (e) \" ET",
+            "/P <</MCID 0>> BDC /Span BMC EMC EMC /Pt 1 MP /Tg /Val DP BX /Unknown EX",
+            "750 0 d0 750 0 0 0 700 700 d1",
+            "/Im1 Do",
+            "Q",
+        });
+
+        var expected = new[]
+        {
+            "q","cm","w","J","j","M","d","ri","i","gs",
+            "m","l","c","v","y","h","re",
+            "S","s","f","F","f*","B","B*","b","b*","W","n","W*",
+            "CS","cs","G","g","RG","rg","K","k","SC","SCN","sc","scn",
+            "sh",
+            "BT","Tf","TL","Tc","Tw","Tz","Tr","Ts","Td","TD","Tm","T*","Tj","TJ","'","\"","ET",
+            "BDC","BMC","EMC","MP","DP","BX","EX",
+            "d0","d1","Do","Q",
+        };
+
+        var parsed = Parse(content).Operators.Select(o => o.Name).ToHashSet();
+        foreach (var op in expected)
+            parsed.Should().Contain(op, "operator '{0}' must be recognized by the parser", op);
+
+        var bytes = new ContentStreamWriter().Write(Parse(content));
+        var roundTripped = new ContentStreamParser(bytes).Parse()
+            .Operators.Select(o => o.Name).ToHashSet();
+        foreach (var op in expected)
+            roundTripped.Should().Contain(op, "operator '{0}' must survive a write->parse round-trip", op);
     }
 }

--- a/Pdfe.Rendering.Tests/OperatorRenderCoverageTests.cs
+++ b/Pdfe.Rendering.Tests/OperatorRenderCoverageTests.cs
@@ -1,0 +1,205 @@
+using AwesomeAssertions;
+using Pdfe.Core.Document;
+using SkiaSharp;
+using System.IO;
+using System.Text;
+using Xunit;
+
+namespace Pdfe.Rendering.Tests;
+
+/// <summary>
+/// Render-OUTPUT coverage for operators whose dispatch existed but whose visual
+/// effect was never asserted (#350): the shading operator <c>sh</c> (axial /
+/// radial gradients, which were silently no-ops in prior tests because the test
+/// PDFs carried no <c>/Shading</c> resource) and the dash operator <c>d</c>
+/// (previously parsed but ignored by the renderer). These tests assert actual
+/// pixels, not just "renders without error".
+/// </summary>
+public class OperatorRenderCoverageTests
+{
+    private const double Scale = 150.0 / 72.0;   // default render DPI is 150
+
+    private static int Px(double userX) => (int)(userX * Scale);
+    private static int Py(SKBitmap b, double userY) => b.Height - (int)(userY * Scale);
+
+    // ---- Shading (sh) ---------------------------------------------------
+
+    [Fact]
+    public void Sh_AxialShading_PaintsLeftToRightGradient()
+    {
+        // /Sh1 is an axial (Type 2) gradient: red at the left edge -> blue at the
+        // right edge, spanning the page. `sh` with no clip fills the whole page.
+        var pdf = CreatePdfWithShadings("/Sh1 sh");
+        using var doc = PdfDocument.Open(pdf);
+        using var bmp = new SkiaRenderer().RenderPage(doc.GetPage(1));
+
+        var left = bmp.GetPixel(Px(30), Py(bmp, 396));
+        var right = bmp.GetPixel(Px(582), Py(bmp, 396));
+
+        left.Red.Should().BeGreaterThan(left.Blue,
+            "the left edge of a red->blue axial gradient must be red-dominant");
+        right.Blue.Should().BeGreaterThan(right.Red,
+            "the right edge of a red->blue axial gradient must be blue-dominant");
+    }
+
+    [Fact]
+    public void Sh_RadialShading_PaintsCenterToEdgeGradient()
+    {
+        // /Sh2 is a radial (Type 3) gradient: yellow at the center -> green at the
+        // outer radius.
+        var pdf = CreatePdfWithShadings("/Sh2 sh");
+        using var doc = PdfDocument.Open(pdf);
+        using var bmp = new SkiaRenderer().RenderPage(doc.GetPage(1));
+
+        var center = bmp.GetPixel(Px(306), Py(bmp, 396));
+        var edge = bmp.GetPixel(Px(306), Py(bmp, 110));   // ~286 user-units below center, near r1=300
+
+        ((int)center.Red).Should().BeGreaterThan(150, "center of a yellow->green radial gradient is yellow (red high)");
+        ((int)center.Red).Should().BeGreaterThan(edge.Red + 30,
+            "red must fall off from the yellow center toward the green edge");
+    }
+
+    [Fact]
+    public void Sh_WithClipping_RestrictsGradientToClipRegion()
+    {
+        // Clip to a 120x120 box in the lower-left, then paint the axial gradient.
+        // Pixels inside the clip are painted; pixels well outside stay white.
+        var pdf = CreatePdfWithShadings("q 20 20 120 120 re W n /Sh1 sh Q");
+        using var doc = PdfDocument.Open(pdf);
+        using var bmp = new SkiaRenderer().RenderPage(doc.GetPage(1));
+
+        var inside = bmp.GetPixel(Px(80), Py(bmp, 80));
+        var outside = bmp.GetPixel(Px(400), Py(bmp, 400));
+
+        // Inside the clip the gradient is painted (not white).
+        (inside.Red < 245 || inside.Green < 245 || inside.Blue < 245).Should().BeTrue(
+            "the gradient must be painted inside the clip region");
+        outside.Should().Be(SKColors.White, "the gradient must not paint outside the clip region");
+    }
+
+    [Fact]
+    public void Sh_MissingShadingResource_DoesNotThrowAndLeavesPageBlank()
+    {
+        var pdf = CreatePdfWithShadings("/DoesNotExist sh");
+        using var doc = PdfDocument.Open(pdf);
+        using var bmp = new SkiaRenderer().RenderPage(doc.GetPage(1));
+
+        bmp.GetPixel(Px(306), Py(bmp, 396)).Should().Be(SKColors.White,
+            "an unresolved shading name is a no-op, leaving the page white");
+    }
+
+    // ---- Dash pattern (d) ----------------------------------------------
+
+    [Fact]
+    public void Dash_BreaksStrokeIntoGaps_ComparedToSolidLine()
+    {
+        // Same thick horizontal line, once solid and once dashed. The dashed line
+        // must leave gaps -> measurably fewer painted pixels along the row.
+        const string geom = "0 G 6 w 100 400 m 500 400 l S";
+        int solidDark = CountDarkAlongRow("[] 0 d " + geom, 400, 100, 500);
+        int dashedDark = CountDarkAlongRow("[12 12] 0 d " + geom, 400, 100, 500);
+
+        solidDark.Should().BeGreaterThan(0, "the solid control line must paint pixels");
+        dashedDark.Should().BeGreaterThan(0, "a dashed line still paints its 'on' segments");
+        dashedDark.Should().BeLessThan((int)(solidDark * 0.8),
+            "a [12 12] dash must leave gaps, painting far fewer pixels than the solid line");
+    }
+
+    [Fact]
+    public void Dash_EmptyArray_RendersSolidLine()
+    {
+        // An empty dash array resets to solid: dashing after `[] 0 d` paints a full
+        // line (no gaps), matching a never-dashed control.
+        const string geom = "0 G 6 w 100 300 m 500 300 l S";
+        int control = CountDarkAlongRow(geom, 300, 100, 500);
+        int reset = CountDarkAlongRow("[5 5] 0 d [] 0 d " + geom, 300, 100, 500);
+
+        reset.Should().BeGreaterThan((int)(control * 0.9),
+            "an empty dash array must produce a solid line again");
+    }
+
+    /// <summary>Count dark (stroked) pixels along the device row of a user-space horizontal line.</summary>
+    private static int CountDarkAlongRow(string content, double userY, double userX0, double userX1)
+    {
+        var pdf = CreatePdfWithShadings(content);
+        using var doc = PdfDocument.Open(pdf);
+        using var bmp = new SkiaRenderer().RenderPage(doc.GetPage(1));
+        int row = Py(bmp, userY);
+        int dark = 0;
+        for (int x = Px(userX0); x <= Px(userX1) && x < bmp.Width; x++)
+        {
+            // scan a few rows to be robust to the line's device thickness/AA
+            for (int dy = -3; dy <= 3; dy++)
+            {
+                int y = row + dy;
+                if (y < 0 || y >= bmp.Height) continue;
+                if (bmp.GetPixel(x, y).Red < 128) { dark++; break; }
+            }
+        }
+        return dark;
+    }
+
+    // ---- PDF builder with /Shading resources ---------------------------
+
+    /// <summary>
+    /// Minimal single-page PDF whose page Resources include two shadings:
+    /// /Sh1 = axial red->blue across the page, /Sh2 = radial yellow(center)->green(edge).
+    /// </summary>
+    private static byte[] CreatePdfWithShadings(string content)
+    {
+        using var ms = new MemoryStream();
+        using var w = new StreamWriter(ms, Encoding.ASCII, leaveOpen: true) { NewLine = "\n" };
+        w.WriteLine("%PDF-1.4");
+        w.Flush();
+
+        var offsets = new long[8];
+
+        void Obj(int n, string body)
+        {
+            offsets[n] = ms.Position;
+            w.WriteLine($"{n} 0 obj");
+            w.WriteLine(body);
+            w.WriteLine("endobj");
+            w.Flush();
+        }
+
+        Obj(1, "<< /Type /Catalog /Pages 2 0 R >>");
+        Obj(2, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+        Obj(3, "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R " +
+               "/Resources << /Font << /F1 5 0 R >> /Shading << /Sh1 6 0 R /Sh2 7 0 R >> >> >>");
+
+        offsets[4] = ms.Position;
+        w.WriteLine("4 0 obj");
+        w.WriteLine($"<< /Length {content.Length} >>");
+        w.WriteLine("stream");
+        w.Write(content);
+        w.WriteLine();
+        w.WriteLine("endstream");
+        w.WriteLine("endobj");
+        w.Flush();
+
+        Obj(5, "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>");
+        // Axial (Type 2) red -> blue, left to right across the page mid-line.
+        Obj(6, "<< /ShadingType 2 /ColorSpace /DeviceRGB /Coords [0 396 612 396] /Domain [0 1] " +
+               "/Function << /FunctionType 2 /Domain [0 1] /C0 [1 0 0] /C1 [0 0 1] /N 1 >> " +
+               "/Extend [true true] >>");
+        // Radial (Type 3) yellow (center, r0=0) -> green (edge, r1=300).
+        Obj(7, "<< /ShadingType 3 /ColorSpace /DeviceRGB /Coords [306 396 0 306 396 300] /Domain [0 1] " +
+               "/Function << /FunctionType 2 /Domain [0 1] /C0 [1 1 0] /C1 [0 1 0] /N 1 >> " +
+               "/Extend [true true] >>");
+
+        long xref = ms.Position;
+        w.WriteLine("xref");
+        w.WriteLine("0 8");
+        w.WriteLine("0000000000 65535 f ");
+        for (int i = 1; i <= 7; i++)
+            w.WriteLine($"{offsets[i]:D10} 00000 n ");
+        w.WriteLine("trailer");
+        w.WriteLine("<< /Root 1 0 R /Size 8 >>");
+        w.WriteLine("startxref");
+        w.WriteLine(xref.ToString());
+        w.WriteLine("%%EOF");
+        w.Flush();
+        return ms.ToArray();
+    }
+}

--- a/Pdfe.Rendering/SkiaRenderer.cs
+++ b/Pdfe.Rendering/SkiaRenderer.cs
@@ -336,7 +336,11 @@ internal class RenderContext
                     _state.MiterLimit = (float)ParseNumber(operands[0]);
                 break;
             case "d":
-                // Dash pattern - for now just ignore (implement later if needed)
+                // Dash pattern: `[ dashArray ] dashPhase d`. The array tokenizes
+                // as separate "[", numbers..., "]" operands followed by the phase,
+                // e.g. [3 2] 0 d -> ["[","3","2","]","0"]. An empty array [] is a
+                // solid line. ISO 32000-1 §8.4.3.6.
+                SetDashPattern(operands);
                 break;
             case "ri":
                 // Rendering intent - no effect on rendering for now
@@ -751,6 +755,67 @@ internal class RenderContext
 
     #region Path Painting
 
+    /// <summary>
+    /// Parse a PDF dash specification (`[ dashArray ] dashPhase d`) into graphics
+    /// state. The array tokenizes as separate "[" numbers… "]" operands followed
+    /// by the phase. An empty array (or all-zero intervals) means a solid line.
+    /// ISO 32000-1 §8.4.3.6.
+    /// </summary>
+    private void SetDashPattern(List<string> operands)
+    {
+        var intervals = new List<float>();
+        int closeIdx = -1;
+        bool inArray = false;
+        for (int i = 0; i < operands.Count; i++)
+        {
+            var t = operands[i];
+            if (t == "[") { inArray = true; continue; }
+            if (t == "]") { inArray = false; closeIdx = i; continue; }
+            if (inArray &&
+                float.TryParse(t, NumberStyles.Float, CultureInfo.InvariantCulture, out var v) && v >= 0)
+                intervals.Add(v);
+        }
+
+        // The phase is the operand immediately after the closing ']'.
+        float phase = (closeIdx >= 0 && closeIdx + 1 < operands.Count)
+            ? (float)ParseNumber(operands[closeIdx + 1])
+            : 0f;
+
+        if (intervals.Count == 0 || intervals.All(v => v <= 0))
+        {
+            _state.DashArray = null;   // solid line
+            _state.DashPhase = 0f;
+        }
+        else
+        {
+            _state.DashArray = intervals.ToArray();
+            _state.DashPhase = phase;
+        }
+    }
+
+    /// <summary>
+    /// Build the Skia dash <see cref="SKPathEffect"/> for the current state, or
+    /// null for a solid line. Skia requires an even number of positive intervals;
+    /// PDF allows an odd-length array (it repeats), so we double it.
+    /// </summary>
+    private SKPathEffect? CreateDashEffect()
+    {
+        var arr = _state.DashArray;
+        if (arr == null || arr.Length == 0) return null;
+
+        var intervals = arr;
+        if (intervals.Length % 2 != 0)
+        {
+            intervals = new float[arr.Length * 2];
+            Array.Copy(arr, 0, intervals, 0, arr.Length);
+            Array.Copy(arr, 0, intervals, arr.Length, arr.Length);
+        }
+        if (intervals.All(v => v <= 0)) return null;
+
+        try { return SKPathEffect.CreateDash(intervals, _state.DashPhase); }
+        catch { return null; }   // never let a degenerate dash array abort rendering
+    }
+
     private void StrokePath()
     {
         if (_currentPath == null) return;
@@ -776,6 +841,9 @@ internal class RenderContext
             BlendMode = _state.BlendMode,
             IsAntialias = _options.AntiAlias
         };
+
+        using var dash = CreateDashEffect();
+        if (dash != null) paint.PathEffect = dash;
 
         _canvas.DrawPath(_currentPath, paint);
         _currentPath.Dispose();
@@ -841,7 +909,9 @@ internal class RenderContext
             BlendMode = _state.BlendMode,
             IsAntialias = _options.AntiAlias
         })
+        using (var dash = CreateDashEffect())
         {
+            if (dash != null) strokePaint.PathEffect = dash;
             _canvas.DrawPath(_currentPath, strokePaint);
         }
 
@@ -3742,6 +3812,10 @@ internal class GraphicsState
     public string FillColorSpace { get; set; } = "DeviceGray";
     public string StrokeColorSpace { get; set; } = "DeviceGray";
     public SKBlendMode BlendMode { get; set; } = SKBlendMode.SrcOver;
+    // Dash pattern (PDF `d` operator): intervals in user-space units and a phase
+    // offset. Null/empty means a solid line. ISO 32000-1 §8.4.3.6.
+    public float[]? DashArray { get; set; }
+    public float DashPhase { get; set; }
 
     public GraphicsState Clone()
     {
@@ -3757,7 +3831,9 @@ internal class GraphicsState
             MiterLimit = MiterLimit,
             FillColorSpace = FillColorSpace,
             StrokeColorSpace = StrokeColorSpace,
-            BlendMode = BlendMode
+            BlendMode = BlendMode,
+            DashArray = DashArray,            // replaced wholesale by `d`, never mutated in place → safe to share
+            DashPhase = DashPhase
         };
     }
 }


### PR DESCRIPTION
## Summary
Continues the #350 operator-coverage push (after #414's in-memory parser coverage) by closing the remaining **render-level** gaps the audit surfaced.

### 1. Dash pattern `d` — now actually implemented
It was parsed but the renderer ignored it (`// for now just ignore`), so every dashed stroke drew **solid**. Added `DashArray`/`DashPhase` to `GraphicsState` (+ `Clone`) and `SKPathEffect.CreateDash` on both stroke paths (`StrokePath` and `FillAndStroke`). PDF odd-length arrays are doubled (Skia needs even on/off pairs); empty/degenerate arrays fall back to solid; a degenerate array never aborts rendering.

### 2. Shading `sh` — render output was silently untested
The existing shading tests referenced `/Sh1` but the test PDFs carried **no `/Shading` resource**, so `GetShading` returned null and `RenderShading` early-returned. The entire axial/radial gradient code path (`RenderAxialShading` / `RenderRadialShading` / `ResolveGradientColors`) was unexercised. New `OperatorRenderCoverageTests` build PDFs with **real** Type 2 (axial red→blue) and Type 3 (radial yellow→green) shadings and assert actual gradient pixels, clip restriction, and graceful handling of a missing resource.

### 3. Dash tests assert real behavior
A `[12 12]` dash paints far fewer pixels along the row than the solid control; an empty array resets to solid. **These would have failed before the implementation in (1)** — they're meaningful regression guards, not "renders without error".

### 4. Authoritative operator inventory + round-trip guard
`OperatorCoverageTests.AuthoritativeOperatorInventory_*`: one stream exercising **every** standard content-stream operator, each asserted to parse **and** survive a parse→write→parse round-trip through `ContentStreamWriter`.

## Verification
- `Pdfe.Core.Tests`: **2908 passed**
- `Pdfe.Rendering.Tests` (deterministic): **221 passed**
- Library-only change (no `PdfEditor/`), so the GUI suite is correctly skipped by the path filter.

Advances #350 (operator render coverage). First of the planned v2.8.0 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)