### PR TITLE
feat(acroform): expose radio-button group export values publicly (#424)

### DIFF
--- a/Pdfe.Core.Tests/Document/PdfAcroFormTests.cs
+++ b/Pdfe.Core.Tests/Document/PdfAcroFormTests.cs
@@ -161,7 +161,93 @@ public class PdfAcroFormTests
         return Encoding.Latin1.GetBytes(sb.ToString());
     }
 
+    /// <summary>
+    /// A radio-button group: a Btn field with two Widget kids, each with an
+    /// /AP /N holding a distinct on-state ("Male" / "Female") plus "Off".
+    /// </summary>
+    private static byte[] MakePdfWithRadioGroup()
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("%PDF-1.7");
+
+        long catalogPos = sb.Length;
+        sb.AppendLine("1 0 obj");
+        sb.AppendLine("<< /Type /Catalog /Pages 2 0 R /AcroForm << /Fields [5 0 R] >> >>");
+        sb.AppendLine("endobj");
+
+        long pagesPos = sb.Length;
+        sb.AppendLine("2 0 obj");
+        sb.AppendLine("<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+        sb.AppendLine("endobj");
+
+        long pagePos = sb.Length;
+        sb.AppendLine("3 0 obj");
+        sb.AppendLine("<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Annots [6 0 R 7 0 R] >>");
+        sb.AppendLine("endobj");
+
+        long contentPos = sb.Length;
+        sb.AppendLine("4 0 obj");
+        sb.AppendLine("<< /Length 0 >>\nstream\nendstream\nendobj");
+
+        // Obj 5 — radio group parent (Btn, Radio flag 0x10000) with two widget kids.
+        long radioPos = sb.Length;
+        sb.AppendLine("5 0 obj");
+        sb.AppendLine("<< /FT /Btn /Ff 49152 /T (Gender) /V /Male /Kids [6 0 R 7 0 R] >>");
+        sb.AppendLine("endobj");
+
+        // Obj 6 — "Male" widget.
+        long w1Pos = sb.Length;
+        sb.AppendLine("6 0 obj");
+        sb.AppendLine("<< /Type /Annot /Subtype /Widget /Parent 5 0 R /Rect [72 700 90 718] " +
+                      "/AS /Male /AP << /N << /Male << >> /Off << >> >> >> /P 3 0 R >>");
+        sb.AppendLine("endobj");
+
+        // Obj 7 — "Female" widget.
+        long w2Pos = sb.Length;
+        sb.AppendLine("7 0 obj");
+        sb.AppendLine("<< /Type /Annot /Subtype /Widget /Parent 5 0 R /Rect [72 680 90 698] " +
+                      "/AS /Off /AP << /N << /Female << >> /Off << >> >> >> /P 3 0 R >>");
+        sb.AppendLine("endobj");
+
+        long xrefPos = sb.Length;
+        sb.AppendLine("xref");
+        sb.AppendLine("0 8");
+        sb.AppendLine("0000000000 65535 f ");
+        foreach (var p in new[] { catalogPos, pagesPos, pagePos, contentPos, radioPos, w1Pos, w2Pos })
+            sb.AppendLine($"{p:D10} 00000 n ");
+        sb.AppendLine("trailer");
+        sb.AppendLine("<< /Size 8 /Root 1 0 R >>");
+        sb.AppendLine("startxref");
+        sb.AppendLine(xrefPos.ToString());
+        sb.AppendLine("%%EOF");
+
+        return Encoding.Latin1.GetBytes(sb.ToString());
+    }
+
     // ─── basic parsing ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void ButtonExportValues_RadioGroup_ReturnsPerWidgetOnStates()
+    {
+        // #424: a consumer importing a radio group needs its selectable export
+        // values (the widget /AP /N on-states), not a generic boolean.
+        byte[] pdf = MakePdfWithRadioGroup();
+        using var doc = PdfDocument.Open(new MemoryStream(pdf), ownsStream: false);
+
+        var field = doc.GetAcroForm()!.Fields.Single(f => f.PartialName == "Gender");
+        field.FieldType.Should().Be(PdfFieldType.Button);
+        field.ButtonExportValues.Should().Equal("Male", "Female");
+    }
+
+    [Fact]
+    public void ButtonExportValues_NonButtonField_IsEmpty()
+    {
+        byte[] pdf = MakePdfWithComplexAcroForm();
+        using var doc = PdfDocument.Open(new MemoryStream(pdf), ownsStream: false);
+
+        var text = doc.GetAcroForm()!.Fields.First(f => f.FieldType == PdfFieldType.Text);
+        text.ButtonExportValues.Should().BeEmpty();
+    }
 
     [Fact]
     public void GetAcroForm_NullDocument_ReturnsNull()

--- a/Pdfe.Core.Tests/PublicApi/Pdfe.Core.approved.txt
+++ b/Pdfe.Core.Tests/PublicApi/Pdfe.Core.approved.txt
@@ -477,6 +477,7 @@ namespace Pdfe.Core.Document
     public sealed class PdfField
     {
         public PdfField(Pdfe.Core.Document.PdfDocument document, string fullName, string partialName, Pdfe.Core.Document.PdfFieldType fieldType, System.Collections.Generic.IReadOnlyList<string>? options, Pdfe.Core.Document.PdfRectangle? rect, int? pageNumber, bool isReadOnly, bool isRequired, bool isMultiline, Pdfe.Core.Primitives.PdfDictionary rawDictionary, System.Collections.Generic.IReadOnlyList<Pdfe.Core.Primitives.PdfDictionary> widgetDictionaries) { }
+        public System.Collections.Generic.IReadOnlyList<string> ButtonExportValues { get; }
         public string? DefaultValue { get; }
         public Pdfe.Core.Document.PdfFieldType FieldType { get; }
         public string FullName { get; }

--- a/Pdfe.Core/Document/PdfField.cs
+++ b/Pdfe.Core/Document/PdfField.cs
@@ -54,6 +54,43 @@ public sealed class PdfField
     public IReadOnlyList<string>? Options { get; }
 
     /// <summary>
+    /// For a <see cref="PdfFieldType.Button"/> field, the selectable "on" export
+    /// values — the appearance-state names from each widget's <c>/AP /N</c>
+    /// dictionary other than <c>Off</c>, in widget order, de-duplicated. A radio
+    /// group exposes one value per option (its widgets); a single checkbox
+    /// typically exposes one. Empty for non-Button fields (and for buttons with
+    /// no on-state appearances). Lets consumers map a radio group to a
+    /// choice/dropdown rather than a generic boolean (#424).
+    /// </summary>
+    public IReadOnlyList<string> ButtonExportValues
+    {
+        get
+        {
+            if (FieldType != PdfFieldType.Button)
+                return Array.Empty<string>();
+
+            var values = new List<string>();
+            foreach (var widget in WidgetDictionaries)
+                foreach (var state in GetWidgetOnStates(widget))
+                    if (!values.Contains(state))
+                        values.Add(state);
+            return values;
+        }
+    }
+
+    /// <summary>The non-<c>Off</c> appearance-state names under a widget's <c>/AP /N</c>.</summary>
+    private IEnumerable<string> GetWidgetOnStates(PdfDictionary widget)
+    {
+        if (_document.Resolve(widget.GetOptional("AP")) is not PdfDictionary ap)
+            yield break;
+        if (_document.Resolve(ap.GetOptional("N")) is not PdfDictionary normal)
+            yield break;
+        foreach (var key in normal.Keys)
+            if (key.Value != "Off")
+                yield return key.Value;
+    }
+
+    /// <summary>
     /// The field's bounding rectangle on the page (from /Rect in the
     /// associated Widget annotation), or null if the field has no visual
     /// representation or the rectangle could not be parsed.


### PR DESCRIPTION
## Summary
Closes the #424 gap hit while building the PromptResponse PDF→form importer: a radio group came through as a single `Button` `PdfField` with **no public way** to get its selectable export values.

- New public **`PdfField.ButtonExportValues`** — for a Button field, the on-state names from each widget's `/AP /N` (excluding `Off`), in widget order, de-duplicated. Radio group → one value per option; non-Button → empty.
- The data was already parsed into `WidgetDictionaries` (internal); this just exposes it cleanly.

Unblocks promptresponse#64 (map radio group → dropdown instead of a generic boolean).

## Tests
-  (two-widget Male/Female group → `["Male","Female"]`)
- 
- Public-API gate regenerated (additive).

Pdfe.Core-only — no GUI suite, no flake risk. Part of the reordered non-flaky work queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)