### PR TITLE
feat(macos): open PDFs from Finder + bound headless test windows (#420)

### DIFF
--- a/PdfEditor.Tests/Utilities/FixedAvaloniaFact.cs
+++ b/PdfEditor.Tests/Utilities/FixedAvaloniaFact.cs
@@ -18,11 +18,14 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
+using Avalonia.Controls;
 using Avalonia.Headless;
+using Avalonia.Reactive;
 using Avalonia.Threading;
 using Xunit;
 using Xunit.Sdk;
@@ -208,12 +211,21 @@ internal sealed class FixedAvaloniaTestRunner
             test, messageBus, explicitOption, aggregator,
             cancellationTokenSource, beforeAfterAttributes,
             constructorArguments, session);
+        HeadlessWindowTracker.Ensure();
         await using (ctxt)
         {
             await ctxt.InitializeAsync();
             return await DispatchWithExecutionContext(session, async () =>
             {
                 var summary = await Run(ctxt);
+                // Close any windows the test opened. The headless test app has no
+                // desktop lifetime, so windows shown with Show() and never closed
+                // pile up on the shared dispatcher (90+ Show() / 2 Close() across
+                // the suite) until a frame stalls and the blame-hang collector
+                // kills the whole host — the residual #363 flakiness left after
+                // the *_MatchesBaseline exclusion. Closing per-test keeps the
+                // dispatcher's live-window set bounded.
+                HeadlessWindowTracker.CloseAll();
                 Dispatcher.UIThread.RunJobs(null);
                 return summary;
             }, ctxt.CancellationTokenSource.Token);
@@ -246,4 +258,50 @@ internal sealed class FixedAvaloniaTestRunnerContext(
         cancellationTokenSource, beforeAfterTestAttributes, constructorArguments)
 {
     public HeadlessUnitTestSession Session { get; } = session;
+}
+
+/// <summary>
+/// Tracks every <see cref="Window"/> opened during the headless test run and lets
+/// the test runner close them after each test. The headless test application uses
+/// <c>SetupWithoutStarting</c> with no desktop lifetime, so Avalonia keeps no
+/// global window list and windows shown with <c>Show()</c> are never disposed —
+/// they accumulate on the single shared dispatcher (the suite does 90+ Show() and
+/// only 2 Close()) until a dispatcher frame stalls and the blame-hang collector
+/// kills the entire test host. That is the residual #363 host-crash flakiness that
+/// survived excluding the heavy *_MatchesBaseline render tests. We subscribe once
+/// to the global <see cref="RoutedEvent"/> <c>Raised</c> streams for window
+/// open/close (no per-test-file changes needed) and close the live set between
+/// tests so the dispatcher never carries more than one test's windows.
+/// </summary>
+internal static class HeadlessWindowTracker
+{
+    private static readonly HashSet<Window> _open = new();
+    private static readonly object _lock = new();
+    private static int _initialized;
+
+    public static void Ensure()
+    {
+        if (Interlocked.Exchange(ref _initialized, 1) != 0) return;
+
+        Window.WindowOpenedEvent.Raised.Subscribe(new AnonymousObserver<(object, Avalonia.Interactivity.RoutedEventArgs)>(t =>
+        {
+            if (t.Item1 is Window w) { lock (_lock) _open.Add(w); }
+        }));
+        Window.WindowClosedEvent.Raised.Subscribe(new AnonymousObserver<(object, Avalonia.Interactivity.RoutedEventArgs)>(t =>
+        {
+            if (t.Item1 is Window w) { lock (_lock) _open.Remove(w); }
+        }));
+    }
+
+    /// <summary>Close all currently-open tracked windows (call on the UI thread).</summary>
+    public static void CloseAll()
+    {
+        Window[] snapshot;
+        lock (_lock) { snapshot = _open.ToArray(); _open.Clear(); }
+        foreach (var w in snapshot)
+        {
+            try { w.Close(); }
+            catch { /* a test may have left the window in an odd state; ignore */ }
+        }
+    }
 }

--- a/PdfEditor/App.axaml.cs
+++ b/PdfEditor/App.axaml.cs
@@ -2,6 +2,8 @@ using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
 using Avalonia.Media;
+using Avalonia.Platform.Storage;
+using Avalonia.Threading;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using PdfEditor.Services;
@@ -51,22 +53,63 @@ public partial class App : Application
 
             logger.LogInformation("Main window created successfully");
 
-            // If a PDF path was passed on the command line, open it once the
-            // window is shown. Supports file-manager "Open With" integrations
-            // and quick demos without clicking through File > Open.
+            // Open a PDF that was passed on the command line once the window is
+            // shown (Windows/Linux "Open With", `pdfe file.pdf`, demos). On macOS
+            // a double-clicked file does NOT arrive as a command-line arg — it
+            // comes through the activation event wired up below.
             var args = desktop.Args;
             if (args != null && args.Length > 0 && System.IO.File.Exists(args[0]))
             {
                 var path = args[0];
-                desktop.MainWindow.Opened += async (_, _) =>
-                {
-                    try { await vm.LoadDocumentAsync(path); }
-                    catch (Exception ex) { logger.LogError(ex, "Failed to auto-open {Path}", path); }
-                };
+                desktop.MainWindow.Opened += (_, _) => OpenPathOnUiThread(vm, path, logger);
             }
         }
 
+        // macOS (and other platforms) deliver "open this document" as an
+        // activation event, not a command-line arg — Finder double-click, the
+        // Dock, or `open -a pdfe file.pdf` against an already-running instance all
+        // come through here. Requires /CFBundleDocumentTypes in the .app's
+        // Info.plist so the OS routes PDFs to us. (#420)
+        if (ApplicationLifetime is IActivatableLifetime activatable
+            && _serviceProvider != null)
+        {
+            activatable.Activated += (_, e) =>
+            {
+                if (e is not FileActivatedEventArgs fileArgs)
+                    return;
+
+                // Resolve the VM lazily: on a warm activation the main window's
+                // VM is the live one; fall back to a fresh resolve if needed.
+                var vm = (ApplicationLifetime as IClassicDesktopStyleApplicationLifetime)
+                             ?.MainWindow?.DataContext as MainWindowViewModel
+                         ?? _serviceProvider.GetRequiredService<MainWindowViewModel>();
+
+                foreach (var file in fileArgs.Files)
+                {
+                    var path = file.TryGetLocalPath();
+                    if (!string.IsNullOrEmpty(path) && System.IO.File.Exists(path))
+                    {
+                        OpenPathOnUiThread(vm, path, logger);
+                        break;   // single-window app: open the first document
+                    }
+                }
+            };
+        }
+
         base.OnFrameworkInitializationCompleted();
+    }
+
+    /// <summary>
+    /// Load a PDF on the UI thread, logging (not throwing) on failure. Shared by
+    /// the command-line and OS file-activation open paths.
+    /// </summary>
+    private static void OpenPathOnUiThread(MainWindowViewModel vm, string path, ILogger logger)
+    {
+        Dispatcher.UIThread.Post(async () =>
+        {
+            try { await vm.LoadDocumentAsync(path); }
+            catch (Exception ex) { logger.LogError(ex, "Failed to open {Path}", path); }
+        });
     }
 
     private void ConfigureServices(IServiceCollection services)

--- a/README.md
+++ b/README.md
@@ -372,7 +372,30 @@ scripts/build-deb.sh --version 2.1.0-rc8      # explicit version
 
 # Windows .exe (requires Inno Setup 6: choco install innosetup)
 pwsh scripts/build-windows-installer.ps1      # → dist/pdfe-<version>-win-x64-setup.exe
+
+# macOS .app bundle (Apple Silicon by default; Intel via --rid osx-x64)
+scripts/build-macos-app.sh --version <version>            # → dist/pdfe-<version>-macos-arm64.zip
+scripts/build-macos-app.sh --version <version> --rid osx-x64
 ```
+
+### Using pdfe as a PDF reader on macOS
+
+The `.app` bundle declares itself a handler for PDF files (`CFBundleDocumentTypes`)
+and opens documents passed by Finder, the Dock, or `open -a` — so it can be used
+as a regular reader, not just launched empty.
+
+```bash
+# First launch: the build is not notarized, so clear the Gatekeeper quarantine
+# (one time, see issue #421 for signing/notarization tracking):
+xattr -dr com.apple.quarantine /Applications/pdfe.app
+
+# Open a PDF in pdfe:
+open -a pdfe ~/Documents/example.pdf
+```
+
+To make pdfe the **default** PDF app: select any `.pdf` in Finder → **⌘I** (Get
+Info) → **Open with** → choose *pdfe* → **Change All…**. Double-clicking PDFs
+then opens them in pdfe.
 
 ### Release automation
 

--- a/scripts/build-macos-app.sh
+++ b/scripts/build-macos-app.sh
@@ -113,6 +113,21 @@ ${ICON_PLIST}
     <true/>
     <key>LSApplicationCategoryType</key>
     <string>public.app-category.productivity</string>
+    <key>CFBundleDocumentTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleTypeName</key>
+            <string>PDF document</string>
+            <key>CFBundleTypeRole</key>
+            <string>Editor</string>
+            <key>LSHandlerRank</key>
+            <string>Alternate</string>
+            <key>LSItemContentTypes</key>
+            <array>
+                <string>com.adobe.pdf</string>
+            </array>
+        </dict>
+    </array>
 </dict>
 </plist>
 PLIST


### PR DESCRIPTION
## macOS reader integration (#420)
- **File-activation handling** in `App.axaml.cs` via `IActivatableLifetime`/`FileActivatedEventArgs` — Finder double-click, Dock, and `open -a pdfe file.pdf` (warm) now load the document. macOS delivers these as activation events, not `argv`, so the existing command-line path never fired for Finder opens.
- **`Info.plist` `CFBundleDocumentTypes`** (`com.adobe.pdf`) so pdfe registers as a PDF handler and can be set as the default reader.
- **README**: `.app` build, one-time Gatekeeper unquarantine, and how to set pdfe as the default PDF app.

## Headless test stability (#363, residual)
The headless test app has no desktop lifetime, so windows shown with `Show()` and never closed accumulate on the shared dispatcher (suite does **90+ Show() / 2 Close()**) until a frame stalls and the blame-hang collector kills the host. The runner now tracks windows via Avalonia's global `RoutedEvent.Raised` streams and **closes each test's windows afterward**, bounding the live set.

**Effect:** the full GUI suite — *including* the heavy `*_MatchesBaseline` render tests — now passes (RUN 1: 755/0) where it previously crashed reliably. It **reduces but doesn't fully eliminate** residual headless flakiness (a later full-suite run still crashed), so the `*_MatchesBaseline` PR-gate exclusion stays in place; the nightly job owns those.

## Notes
- Tests use `TestApp`, never the real `App`, so the `App.axaml.cs` change is inert in the test suite.
- Part of the v2.9.0 viewer + macOS-reader release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)