### PR TITLE
feat(test): public-API gate for Pdfe.Avalonia + Pdfe.Rendering in a non-flaky project (#384)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,15 @@ jobs:
           dotnet test Pdfe.Cli.Tests --no-build -c Debug \
             --logger "console;verbosity=normal"
 
+      - name: Run Pdfe.Avalonia.Tests
+        # Lightweight, non-GUI tests for the viewer libraries (API gates, pure
+        # logic). Deliberately separate from the heavy, flaky headless
+        # PdfEditor.Tests suite so viewer-library changes get reliable coverage
+        # on every PR. (#363, #384)
+        run: |
+          dotnet test Pdfe.Avalonia.Tests --no-build -c Debug \
+            --logger "console;verbosity=normal"
+
       - name: Run Pdfe.Rendering.Tests (deterministic only)
         run: |
           # The PR gate runs only environment-independent rendering tests

--- a/Pdfe.Avalonia.Tests/Pdfe.Avalonia.Tests.csproj
+++ b/Pdfe.Avalonia.Tests/Pdfe.Avalonia.Tests.csproj
@@ -1,0 +1,37 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Lightweight, NON-GUI test project for the viewer libraries (Pdfe.Avalonia /
+    Pdfe.Rendering). It deliberately does NOT reference the PdfEditor app and is
+    NOT part of the `gui` paths-filter, so it runs on every PR without dragging in
+    the heavy, flaky headless PdfEditor.Tests suite. Keep tests here lightweight
+    (reflection/API gates, pure logic) — anything that drives many real-Skia
+    renders belongs in PdfEditor.Tests / the nightly job. (#363, #384)
+  -->
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <NoWarn>$(NoWarn);xUnit1051</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Pdfe.Avalonia\Pdfe.Avalonia.csproj" />
+    <ProjectReference Include="..\Pdfe.Rendering\Pdfe.Rendering.csproj" />
+    <ProjectReference Include="..\Pdfe.Core\Pdfe.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AwesomeAssertions" Version="9.4.0" />
+    <PackageReference Include="PublicApiGenerator" Version="11.5.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/Pdfe.Avalonia.Tests/PublicApi/Pdfe.Avalonia.approved.txt
+++ b/Pdfe.Avalonia.Tests/PublicApi/Pdfe.Avalonia.approved.txt
@@ -1,0 +1,142 @@
+namespace Pdfe.Avalonia.Controls
+{
+    public class FormFieldEditedEventArgs : System.EventArgs
+    {
+        public FormFieldEditedEventArgs(string fieldName, string? newValue, int pageNumber) { }
+        public string FieldName { get; }
+        public string? NewValue { get; }
+        public int PageNumber { get; }
+    }
+    public class FormFieldRectDrawnEventArgs : System.EventArgs
+    {
+        public FormFieldRectDrawnEventArgs(Pdfe.Core.Document.PdfRectangle rect, int pageNumber) { }
+        public int PageNumber { get; }
+        public Pdfe.Core.Document.PdfRectangle Rect { get; }
+    }
+    public sealed class HiddenTextHighlight : System.IEquatable<Pdfe.Avalonia.Controls.HiddenTextHighlight>
+    {
+        public HiddenTextHighlight(string Text, Avalonia.Rect ScreenBounds, string HiddenBy, Pdfe.Avalonia.Controls.HiddenTextSource Source = 0) { }
+        public string HiddenBy { get; init; }
+        public Avalonia.Rect ScreenBounds { get; init; }
+        public Pdfe.Avalonia.Controls.HiddenTextSource Source { get; init; }
+        public string Text { get; init; }
+    }
+    public enum HiddenTextSource
+    {
+        Structural = 0,
+        DifferentialOcr = 1,
+    }
+    public enum InteractionMode
+    {
+        None = 0,
+        Redaction = 1,
+        TextSelection = 2,
+        Pan = 3,
+        FormAuthoring = 4,
+    }
+    public class LinkClickedEventArgs : System.EventArgs
+    {
+        public LinkClickedEventArgs(int pageNumber) { }
+        public int PageNumber { get; }
+    }
+    public class PageChangedEventArgs : System.EventArgs
+    {
+        public PageChangedEventArgs(int pageNumber) { }
+        public int PageNumber { get; }
+    }
+    public sealed class PdfPageSlot : System.ComponentModel.INotifyPropertyChanged
+    {
+        public Avalonia.Media.Imaging.WriteableBitmap? Bitmap { get; set; }
+        public double DisplayHeight { get; }
+        public double DisplayWidth { get; }
+        public double HeightPt { get; }
+        public int PageNumber { get; }
+        public double WidthPt { get; }
+        public event System.ComponentModel.PropertyChangedEventHandler? PropertyChanged;
+    }
+    public enum PdfViewMode
+    {
+        SinglePage = 0,
+        Continuous = 1,
+    }
+    public class PdfViewerControl : Avalonia.Controls.UserControl
+    {
+        public static readonly Avalonia.StyledProperty<System.Collections.Generic.IEnumerable<Pdfe.Core.Document.PdfAnnotation>?> AnnotationsProperty;
+        public static readonly Avalonia.StyledProperty<int> CurrentPageProperty;
+        public static readonly Avalonia.StyledProperty<Pdfe.Core.Document.PdfDocument?> DocumentProperty;
+        public static readonly Avalonia.StyledProperty<string?> ErrorMessageProperty;
+        public static readonly Avalonia.StyledProperty<System.Collections.Generic.IReadOnlyList<Pdfe.Core.Document.PdfField>?> FormFieldsProperty;
+        public static readonly Avalonia.StyledProperty<bool> HasErrorProperty;
+        public static readonly Avalonia.StyledProperty<System.Collections.Generic.IEnumerable<Pdfe.Avalonia.Controls.HiddenTextHighlight>?> HiddenTextHighlightsProperty;
+        public static readonly Avalonia.StyledProperty<Pdfe.Avalonia.Controls.InteractionMode> InteractionModeProperty;
+        public static readonly Avalonia.StyledProperty<bool> IsLoadingProperty;
+        public static readonly Avalonia.StyledProperty<Pdfe.Avalonia.Controls.PdfViewMode> ViewModeProperty;
+        public static readonly Avalonia.StyledProperty<double> ZoomLevelProperty;
+        public PdfViewerControl() { }
+        public System.Collections.Generic.IEnumerable<Pdfe.Core.Document.PdfAnnotation>? Annotations { get; set; }
+        public int CurrentPage { get; set; }
+        public Pdfe.Core.Document.PdfDocument? Document { get; set; }
+        public string? ErrorMessage { get; }
+        public System.Collections.Generic.IReadOnlyList<Pdfe.Core.Document.PdfField>? FormFields { get; set; }
+        public bool HasError { get; }
+        public System.Collections.Generic.IEnumerable<Pdfe.Avalonia.Controls.HiddenTextHighlight>? HiddenTextHighlights { get; set; }
+        public Pdfe.Avalonia.Controls.InteractionMode InteractionMode { get; set; }
+        public bool IsLoading { get; }
+        public Pdfe.Avalonia.Controls.PdfViewMode ViewMode { get; set; }
+        public double ZoomLevel { get; set; }
+        public event System.EventHandler<Pdfe.Avalonia.Controls.FormFieldEditedEventArgs>? FormFieldEdited;
+        public event System.EventHandler<Pdfe.Avalonia.Controls.FormFieldRectDrawnEventArgs>? FormFieldRectDrawn;
+        public event System.EventHandler<Pdfe.Avalonia.Controls.LinkClickedEventArgs>? LinkClicked;
+        public event System.EventHandler<Pdfe.Avalonia.Controls.PageChangedEventArgs>? PageChanged;
+        public event System.EventHandler<Pdfe.Avalonia.Controls.RedactionDrawnEventArgs>? RedactionDrawn;
+        public event System.EventHandler<Pdfe.Avalonia.Controls.TextSelectedEventArgs>? TextSelected;
+        public event System.EventHandler<Avalonia.Size>? VisibleViewportChanged;
+        public void AddAppliedRedaction(Avalonia.Rect area) { }
+        public void AddPendingRedaction(Avalonia.Rect area) { }
+        public void AddSearchHighlight(Avalonia.Rect area) { }
+        public void ClearAllOverlays() { }
+        public void ClearAppliedRedactions() { }
+        public void ClearPendingRedactions() { }
+        public void ClearSearchHighlights() { }
+        public void ClearSelectionHighlight() { }
+        public Avalonia.Size GetVisibleViewportSize() { }
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+        public void InitializeComponent(bool loadXaml = true) { }
+        public void InvalidatePageCache() { }
+        public void NextPage() { }
+        public void PreviousPage() { }
+        public void ZoomIn() { }
+        public void ZoomOut() { }
+        public void ZoomToActualSize() { }
+    }
+    public class RedactionDrawnEventArgs : System.EventArgs
+    {
+        public RedactionDrawnEventArgs(Avalonia.Rect area) { }
+        public Avalonia.Rect Area { get; }
+    }
+    public class TextSelectedEventArgs : System.EventArgs
+    {
+        public TextSelectedEventArgs(Avalonia.Rect area) { }
+        public TextSelectedEventArgs(Avalonia.Rect area, string text, System.Collections.Generic.IReadOnlyList<Avalonia.Rect> letterBoundsDips) { }
+        public Avalonia.Rect Area { get; }
+        public System.Collections.Generic.IReadOnlyList<Avalonia.Rect> LetterBoundsDips { get; }
+        public string Text { get; }
+    }
+}
+namespace Pdfe.Avalonia.Imaging
+{
+    public static class SkiaInterop
+    {
+        public static Avalonia.Media.Imaging.WriteableBitmap? ToAvaloniaBitmap(SkiaSharp.SKBitmap? skBitmap) { }
+    }
+}
+namespace Pdfe.Avalonia.Services
+{
+    public static class TextSelectionEngine
+    {
+        public static Pdfe.Core.Text.Letter? HitTest(System.Collections.Generic.IReadOnlyList<Pdfe.Core.Text.Letter> letters, double pdfX, double pdfY) { }
+        public static string JoinText(System.Collections.Generic.IReadOnlyList<Pdfe.Core.Text.Letter> letters) { }
+        public static System.Collections.Generic.List<Pdfe.Core.Text.Letter> RangeBetween(System.Collections.Generic.IReadOnlyList<Pdfe.Core.Text.Letter> ordered, Pdfe.Core.Text.Letter anchor, Pdfe.Core.Text.Letter focus) { }
+        public static System.Collections.Generic.List<Pdfe.Core.Text.Letter> SortReadingOrder(System.Collections.Generic.IEnumerable<Pdfe.Core.Text.Letter> letters) { }
+    }
+}

--- a/Pdfe.Avalonia.Tests/PublicApi/Pdfe.Rendering.approved.txt
+++ b/Pdfe.Avalonia.Tests/PublicApi/Pdfe.Rendering.approved.txt
@@ -1,0 +1,61 @@
+namespace Pdfe.Rendering.Differential
+{
+    public static class DifferentialMetrics
+    {
+        public static SkiaSharp.SKBitmap BuildDiffOverlay(SkiaSharp.SKBitmap a, SkiaSharp.SKBitmap b) { }
+        public static Pdfe.Rendering.Differential.DifferentialReport Compare(SkiaSharp.SKBitmap a, SkiaSharp.SKBitmap b) { }
+        public static SkiaSharp.SKBitmap ResizeMatch(SkiaSharp.SKBitmap src, int targetW, int targetH) { }
+        public static void SaveTriptych(string path, SkiaSharp.SKBitmap pdfe, SkiaSharp.SKBitmap mutool, SkiaSharp.SKBitmap? diff = null) { }
+    }
+    public sealed class DifferentialReport : System.IEquatable<Pdfe.Rendering.Differential.DifferentialReport>
+    {
+        public DifferentialReport(int Width, int Height, int PixelCount, int DifferingPixels, double DifferingPixelFraction, double MeanAbsoluteError, double MaxAbsoluteError) { }
+        public double DifferingPixelFraction { get; init; }
+        public int DifferingPixels { get; init; }
+        public int Height { get; init; }
+        public double MaxAbsoluteError { get; init; }
+        public double MeanAbsoluteError { get; init; }
+        public int PixelCount { get; init; }
+        public int Width { get; init; }
+        public override string ToString() { }
+    }
+    public static class MutoolReferenceRenderer
+    {
+        public static bool IsAvailable { get; }
+        public static SkiaSharp.SKBitmap? RenderPage(string pdfPath, int pageNumber, int dpi, int timeoutMs = 30000) { }
+    }
+    public static class PdftocairoReferenceRenderer
+    {
+        public static bool IsAvailable { get; }
+        public static SkiaSharp.SKBitmap? RenderPage(string pdfPath, int pageNumber, int dpi, int timeoutMs = 30000) { }
+    }
+}
+namespace Pdfe.Rendering
+{
+    public class RenderOptions : System.IEquatable<Pdfe.Rendering.RenderOptions>
+    {
+        public RenderOptions() { }
+        public bool AntiAlias { get; init; }
+        public SkiaSharp.SKColor BackgroundColor { get; init; }
+        public SkiaSharp.SKRect? ClipRect { get; init; }
+        public int Dpi { get; init; }
+    }
+    public class SKBitmapPool : System.IDisposable
+    {
+        public SKBitmapPool() { }
+        public long CurrentMemoryUsage { get; }
+        public void Dispose() { }
+        public int GetPoolCountForSize(int width, int height) { }
+        public int GetTotalPoolCount() { }
+        public SkiaSharp.SKBitmap Rent(int width, int height) { }
+        public void Return(SkiaSharp.SKBitmap bitmap) { }
+    }
+    public class SkiaRenderer
+    {
+        public SkiaRenderer() { }
+        public SkiaSharp.SKBitmap RenderPage(Pdfe.Core.Document.PdfPage page) { }
+        public SkiaSharp.SKBitmap RenderPage(Pdfe.Core.Document.PdfPage page, Pdfe.Rendering.RenderOptions options) { }
+        public SkiaSharp.SKBitmap RenderPage(Pdfe.Core.Document.PdfPage page, Pdfe.Rendering.RenderOptions options, System.Threading.CancellationToken cancellationToken) { }
+        public void RenderPageToPng(Pdfe.Core.Document.PdfPage page, System.IO.Stream destination, Pdfe.Rendering.RenderOptions? options = null, System.Threading.CancellationToken cancellationToken = default) { }
+    }
+}

--- a/Pdfe.Avalonia.Tests/ViewerPublicApiApprovalTests.cs
+++ b/Pdfe.Avalonia.Tests/ViewerPublicApiApprovalTests.cs
@@ -1,0 +1,68 @@
+using System;
+using System.IO;
+using System.Runtime.CompilerServices;
+using AwesomeAssertions;
+using PublicApiGenerator;
+using Xunit;
+
+namespace Pdfe.Avalonia.Tests;
+
+/// <summary>
+/// Public-API gate for the packable viewer libraries <c>Pdfe.Avalonia</c> and
+/// <c>Pdfe.Rendering</c> (issue #384 — the DX/stability treatment #383 gave the
+/// writer, applied to the viewer/render side).
+///
+/// <para>
+/// Each test snapshots the full public surface of one assembly and compares it to
+/// a committed baseline under <c>PublicApi/</c>. Any change to the public API — a
+/// new/removed/renamed public type or member, a changed signature — fails the
+/// test, forcing an intentional SemVer review before it ships.
+/// </para>
+///
+/// <para>
+/// To accept an intentional change: re-run with the <c>APPROVE_PUBLIC_API=1</c>
+/// env var (the test regenerates the baseline) and commit the updated
+/// <c>*.approved.txt</c>. The diff in review *is* the API-change review. This is a
+/// pure-reflection test (no Avalonia runtime), so it runs reliably outside the
+/// flaky headless GUI suite.
+/// </para>
+/// </summary>
+public class ViewerPublicApiApprovalTests
+{
+    [Fact]
+    public void PdfeAvalonia_PublicApi_MatchesApprovedBaseline()
+        => AssertPublicApi(typeof(global::Pdfe.Avalonia.Controls.PdfViewerControl), "Pdfe.Avalonia.approved.txt");
+
+    [Fact]
+    public void PdfeRendering_PublicApi_MatchesApprovedBaseline()
+        => AssertPublicApi(typeof(global::Pdfe.Rendering.SkiaRenderer), "Pdfe.Rendering.approved.txt");
+
+    private static void AssertPublicApi(Type anchor, string approvedFile)
+    {
+        var api = anchor.Assembly
+            .GeneratePublicApi(new ApiGeneratorOptions { IncludeAssemblyAttributes = false })
+            .Replace("\r\n", "\n")
+            .TrimEnd();
+
+        var approvedPath = Path.Combine(ApprovedDir(), approvedFile);
+
+        bool approveMode = Environment.GetEnvironmentVariable("APPROVE_PUBLIC_API") == "1";
+        if (approveMode || !File.Exists(approvedPath))
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(approvedPath)!);
+            File.WriteAllText(approvedPath, api + "\n");
+            File.Exists(approvedPath).Should().BeTrue();
+            return;
+        }
+
+        var approved = File.ReadAllText(approvedPath).Replace("\r\n", "\n").TrimEnd();
+        api.Should().Be(approved,
+            $"the {anchor.Assembly.GetName().Name} public API must not change without an intentional " +
+            "SemVer review. If deliberate, re-run with APPROVE_PUBLIC_API=1 and commit the updated " +
+            approvedFile + ".");
+    }
+
+    /// <summary>Locate the PublicApi folder next to this test source file.</summary>
+    private static string ApprovedDir([CallerFilePath] string thisFile = "")
+        => Path.Combine(Path.GetDirectoryName(thisFile)!, "PublicApi");
+}

--- a/pdfe.sln
+++ b/pdfe.sln
@@ -29,6 +29,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Pdfe.Avalonia", "Pdfe.Avalo
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Pdfe.Avalonia.Sample", "Pdfe.Avalonia.Sample\Pdfe.Avalonia.Sample.csproj", "{0080D695-9AE4-4A3F-B0A8-7A643148A9E4}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Pdfe.Avalonia.Tests", "Pdfe.Avalonia.Tests\Pdfe.Avalonia.Tests.csproj", "{58448B0F-9E30-4BB5-9B89-921F095A43A6}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -195,6 +197,18 @@ Global
 		{0080D695-9AE4-4A3F-B0A8-7A643148A9E4}.Release|x64.Build.0 = Release|Any CPU
 		{0080D695-9AE4-4A3F-B0A8-7A643148A9E4}.Release|x86.ActiveCfg = Release|Any CPU
 		{0080D695-9AE4-4A3F-B0A8-7A643148A9E4}.Release|x86.Build.0 = Release|Any CPU
+		{58448B0F-9E30-4BB5-9B89-921F095A43A6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{58448B0F-9E30-4BB5-9B89-921F095A43A6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{58448B0F-9E30-4BB5-9B89-921F095A43A6}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{58448B0F-9E30-4BB5-9B89-921F095A43A6}.Debug|x64.Build.0 = Debug|Any CPU
+		{58448B0F-9E30-4BB5-9B89-921F095A43A6}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{58448B0F-9E30-4BB5-9B89-921F095A43A6}.Debug|x86.Build.0 = Debug|Any CPU
+		{58448B0F-9E30-4BB5-9B89-921F095A43A6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{58448B0F-9E30-4BB5-9B89-921F095A43A6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{58448B0F-9E30-4BB5-9B89-921F095A43A6}.Release|x64.ActiveCfg = Release|Any CPU
+		{58448B0F-9E30-4BB5-9B89-921F095A43A6}.Release|x64.Build.0 = Release|Any CPU
+		{58448B0F-9E30-4BB5-9B89-921F095A43A6}.Release|x86.ActiveCfg = Release|Any CPU
+		{58448B0F-9E30-4BB5-9B89-921F095A43A6}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary
Part of **#384** (stable, documented viewer/render API). Adds a public-API approval gate for the packable viewer libraries — mirroring the `Pdfe.Core` gate from #383.

- New **`Pdfe.Avalonia.Tests`** project snapshots `Pdfe.Avalonia` + `Pdfe.Rendering` public surfaces against committed baselines; any API change fails CI until `APPROVE_PUBLIC_API=1` regenerates them (a deliberate SemVer decision).
- **Deliberately non-flaky:** the project is separate from `PdfEditor.Tests` and **not in the `gui` paths-filter**, so viewer-library changes finally get reliable per-PR coverage *without* the heavy, crash-prone headless GUI suite (#363). Tests here stay lightweight (pure-reflection gates); real-Skia render tests stay in `PdfEditor.Tests`/nightly.
- CI runs it as its own always-on step.

This is the first item of the reordered, flake-avoiding work plan (after the v2.9.0 release). It also establishes the home for future viewer-lib unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)