### PR TITLE
release: v2.9.0 — continuous reading view + macOS open + PDF/A export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,26 @@ All notable changes to pdfe are documented here. Format roughly follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this project uses
 semantic versioning.
 
-## [2.8.0] — 2026-06-08
+## [2.9.0] — 2026-06-08
 
-Operator render-coverage release (#350). Additive; no breaking changes.
+Viewer + macOS-reader + archival release. Additive; no breaking changes
+(public-API gate confirmed for `Pdfe.Core`).
 
 ### Added
+- **Continuous (reading) view mode for `Pdfe.Avalonia` (#371).** New
+  `PdfViewerControl.ViewMode` (`PdfViewMode.SinglePage` default | `Continuous`).
+  Continuous shows every page in a vertically-scrolling, **render-virtualized**
+  list — only pages near the viewport render, bitmaps are bounded by an LRU
+  cache, and off-screen renders are cancelled. It is **read-only by design**:
+  entering an editing interaction (Redaction / TextSelection / FormAuthoring)
+  auto-switches back to single-page, so the editing/redaction overlays only ever
+  run against a single rendered page. Scroll ⇄ current-page stay in sync and zoom
+  resizes pages live. New public types `PdfViewMode`, `PdfPageSlot`.
+- **macOS: open PDFs from Finder / be a default reader (#420).** The app handles
+  the macOS file-activation event (Finder double-click, Dock, `open -a`), and the
+  generated `.app` `Info.plist` declares `CFBundleDocumentTypes` for
+  `com.adobe.pdf` so pdfe registers as a PDF handler. README documents setting it
+  as the default reader and the one-time Gatekeeper unquarantine.
 - **PDF/A archival output.** `PdfDocumentBuilder.PdfA(PdfAConformance.PdfA2B)`
   adds the document structures PDF/A requires at save time — an XMP metadata
   packet with the `pdfaid` identifier and an sRGB OutputIntent (embedded ICC
@@ -18,6 +33,20 @@ Operator render-coverage release (#350). Additive; no breaking changes.
 - **Trailer `/ID`.** Newly authored documents now always get a file-identifier
   array in the trailer (ISO 32000-1 §14.4) — required by PDF/A and recommended
   generally; an existing `/ID` is preserved.
+
+### Fixed
+- **Chronic headless GUI test host-crash (#363), part 2.** The headless test
+  runner now closes each test's windows afterward (tracked via Avalonia's global
+  routed-event streams), bounding the shared dispatcher's live-window set, and the
+  heavy `*_MatchesBaseline` visual-regression tests are excluded from the PR gate
+  (owned by the nightly job). Reduces — but does not yet fully eliminate — the
+  residual native host crash; full resolution is in progress.
+
+## [2.8.0] — 2026-06-08
+
+Operator render-coverage release (#350). Additive; no breaking changes.
+
+### Added
 - **Dash pattern (`d`) rendering.** The dash operator was parsed but ignored by
   the renderer, so dashed strokes drew solid. `SkiaRenderer` now honors it via
   `SKPathEffect.CreateDash` on both stroke paths; odd-length PDF dash arrays are

--- a/Pdfe.Avalonia/Pdfe.Avalonia.csproj
+++ b/Pdfe.Avalonia/Pdfe.Avalonia.csproj
@@ -14,7 +14,7 @@
   <!-- NuGet package metadata (packed explicitly via `dotnet pack`, not on build). -->
   <PropertyGroup>
     <PackageId>Pdfe.Avalonia</PackageId>
-    <Version>2.8.0</Version>
+    <Version>2.9.0</Version>
     <Authors>Marc Jones</Authors>
     <Description>A reusable, pure-managed PDF viewer control for Avalonia. Renders with SkiaSharp (no native PDFium), supports zoom/pan, page navigation, text selection, search highlights, annotations, links, and form-field overlays. Built on Pdfe.Core + Pdfe.Rendering.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Pdfe.Core/Pdfe.Core.csproj
+++ b/Pdfe.Core/Pdfe.Core.csproj
@@ -10,7 +10,7 @@
 
   <PropertyGroup>
     <PackageId>Pdfe.Core</PackageId>
-    <Version>2.8.0</Version>
+    <Version>2.9.0</Version>
     <Authors>Marc Jones</Authors>
     <Description>Pure-managed PDF parser, document model, and writer for .NET. Open/edit/save PDFs, extract text/links/annotations/forms, and perform true glyph-level redaction. No native dependencies; cross-platform and trim/AOT-friendlier.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Pdfe.Rendering/Pdfe.Rendering.csproj
+++ b/Pdfe.Rendering/Pdfe.Rendering.csproj
@@ -10,7 +10,7 @@
 
   <PropertyGroup>
     <PackageId>Pdfe.Rendering</PackageId>
-    <Version>2.8.0</Version>
+    <Version>2.9.0</Version>
     <Authors>Marc Jones</Authors>
     <Description>Pure-managed, SkiaSharp-based PDF render API for .NET. Render pages to SKBitmap or PNG with DPI/clip/rotation support and cancellable rendering. Framework-neutral engine behind Pdfe.Avalonia; no native PDFium. Cross-platform, trim/AOT-friendlier.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
Version bump to 2.9.0 (Pdfe.Core / Pdfe.Rendering / Pdfe.Avalonia) + CHANGELOG. Bundles the work merged since v2.8.0: continuous reading view mode (#371 pt2, #428), macOS Finder-open / default-reader (#420, #423), PDF/A archival export (#429), trailer /ID, and the #363 host-crash mitigation. Tag v2.9.0 after merge to trigger the release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)