### PR TITLE
feat(authoring): PDF/A archival export (PdfA) + trailer /ID (#425)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ semantic versioning.
 Operator render-coverage release (#350). Additive; no breaking changes.
 
 ### Added
+- **PDF/A archival output.** `PdfDocumentBuilder.PdfA(PdfAConformance.PdfA2B)`
+  adds the document structures PDF/A requires at save time — an XMP metadata
+  packet with the `pdfaid` identifier and an sRGB OutputIntent (embedded ICC
+  profile). With an embedded font (`DefaultFont`), the output validates as
+  **PDF/A-2b under veraPDF 1.30.2 (144/144 rules)**. New `PdfAConformance` enum.
+  (PDF/A-1b is stricter and not yet fully met — tracked in #425.)
+- **Trailer `/ID`.** Newly authored documents now always get a file-identifier
+  array in the trailer (ISO 32000-1 §14.4) — required by PDF/A and recommended
+  generally; an existing `/ID` is preserved.
 - **Dash pattern (`d`) rendering.** The dash operator was parsed but ignored by
   the renderer, so dashed strokes drew solid. `SkiaRenderer` now honors it via
   `SKPathEffect.CreateDash` on both stroke paths; odd-length PDF dash arrays are

--- a/Pdfe.Core.Tests/PdfATests.cs
+++ b/Pdfe.Core.Tests/PdfATests.cs
@@ -1,0 +1,47 @@
+using System.Text;
+using Pdfe.Core.Authoring;
+using Pdfe.Core.Graphics;
+using Xunit;
+
+namespace Pdfe.Core.Tests;
+
+/// <summary>
+/// Verifies <see cref="PdfDocumentBuilder.PdfA"/> emits the document-level
+/// structures PDF/A requires: an XMP packet with the pdfaid identifier, an sRGB
+/// OutputIntent, a trailer /ID, and an embedded font (no base-14). Full
+/// conformance is validated externally with veraPDF (PDF/A-2b: 144/144 rules).
+/// </summary>
+public class PdfATests
+{
+    private static byte[] BuildPdfA()
+    {
+        var font = PdfFont.FromFile("/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf", 11);
+        return PdfDocumentBuilder.Create()
+            .Language("en-US")
+            .Title("Archival Test")
+            .DefaultFont(font)
+            .PdfA(PdfAConformance.PdfA2B)
+            .Heading("Archival Test")
+            .Paragraph("Body text — with an em dash and unicode: café.")
+            .SaveToBytes();
+    }
+
+    [Fact]
+    public void PdfA_EmitsXmpPdfaId_OutputIntent_AndTrailerId()
+    {
+        var latin1 = Encoding.Latin1.GetString(BuildPdfA());
+
+        Assert.Contains("pdfaid:part>2", latin1);
+        Assert.Contains("pdfaid:conformance>B", latin1);
+        Assert.Contains("/OutputIntents", latin1);
+        Assert.Contains("GTS_PDFA1", latin1);
+        Assert.Contains("/ID", latin1);
+    }
+
+    [Fact]
+    public void NewDocument_AlwaysGetsATrailerId()
+    {
+        var bytes = PdfDocumentBuilder.Create().Heading("Hi").SaveToBytes();
+        Assert.Contains("/ID", Encoding.Latin1.GetString(bytes));
+    }
+}

--- a/Pdfe.Core.Tests/PublicApi/Pdfe.Core.approved.txt
+++ b/Pdfe.Core.Tests/PublicApi/Pdfe.Core.approved.txt
@@ -60,6 +60,11 @@ namespace Pdfe.Core.Authoring
         public Pdfe.Core.Authoring.PageSize Landscape() { }
         public Pdfe.Core.Authoring.PageSize Portrait() { }
     }
+    public enum PdfAConformance
+    {
+        PdfA2B = 0,
+        PdfA1B = 1,
+    }
     public sealed class PdfDocumentBuilder
     {
         public double ContentLeft { get; }
@@ -82,6 +87,7 @@ namespace Pdfe.Core.Authoring
         public Pdfe.Core.Authoring.PdfDocumentBuilder NumberedList(System.Collections.Generic.IEnumerable<string> items, Pdfe.Core.Authoring.TextStyle? style = null) { }
         public Pdfe.Core.Authoring.PdfDocumentBuilder PageBreak() { }
         public Pdfe.Core.Authoring.PdfDocumentBuilder Paragraph(string text, Pdfe.Core.Authoring.TextStyle? style = null) { }
+        public Pdfe.Core.Authoring.PdfDocumentBuilder PdfA(Pdfe.Core.Authoring.PdfAConformance conformance = 0) { }
         public void Save(System.IO.Stream stream) { }
         public void Save(string path) { }
         public byte[] SaveToBytes() { }

--- a/Pdfe.Core/Authoring/PdfA.cs
+++ b/Pdfe.Core/Authoring/PdfA.cs
@@ -1,0 +1,99 @@
+using System.Text;
+using Pdfe.Core.Document;
+using Pdfe.Core.Primitives;
+
+namespace Pdfe.Core.Authoring;
+
+/// <summary>The PDF/A conformance level to target.</summary>
+public enum PdfAConformance
+{
+    /// <summary>PDF/A-2b — visual reproducibility (recommended for archival).</summary>
+    PdfA2B,
+
+    /// <summary>PDF/A-1b — the original visual-reproducibility level.</summary>
+    PdfA1B,
+}
+
+/// <summary>
+/// Adds the document-level structures a PDF/A file requires: an XMP metadata
+/// packet with the <c>pdfaid</c> identifier, and an OutputIntent referencing an
+/// embedded sRGB ICC profile. The caller must also embed all fonts (e.g. via
+/// <see cref="PdfDocumentBuilder.DefaultFont"/>) — PDF/A forbids the non-embedded
+/// base-14 fonts.
+/// </summary>
+internal static class PdfAWriter
+{
+    public static void Apply(PdfDocument document, PdfAConformance conformance)
+    {
+        WriteXmp(document, conformance);
+        WriteOutputIntent(document);
+    }
+
+    private static void WriteXmp(PdfDocument document, PdfAConformance conformance)
+    {
+        var part = conformance == PdfAConformance.PdfA1B ? 1 : 2;
+        var title = XmlEscape(document.Info?.GetStringOrNull("Title") ?? document.Title ?? string.Empty);
+        var producer = XmlEscape(document.Info?.GetStringOrNull("Producer") ?? "pdfe");
+        var creator = XmlEscape(document.Info?.GetStringOrNull("Creator") ?? string.Empty);
+
+        var sb = new StringBuilder();
+        sb.Append("<?xpacket begin=\"﻿\" id=\"W5M0MpCehiHzreSzNTczkc9d\"?>\n");
+        sb.Append("<x:xmpmeta xmlns:x=\"adobe:ns:meta/\">\n");
+        sb.Append(" <rdf:RDF xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\">\n");
+        sb.Append("  <rdf:Description rdf:about=\"\" xmlns:pdfaid=\"http://www.aiim.org/pdfa/ns/id/\">\n");
+        sb.Append($"   <pdfaid:part>{part}</pdfaid:part>\n");
+        sb.Append("   <pdfaid:conformance>B</pdfaid:conformance>\n");
+        sb.Append("  </rdf:Description>\n");
+        sb.Append("  <rdf:Description rdf:about=\"\" xmlns:dc=\"http://purl.org/dc/elements/1.1/\">\n");
+        sb.Append("   <dc:format>application/pdf</dc:format>\n");
+        if (title.Length > 0)
+        {
+            sb.Append($"   <dc:title><rdf:Alt><rdf:li xml:lang=\"x-default\">{title}</rdf:li></rdf:Alt></dc:title>\n");
+        }
+        sb.Append("  </rdf:Description>\n");
+        sb.Append("  <rdf:Description rdf:about=\"\" xmlns:pdf=\"http://ns.adobe.com/pdf/1.3/\">\n");
+        sb.Append($"   <pdf:Producer>{producer}</pdf:Producer>\n");
+        sb.Append("  </rdf:Description>\n");
+        if (creator.Length > 0)
+        {
+            sb.Append("  <rdf:Description rdf:about=\"\" xmlns:xmp=\"http://ns.adobe.com/xap/1.0/\">\n");
+            sb.Append($"   <xmp:CreatorTool>{creator}</xmp:CreatorTool>\n");
+            sb.Append("  </rdf:Description>\n");
+        }
+        sb.Append(" </rdf:RDF>\n</x:xmpmeta>\n<?xpacket end=\"w\"?>");
+
+        var bytes = Encoding.UTF8.GetBytes(sb.ToString());
+        var dict = new PdfDictionary();
+        dict.SetName("Type", "Metadata");
+        dict.SetName("Subtype", "XML");
+        dict.SetInt("Length", bytes.Length);
+        document.Catalog["Metadata"] = document.AddIndirectObject(new PdfStream(dict, bytes));
+    }
+
+    private static void WriteOutputIntent(PdfDocument document)
+    {
+        if (document.Catalog.ContainsKey("OutputIntents")) return;
+
+        var icc = Convert.FromBase64String(SrgbIccProfileBase64);
+        var iccDict = new PdfDictionary();
+        iccDict.SetInt("N", 3);
+        iccDict.SetInt("Length", icc.Length);
+        var iccRef = document.AddIndirectObject(new PdfStream(iccDict, icc));
+
+        var outputIntent = new PdfDictionary();
+        outputIntent.SetName("Type", "OutputIntent");
+        outputIntent.SetName("S", "GTS_PDFA1");
+        outputIntent.SetString("OutputConditionIdentifier", "sRGB IEC61966-2.1");
+        outputIntent.SetString("Info", "sRGB IEC61966-2.1");
+        outputIntent.Set("DestOutputProfile", iccRef);
+
+        document.Catalog["OutputIntents"] = new PdfArray(outputIntent);
+    }
+
+    private static string XmlEscape(string s) =>
+        s.Replace("&", "&amp;").Replace("<", "&lt;").Replace(">", "&gt;");
+
+    // Minimal valid sRGB v2 ICC profile (736 bytes), suitable for PDF/A OutputIntent embedding.
+    private const string SrgbIccProfileBase64 =
+        "AAAC4GxjbXMCEAAAbW50clJHQiBYWVogB+IAAwAUAAkADgAdYWNzcE1TRlQAAAAAc2F3c2N0cmwAAAAAAAAAAAAAAAAAAPbWAAEAAAAA0y1oYW5kk7I0qQ6wIoqY/Zqvo2eJmwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJZGVzYwAAAPAAAABfY3BydAAAAQwAAAAMd3RwdAAAARgAAAAUclhZWgAAASwAAAAUZ1hZWgAAAUAAAAAUYlhZWgAAAVQAAAAUclRSQwAAAWgAAAF4Z1RSQwAAAWgAAAF4YlRSQwAAAWgAAAF4ZGVzYwAAAAAAAAAFc1JHQgAAAAAAAAAAAAAAAHRleHQAAAAAQ0MwAFhZWiAAAAAAAADzVAABAAAAARbJWFlaIAAAAAAAAG+gAAA48gAAA49YWVogAAAAAAAAYpYAALeJAAAY2lhZWiAAAAAAAAAkoAAAD4UAALbEY3VydgAAAAAAAAC2AAAAHAA4AFQAcACMAKgAxADhAQABIgFGAW0BlQHBAfACIAJVAosCxAMBAz8DggPGBA4EWQSnBPkFTAWkBf4GXAa+ByEHigf0CGMI1QlJCcMKPwq/C0ILyQxUDOENdA4JDqIPQA/gEIURLRHaEooTPhP2FLIVcRY2Fv0XyhiZGW4aRhsiHAMc5x3QHr0friCkIZ4inCOfJKUlsSbAJ9Uo7SoKKyssUS18Lqov3jEWMlIzlDTZNiQ3czjGOiA7fDzfPkU/sEEhQpZEEEWPRxJIm0ooS7tNUU7uUI9SNVPgVZBXRVkAWr5chF5MYBth72PHZaZniWlxa19tUW9KcUZzSnVRd155cXuIfaZ/yIHwhB6GUIiJisWNCY9RkZ+T85ZLmKubDp14n+eiW6TWp1ap26xnrvexj7Qqtsy5dLwhvtXBjcRMxxDJ2syrz3/SXNU92CTbEt4E4P7j/OcB6gztHPA081D2c/mb/Mr//w==";
+}

--- a/Pdfe.Core/Authoring/PdfDocumentBuilder.cs
+++ b/Pdfe.Core/Authoring/PdfDocumentBuilder.cs
@@ -92,6 +92,20 @@ public sealed class PdfDocumentBuilder
         return this;
     }
 
+    /// <summary>
+    /// Produce a PDF/A archival file: adds the required XMP metadata (with the
+    /// <c>pdfaid</c> identifier) and an sRGB OutputIntent at save time. The caller
+    /// must embed all fonts via <see cref="DefaultFont"/> — PDF/A forbids the
+    /// non-embedded base-14 fonts. Best for flat (non-interactive) output.
+    /// </summary>
+    public PdfDocumentBuilder PdfA(PdfAConformance conformance = PdfAConformance.PdfA2B)
+    {
+        // PDF/A requires the XMP pdf:Producer to match the Info dictionary.
+        _document.SetProducer("pdfe");
+        _document.RegisterPreSaveAction(() => PdfAWriter.Apply(_document, conformance));
+        return this;
+    }
+
     private static string HeadingTag(int level) => level switch
     {
         <= 1 => "H1", 2 => "H2", 3 => "H3", _ => "H4"

--- a/Pdfe.Core/Writing/PdfDocumentWriter.cs
+++ b/Pdfe.Core/Writing/PdfDocumentWriter.cs
@@ -169,6 +169,20 @@ public class PdfDocumentWriter
             trailer["Info"] = infoRef;
         }
 
+        // /ID — a file identifier array of two byte strings (ISO 32000-1 §14.4).
+        // Required by PDF/A and recommended for every file. Preserve an existing
+        // one; otherwise generate a fresh pair.
+        var existingId = _document.Trailer.ContainsKey("ID") ? _document.Trailer.GetArray("ID") : null;
+        if (existingId is { Count: > 0 })
+        {
+            trailer["ID"] = existingId;
+        }
+        else
+        {
+            var id = new PdfString(System.Security.Cryptography.RandomNumberGenerator.GetBytes(16), isHex: true);
+            trailer["ID"] = new PdfArray(id, id);
+        }
+
         // Write trailer
         writer.Write(Encoding.ASCII.GetBytes("trailer\n"));
         var trailerStr = PdfObjectWriter.Serialize(trailer);


### PR DESCRIPTION
## Summary
Preserves PDF/A archival-export support for the authoring API — work that addresses **#425** and was built for **PromptResponse** archival export. (It had been left uncommitted in the working tree by a separate session; recovered and put on its own branch.)

- **`PdfDocumentBuilder.PdfA(PdfAConformance = PdfA2B)`** — registers a pre-save action that writes the document-level structures PDF/A requires.
- **`PdfAWriter`** — emits an XMP metadata packet with the `pdfaid` identifier and an `OutputIntent` referencing an embedded sRGB ICC profile.
- **`enum PdfAConformance`** — `PdfA1B`, `PdfA2B`.
- **Trailer `/ID`** — every new document now gets a trailer file identifier (a PDF/A requirement).

## Status (per #425)
- **PDF/A-2b validates as compliant in veraPDF 1.30.2 (144/144).**
- **PDF/A-1b** still fails 3 stricter rules (likely subset-font `CIDSet`) — that gap + a veraPDF CI gate is the **remaining** work tracked in #425; this PR lands the working 2b export.

## Tests
`PdfATests` (XMP `pdfaid` + OutputIntent + trailer `/ID`; new doc always gets a trailer `/ID`) pass; `PublicApiApprovalTests` baseline regenerated for the new public surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)