### PR TITLE
release: v2.8.0 — operator render coverage (dash + shading) (#350)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to pdfe are documented here. Format roughly follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this project uses
 semantic versioning.
 
+## [2.8.0] — 2026-06-08
+
+Operator render-coverage release (#350). Additive; no breaking changes.
+
+### Added
+- **Dash pattern (`d`) rendering.** The dash operator was parsed but ignored by
+  the renderer, so dashed strokes drew solid. `SkiaRenderer` now honors it via
+  `SKPathEffect.CreateDash` on both stroke paths; odd-length PDF dash arrays are
+  doubled (Skia needs even on/off pairs) and empty/degenerate arrays fall back to
+  a solid line.
+- **Authoritative operator inventory test.** One stream exercising every standard
+  content-stream operator, each asserted to parse **and** survive a
+  parse→write→parse round-trip through `ContentStreamWriter`.
+
+### Tests
+- **Shading (`sh`) render output is now actually verified.** Earlier shading
+  tests referenced a `/Shading` resource the test PDFs never contained, so the
+  axial/radial gradient code path ran as a no-op. New `OperatorRenderCoverageTests`
+  build PDFs with real Type 2 (axial) and Type 3 (radial) shadings and assert
+  gradient pixels, clip restriction, and graceful handling of a missing resource.
+- Dash render tests assert real behavior (a dash leaves measurable gaps vs. a
+  solid control; an empty array resets to solid).
+
 ## [2.7.0] — 2026-06-06
 
 Fillable-table authoring + PDF/UA accessibility hardening. Additive; no breaking

--- a/Pdfe.Avalonia/Pdfe.Avalonia.csproj
+++ b/Pdfe.Avalonia/Pdfe.Avalonia.csproj
@@ -14,7 +14,7 @@
   <!-- NuGet package metadata (packed explicitly via `dotnet pack`, not on build). -->
   <PropertyGroup>
     <PackageId>Pdfe.Avalonia</PackageId>
-    <Version>2.7.0</Version>
+    <Version>2.8.0</Version>
     <Authors>Marc Jones</Authors>
     <Description>A reusable, pure-managed PDF viewer control for Avalonia. Renders with SkiaSharp (no native PDFium), supports zoom/pan, page navigation, text selection, search highlights, annotations, links, and form-field overlays. Built on Pdfe.Core + Pdfe.Rendering.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Pdfe.Core/Pdfe.Core.csproj
+++ b/Pdfe.Core/Pdfe.Core.csproj
@@ -10,7 +10,7 @@
 
   <PropertyGroup>
     <PackageId>Pdfe.Core</PackageId>
-    <Version>2.7.0</Version>
+    <Version>2.8.0</Version>
     <Authors>Marc Jones</Authors>
     <Description>Pure-managed PDF parser, document model, and writer for .NET. Open/edit/save PDFs, extract text/links/annotations/forms, and perform true glyph-level redaction. No native dependencies; cross-platform and trim/AOT-friendlier.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Pdfe.Rendering/Pdfe.Rendering.csproj
+++ b/Pdfe.Rendering/Pdfe.Rendering.csproj
@@ -10,7 +10,7 @@
 
   <PropertyGroup>
     <PackageId>Pdfe.Rendering</PackageId>
-    <Version>2.7.0</Version>
+    <Version>2.8.0</Version>
     <Authors>Marc Jones</Authors>
     <Description>Pure-managed, SkiaSharp-based PDF render API for .NET. Render pages to SKBitmap or PNG with DPI/clip/rotation support and cancellable rendering. Framework-neutral engine behind Pdfe.Avalonia; no native PDFium. Cross-platform, trim/AOT-friendlier.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
Version bump to 2.8.0 (Pdfe.Core / Pdfe.Rendering / Pdfe.Avalonia) + CHANGELOG. Ships the #350 operator render-coverage work merged in #418 (dash implementation, shading render verification, authoritative operator inventory). Tag v2.8.0 after merge to trigger the release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)