### PR TITLE
feat(viewer): continuous (reading) view mode for Pdfe.Avalonia (#371)

### DIFF
--- a/PdfEditor.Tests/Controls/PdfViewerControlTests.cs
+++ b/PdfEditor.Tests/Controls/PdfViewerControlTests.cs
@@ -488,4 +488,80 @@ public class PdfViewerControlTests
     }
 
     #endregion
+
+    #region Continuous View Mode (#371)
+
+    [FixedAvaloniaFact]
+    public void ViewMode_DefaultsToSinglePage()
+    {
+        new PdfViewerControl().ViewMode.Should().Be(PdfViewMode.SinglePage);
+    }
+
+    [FixedAvaloniaFact]
+    public void ViewMode_TogglesScrollViewerVisibility()
+    {
+        var control = new PdfViewerControl();
+        var single = control.FindControl<ScrollViewer>("PdfScrollViewer")!;
+        var continuous = control.FindControl<ScrollViewer>("ContinuousScrollViewer")!;
+
+        single.IsVisible.Should().BeTrue("single-page is the default view");
+        continuous.IsVisible.Should().BeFalse();
+
+        control.ViewMode = PdfViewMode.Continuous;
+
+        single.IsVisible.Should().BeFalse();
+        continuous.IsVisible.Should().BeTrue();
+    }
+
+    [FixedAvaloniaFact]
+    public void EnteringEditingMode_InContinuous_AutoSwitchesToSinglePage()
+    {
+        foreach (var editing in new[] { InteractionMode.Redaction, InteractionMode.TextSelection, InteractionMode.FormAuthoring })
+        {
+            var control = new PdfViewerControl { ViewMode = PdfViewMode.Continuous };
+            control.ViewMode.Should().Be(PdfViewMode.Continuous);
+
+            control.InteractionMode = editing;
+
+            control.ViewMode.Should().Be(PdfViewMode.SinglePage,
+                $"{editing} is an editing interaction and must force single-page");
+        }
+    }
+
+    [FixedAvaloniaFact]
+    public void ContinuousMode_BuildsOneSlotPerPage()
+    {
+        var path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"pdfe_cont_{Guid.NewGuid():N}.pdf");
+        TestPdfGenerator.CreateMultiPagePdf(path, pageCount: 3);
+        try
+        {
+            var control = new PdfViewerControl { Document = PdfCoreDocument.Open(path) };
+            control.ViewMode = PdfViewMode.Continuous;
+
+            var items = control.FindControl<ItemsControl>("ContinuousItems")!;
+            items.ItemsSource.Should().NotBeNull();
+            items.ItemsSource!.Cast<PdfPageSlot>().Select(s => s.PageNumber)
+                .Should().Equal(1, 2, 3);
+        }
+        finally { System.IO.File.Delete(path); }
+    }
+
+    [FixedAvaloniaFact]
+    public void ContinuousSlot_DisplayWidthScalesWithZoom()
+    {
+        var control = new PdfViewerControl { Document = PdfCoreDocument.Open(TestPdfGenerator.CreateSimplePdf("zoom")) };
+        control.ViewMode = PdfViewMode.Continuous;
+
+        var slot = control.FindControl<ItemsControl>("ContinuousItems")!
+            .ItemsSource!.Cast<PdfPageSlot>().First();
+        var widthAt1x = slot.DisplayWidth;
+        widthAt1x.Should().BeGreaterThan(0);
+
+        control.ZoomLevel = 2.0;
+
+        slot.DisplayWidth.Should().BeApproximately(widthAt1x * 2.0, 0.5,
+            "page slots resize with zoom so the reading view scales");
+    }
+
+    #endregion
 }

--- a/Pdfe.Avalonia/Controls/PdfViewerControl.Continuous.cs
+++ b/Pdfe.Avalonia/Controls/PdfViewerControl.Continuous.cs
@@ -1,0 +1,315 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using global::Avalonia;
+using global::Avalonia.Controls;
+using global::Avalonia.Media.Imaging;
+using global::Avalonia.Reactive;
+using global::Avalonia.Threading;
+using Pdfe.Rendering;
+
+namespace Pdfe.Avalonia.Controls;
+
+/// <summary>
+/// Continuous (reading) view mode for <see cref="PdfViewerControl"/> (#371 part 2).
+/// A render-virtualized vertical scroll of every page: only the pages near the
+/// viewport are rendered, bitmaps are bounded, and off-screen renders are
+/// cancelled. This view is read-only — all editing happens in single-page mode
+/// (entering an editing interaction auto-switches back), so none of the
+/// security-critical redaction/selection overlays run here.
+/// </summary>
+public partial class PdfViewerControl
+{
+    private ScrollViewer? _continuousScrollViewer;
+    private ItemsControl? _continuousItems;
+    private List<PdfPageSlot>? _continuousSlots;
+
+    // Bitmaps are bounded by an LRU list. We do NOT dispose on eviction: a bitmap
+    // may still be bound to a realized (visible) Image, and disposing it would
+    // crash the render. Dropping the reference lets the GC reclaim it once no
+    // slot/Image holds it. Full disposal happens only on document change.
+    private readonly LinkedList<(int Page, WriteableBitmap Bmp)> _continuousCache = new();
+    private readonly Dictionary<int, CancellationTokenSource> _continuousRenderCts = new();
+    private const int ContinuousCacheCapacity = 16;
+    internal const double PointsToDip = 96.0 / 72.0;
+    private const double PageGapDip = 12.0;   // matches the DataTemplate Border bottom margin
+
+    // Guards the scroll -> CurrentPage -> scroll feedback loop.
+    private bool _syncingPageFromScroll;
+
+    private void InitializeContinuous()
+    {
+        _continuousScrollViewer = this.FindControl<ScrollViewer>("ContinuousScrollViewer");
+        _continuousItems = this.FindControl<ItemsControl>("ContinuousItems");
+
+        if (_continuousItems != null)
+        {
+            _continuousItems.ContainerPrepared += OnContinuousContainerPrepared;
+            _continuousItems.ContainerClearing += OnContinuousContainerClearing;
+        }
+        if (_continuousScrollViewer != null)
+        {
+            _continuousScrollViewer
+                .GetObservable(ScrollViewer.OffsetProperty)
+                .Subscribe(new AnonymousObserver<Vector>(_ => OnContinuousScrolled()));
+        }
+    }
+
+    private void OnViewModeChanged()
+    {
+        bool continuous = ViewMode == PdfViewMode.Continuous;
+        if (_continuousScrollViewer != null) _continuousScrollViewer.IsVisible = continuous;
+        if (_scrollViewer != null) _scrollViewer.IsVisible = !continuous;
+
+        if (continuous)
+        {
+            RebuildContinuous();
+            // Defer the scroll-to until the items panel has measured the slots.
+            int target = CurrentPage;
+            Dispatcher.UIThread.Post(() => ScrollToPageContinuous(target), DispatcherPriority.Background);
+        }
+        else
+        {
+            // Back to single-page: make sure the current page is rendered.
+            _ = RenderCurrentPageAsync();
+        }
+    }
+
+    /// <summary>(Re)build the per-page slots from the current document.</summary>
+    private void RebuildContinuous()
+    {
+        if (_continuousItems == null) return;
+        var doc = Document;
+        if (doc == null) { ClearContinuous(); return; }
+
+        var slots = new List<PdfPageSlot>(doc.PageCount);
+        for (int i = 1; i <= doc.PageCount; i++)
+        {
+            var page = doc.GetPage(i);
+            slots.Add(new PdfPageSlot(i, page.VisualWidth, page.VisualHeight, ZoomLevel));
+        }
+        _continuousSlots = slots;
+        _continuousItems.ItemsSource = slots;
+    }
+
+    private void ClearContinuous()
+    {
+        if (_continuousItems != null) _continuousItems.ItemsSource = null;
+        _continuousSlots = null;
+    }
+
+    private void InvalidateContinuousCache()
+    {
+        foreach (var cts in _continuousRenderCts.Values) cts.Cancel();
+        _continuousRenderCts.Clear();
+        foreach (var entry in _continuousCache) entry.Bmp.Dispose();
+        _continuousCache.Clear();
+    }
+
+    /// <summary>Resize every slot to the new zoom (bindings re-layout the borders).</summary>
+    private void ApplyContinuousZoom()
+    {
+        if (_continuousSlots == null) return;
+        foreach (var slot in _continuousSlots) slot.ApplyZoom(ZoomLevel);
+    }
+
+    // ---- Scroll <-> CurrentPage sync -----------------------------------
+
+    private void ScrollToPageContinuous(int pageNumber)
+    {
+        if (_continuousScrollViewer == null || _continuousSlots == null) return;
+        if (pageNumber < 1 || pageNumber > _continuousSlots.Count) return;
+
+        double y = 0;
+        for (int i = 0; i < pageNumber - 1; i++)
+            y += _continuousSlots[i].DisplayHeight + PageGapDip;
+
+        var x = _continuousScrollViewer.Offset.X;
+        _continuousScrollViewer.Offset = new Vector(x, y);
+    }
+
+    private void OnContinuousScrolled()
+    {
+        if (ViewMode != PdfViewMode.Continuous || _continuousScrollViewer == null || _continuousSlots == null)
+            return;
+
+        // Topmost visible page = the slot whose cumulative bottom passes the
+        // current vertical offset (+ a small bias so a page counts as "current"
+        // once its top edge is in view).
+        double offsetY = _continuousScrollViewer.Offset.Y + 1;
+        double cumulative = 0;
+        int top = 1;
+        for (int i = 0; i < _continuousSlots.Count; i++)
+        {
+            cumulative += _continuousSlots[i].DisplayHeight + PageGapDip;
+            top = i + 1;
+            if (offsetY < cumulative) break;
+        }
+
+        if (top != CurrentPage)
+        {
+            // Mark the change as scroll-driven so OnCurrentPageChanged doesn't
+            // scroll back (feedback loop).
+            _syncingPageFromScroll = true;
+            try { CurrentPage = top; }
+            finally { _syncingPageFromScroll = false; }
+        }
+    }
+
+    // ---- Container realization -> on-demand render ---------------------
+
+    private void OnContinuousContainerPrepared(object? sender, ContainerPreparedEventArgs e)
+    {
+        if (e.Container.DataContext is PdfPageSlot slot)
+            _ = RenderContinuousAsync(slot);
+    }
+
+    private void OnContinuousContainerClearing(object? sender, ContainerClearingEventArgs e)
+    {
+        if (e.Container.DataContext is PdfPageSlot slot)
+        {
+            // Cancel an in-flight render for a page scrolled away before it
+            // finished; keep the bitmap in the LRU cache for a quick return.
+            if (_continuousRenderCts.TryGetValue(slot.PageNumber, out var cts))
+            {
+                cts.Cancel();
+                _continuousRenderCts.Remove(slot.PageNumber);
+            }
+        }
+    }
+
+    private async Task RenderContinuousAsync(PdfPageSlot slot)
+    {
+        var doc = Document;
+        if (doc == null || slot.PageNumber < 1 || slot.PageNumber > doc.PageCount) return;
+
+        if (TryGetContinuousCached(slot.PageNumber, out var cached))
+        {
+            slot.Bitmap = cached;
+            return;
+        }
+
+        // Cancel any prior in-flight render for this same page.
+        if (_continuousRenderCts.TryGetValue(slot.PageNumber, out var prior))
+            prior.Cancel();
+        var cts = new CancellationTokenSource();
+        _continuousRenderCts[slot.PageNumber] = cts;
+        var token = cts.Token;
+        var pageNumber = slot.PageNumber;
+
+        try
+        {
+            var skBitmap = await Task.Run(() =>
+            {
+                token.ThrowIfCancellationRequested();
+                var page = doc.GetPage(pageNumber);
+                // A fresh renderer per page: SkiaRenderer carries per-render
+                // instance state and is not reentrant, and continuous mode may
+                // render several pages around the viewport concurrently.
+                var renderer = new SkiaRenderer();
+                return renderer.RenderPage(page, new RenderOptions { Dpi = DefaultRenderDpi });
+            }, token);
+
+            try
+            {
+                if (token.IsCancellationRequested) return;
+                var bitmap = Imaging.SkiaInterop.ToAvaloniaBitmap(skBitmap);
+                if (bitmap != null)
+                {
+                    AddToContinuousCache(pageNumber, bitmap);
+                    slot.Bitmap = bitmap;
+                }
+            }
+            finally
+            {
+                skBitmap?.Dispose();
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Scrolled away before the render finished — drop it silently.
+        }
+        catch
+        {
+            // A single bad page must not break the reading scroll.
+        }
+        finally
+        {
+            if (_continuousRenderCts.TryGetValue(pageNumber, out var mine) && mine == cts)
+                _continuousRenderCts.Remove(pageNumber);
+        }
+    }
+
+    private bool TryGetContinuousCached(int page, out WriteableBitmap? bmp)
+    {
+        for (var node = _continuousCache.First; node != null; node = node.Next)
+        {
+            if (node.Value.Page == page)
+            {
+                _continuousCache.Remove(node);
+                _continuousCache.AddFirst(node);
+                bmp = node.Value.Bmp;
+                return true;
+            }
+        }
+        bmp = null;
+        return false;
+    }
+
+    private void AddToContinuousCache(int page, WriteableBitmap bmp)
+    {
+        for (var node = _continuousCache.First; node != null; node = node.Next)
+        {
+            if (node.Value.Page == page) { _continuousCache.Remove(node); break; }
+        }
+        _continuousCache.AddFirst((page, bmp));
+        // Drop (don't dispose) the LRU tail — see field comment on why.
+        while (_continuousCache.Count > ContinuousCacheCapacity)
+            _continuousCache.RemoveLast();
+    }
+}
+
+/// <summary>
+/// One page in the continuous (reading) view. Observable so the data-template's
+/// Border size and Image source update as zoom changes and the page renders.
+/// </summary>
+public sealed class PdfPageSlot : INotifyPropertyChanged
+{
+    private double _displayWidth;
+    private double _displayHeight;
+    private WriteableBitmap? _bitmap;
+
+    internal PdfPageSlot(int pageNumber, double widthPt, double heightPt, double zoom)
+    {
+        PageNumber = pageNumber;
+        WidthPt = widthPt;
+        HeightPt = heightPt;
+        ApplyZoom(zoom);
+    }
+
+    public int PageNumber { get; }
+    public double WidthPt { get; }
+    public double HeightPt { get; }
+
+    public double DisplayWidth { get => _displayWidth; private set => Set(ref _displayWidth, value); }
+    public double DisplayHeight { get => _displayHeight; private set => Set(ref _displayHeight, value); }
+    public WriteableBitmap? Bitmap { get => _bitmap; set => Set(ref _bitmap, value); }
+
+    internal void ApplyZoom(double zoom)
+    {
+        DisplayWidth = WidthPt * PdfViewerControl.PointsToDip * zoom;
+        DisplayHeight = HeightPt * PdfViewerControl.PointsToDip * zoom;
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    private void Set<T>(ref T field, T value, [CallerMemberName] string? name = null)
+    {
+        if (EqualityComparer<T>.Default.Equals(field, value)) return;
+        field = value;
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+    }
+}

--- a/Pdfe.Avalonia/Controls/PdfViewerControl.axaml
+++ b/Pdfe.Avalonia/Controls/PdfViewerControl.axaml
@@ -2,6 +2,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:controls="clr-namespace:Pdfe.Avalonia.Controls"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="600"
              x:Class="Pdfe.Avalonia.Controls.PdfViewerControl">
 
@@ -47,6 +48,44 @@
                     </Canvas>
                 </Grid>
             </LayoutTransformControl>
+        </ScrollViewer>
+
+        <!-- Continuous (reading) view: a vertically-scrolling, render-virtualized
+             stack of all pages. Shown only when ViewMode=Continuous; hidden (and
+             not measured) otherwise so the single-page ScrollViewer above owns
+             the viewport. No editing overlays here by design — editing always
+             happens in single-page mode (#371). -->
+        <ScrollViewer Name="ContinuousScrollViewer"
+                      IsVisible="False"
+                      HorizontalScrollBarVisibility="Auto"
+                      VerticalScrollBarVisibility="Auto"
+                      HorizontalContentAlignment="Center">
+            <ItemsControl Name="ContinuousItems">
+                <ItemsControl.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <VirtualizingStackPanel Orientation="Vertical" />
+                    </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate x:DataType="controls:PdfPageSlot">
+                        <!-- Border is sized to the (zoomed) page via bindings on
+                             the PageSlot VM; the Image stretches the rendered
+                             bitmap to fill it. Rendering is kicked on container
+                             realization (code-behind) and flows back through the
+                             Bitmap binding, so virtualization only renders the
+                             pages near the viewport. -->
+                        <Border Width="{Binding DisplayWidth}"
+                                Height="{Binding DisplayHeight}"
+                                Background="White"
+                                Margin="0,0,0,12"
+                                HorizontalAlignment="Center"
+                                BorderBrush="#40000000"
+                                BorderThickness="1">
+                            <Image Source="{Binding Bitmap}" Stretch="Fill" />
+                        </Border>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
         </ScrollViewer>
 
         <!-- Thin indeterminate progress bar pinned to the top edge of the

--- a/Pdfe.Avalonia/Controls/PdfViewerControl.axaml.cs
+++ b/Pdfe.Avalonia/Controls/PdfViewerControl.axaml.cs
@@ -77,6 +77,24 @@ public partial class PdfViewerControl : UserControl
     }
 
     /// <summary>
+    /// View mode: <see cref="PdfViewMode.SinglePage"/> (the default — one page at
+    /// a time, with all editing/redaction/selection interactions) or
+    /// <see cref="PdfViewMode.Continuous"/> (a scrollable reading view of all
+    /// pages, render-virtualized, with NO editing). Entering an editing
+    /// interaction mode auto-switches back to SinglePage so the editing overlays
+    /// (which are single-page by design, incl. security-critical redaction) are
+    /// never driven against a continuous layout.
+    /// </summary>
+    public static readonly StyledProperty<PdfViewMode> ViewModeProperty =
+        AvaloniaProperty.Register<PdfViewerControl, PdfViewMode>(nameof(ViewMode), defaultValue: PdfViewMode.SinglePage);
+
+    public PdfViewMode ViewMode
+    {
+        get => GetValue(ViewModeProperty);
+        set => SetValue(ViewModeProperty, value);
+    }
+
+    /// <summary>
     /// Is page currently loading?
     /// </summary>
     public static readonly StyledProperty<bool> IsLoadingProperty =
@@ -272,7 +290,25 @@ public partial class PdfViewerControl : UserControl
             control.OnHiddenTextHighlightsChanged(
                 e.OldValue as System.Collections.Generic.IEnumerable<HiddenTextHighlight>,
                 e.NewValue as System.Collections.Generic.IEnumerable<HiddenTextHighlight>));
+        ViewModeProperty.Changed.AddClassHandler<PdfViewerControl>((control, _) =>
+            control.OnViewModeChanged());
+        // Editing interactions are single-page only. If the host turns on an
+        // editing mode while we're in the continuous reading view, switch back
+        // to single-page (at the current page) so the editing overlays line up
+        // with a single rendered page — never a continuous stack.
+        InteractionModeProperty.Changed.AddClassHandler<PdfViewerControl>((control, e) =>
+        {
+            if (control.ViewMode == PdfViewMode.Continuous
+                && e.NewValue is InteractionMode m && IsEditingMode(m))
+            {
+                control.ViewMode = PdfViewMode.SinglePage;
+            }
+        });
     }
+
+    /// <summary>An interaction mode that draws/edits and therefore needs single-page layout.</summary>
+    private static bool IsEditingMode(InteractionMode m) =>
+        m is InteractionMode.Redaction or InteractionMode.TextSelection or InteractionMode.FormAuthoring;
 
     private System.Collections.Specialized.INotifyCollectionChanged? _watchedHighlights;
 
@@ -585,6 +621,8 @@ public partial class PdfViewerControl : UserControl
                 .GetObservable(ScrollViewer.ViewportProperty)
                 .Subscribe(new AnonymousObserver<Size>(OnScrollViewerViewportChanged));
         }
+
+        InitializeContinuous();
     }
 
     /// <summary>
@@ -624,6 +662,8 @@ public partial class PdfViewerControl : UserControl
             _zoomScaleTransform.ScaleX = ZoomLevel;
             _zoomScaleTransform.ScaleY = ZoomLevel;
         }
+        if (ViewMode == PdfViewMode.Continuous)
+            ApplyContinuousZoom();
     }
 
     private void OnLoadingStateChanged()
@@ -681,15 +721,19 @@ public partial class PdfViewerControl : UserControl
         _linksPageNumber = -1;
         ClearSelectionHighlight();
 
+        InvalidateContinuousCache();
         if (Document != null)
         {
             RefreshPageAnnotations();
+            if (ViewMode == PdfViewMode.Continuous)
+                RebuildContinuous();
             await RenderCurrentPageAsync();
         }
         else
         {
             Annotations = null;
             ClearDisplay();
+            ClearContinuous();
         }
     }
 
@@ -714,6 +758,12 @@ public partial class PdfViewerControl : UserControl
 
             await RenderCurrentPageAsync();
             PageChanged?.Invoke(this, new PageChangedEventArgs(CurrentPage));
+
+            // In continuous mode, a CurrentPage change that did NOT originate
+            // from the user scrolling (e.g. a "go to page" command or a clicked
+            // link) should scroll the reading view to that page.
+            if (ViewMode == PdfViewMode.Continuous && !_syncingPageFromScroll)
+                ScrollToPageContinuous(CurrentPage);
         }
     }
 
@@ -1485,6 +1535,20 @@ public class PageChangedEventArgs : EventArgs
 /// <summary>
 /// Interaction modes for the PDF viewer.
 /// </summary>
+/// <summary>
+/// How the viewer lays out pages. <see cref="SinglePage"/> shows one page with
+/// full editing; <see cref="Continuous"/> is a render-virtualized scrolling
+/// reading view of all pages with no editing.
+/// </summary>
+public enum PdfViewMode
+{
+    /// <summary>One page at a time, with all editing interactions (the default).</summary>
+    SinglePage,
+
+    /// <summary>Scrollable all-pages reading view, render-virtualized, no editing.</summary>
+    Continuous,
+}
+
 public enum InteractionMode
 {
     /// <summary>


### PR DESCRIPTION
## Summary
Adds an **opt-in continuous reading mode** to `PdfViewerControl`, the larger half of #371. The single-page editing path is unchanged.

### `ViewMode` (new)
`PdfViewMode.SinglePage` (default) | `Continuous`. Continuous shows every page in a vertically-scrolling, **render-virtualized** list (`VirtualizingStackPanel`):
- only pages near the viewport render (on container realization),
- bitmaps bounded by an LRU cache,
- off-screen renders cancelled,
- each page renders on a **fresh `SkiaRenderer`** (it carries per-render state and isn't reentrant).

### Read-only by design (your simplification)
Entering an editing interaction (`Redaction` / `TextSelection` / `FormAuthoring`) while in Continuous **auto-switches back to SinglePage**, so the security-critical redaction/selection overlays only ever run against a single rendered page — never a continuous stack.

### Sync & zoom
Scroll ⇄ `CurrentPage` stay in sync both ways (scroll updates the page number; "go to page" / link clicks scroll the reading view); zoom resizes page slots live.

### New public surface (`Pdfe.Avalonia`)
`PdfViewerControl.ViewMode`, `enum PdfViewMode`, `class PdfPageSlot`.

## Tests (headless)
`ViewMode` default, scroll-viewer visibility toggle, auto-switch-on-edit (all 3 editing modes), one-slot-per-page, zoom scaling — all pass.

## Notes
- This is **#371 part 2 (continuous scroll)**. **Part 1 (tiling / sharp high-zoom rendering)** is a follow-up that needs render-region support in `SkiaRenderer`; tracked separately.
- Part of the v2.9.0 viewer + macOS-reader release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)