### PR TITLE
fix(authoring): correct base-14 WinAnsi text encoding — no more mojibake (#426)

### DIFF
--- a/Pdfe.Core.Tests/Graphics/WinAnsiEncodingTests.cs
+++ b/Pdfe.Core.Tests/Graphics/WinAnsiEncodingTests.cs
@@ -1,0 +1,42 @@
+using AwesomeAssertions;
+using Pdfe.Core.Graphics;
+using Xunit;
+
+namespace Pdfe.Core.Tests.Graphics;
+
+/// <summary>
+/// Regression tests for #426: the base-14 (WinAnsi) text encoder used to format
+/// the Unicode code point in decimal as a "\ddd" escape — which PDF reads as
+/// octal — so accented / punctuation characters came out as mojibake, and code
+/// points above 255 (em dash etc.) were never mapped to their WinAnsi byte. The
+/// encoder now maps Unicode → WinAnsi and emits correct octal, falling back to
+/// '?' for anything genuinely unrepresentable in base-14.
+/// </summary>
+public class WinAnsiEncodingTests
+{
+    private static readonly PdfFont Helv = PdfFont.Helvetica(12);
+
+    [Theory]
+    [InlineData("plain", "(plain)")]
+    [InlineData("café", "(caf\\351)")]    // é U+00E9 -> WinAnsi 0xE9 -> octal 351
+    [InlineData("a·b", "(a\\267b)")]      // middot U+00B7 -> 0xB7 -> octal 267
+    [InlineData("a–b", "(a\\226b)")]      // en dash U+2013 -> 0x96 -> octal 226
+    [InlineData("a—b", "(a\\227b)")]      // em dash U+2014 -> 0x97 -> octal 227
+    [InlineData("“q”", "(\\223q\\224)")]  // curly quotes U+201C/U+201D -> 0x93/0x94
+    public void EncodeString_WinAnsiChars_UseCorrectOctal(string input, string expected)
+        => Helv.EncodeString(input).Should().Be(expected);
+
+    [Fact]
+    public void EncodeString_UnmappableChar_FallsBackToQuestionMark()
+    {
+        // CJK is not representable in base-14 WinAnsi -> '?', never garbage.
+        Helv.EncodeString("你好").Should().Be("(??)");
+    }
+
+    [Fact]
+    public void EncodeString_DoesNotEmitDecimalCodePoint()
+    {
+        // The exact #426 symptom: "—" must not serialize as its decimal code point.
+        Helv.EncodeString("—").Should().NotContain("8212");
+    }
+}

--- a/Pdfe.Core/Graphics/PdfFont.cs
+++ b/Pdfe.Core/Graphics/PdfFont.cs
@@ -252,14 +252,26 @@ public class PdfFont
                     sb.Append("\\t");
                     break;
                 default:
-                    if (c < 32 || c > 126)
+                    if (c >= 32 && c <= 126)
                     {
-                        // Use octal for non-printable characters
-                        sb.Append($"\\{(int)c:000}");
+                        sb.Append(c);   // printable ASCII — identical in WinAnsi
+                    }
+                    else if (TryMapToWinAnsi(c, out byte b))
+                    {
+                        // Emit the WinAnsi byte as a 3-digit OCTAL escape. (The old
+                        // code formatted the Unicode code point in *decimal* — PDF
+                        // reads \ddd as octal, so "é"/"—"/"·" came out as garbage,
+                        // and code points > 255 like "—" (U+2014) were never mapped
+                        // to their WinAnsi byte at all. #426.)
+                        sb.Append('\\').Append(Convert.ToString(b, 8).PadLeft(3, '0'));
                     }
                     else
                     {
-                        sb.Append(c);
+                        // Not representable in the base-14 WinAnsi encoding (e.g.
+                        // CJK, U+0100+ Latin). Fall back to '?' instead of emitting
+                        // an invalid escape that renders as mojibake. To keep such
+                        // text intact, embed a font via DefaultFont (#398/#378).
+                        sb.Append('?');
                     }
                     break;
             }
@@ -267,6 +279,28 @@ public class PdfFont
 
         sb.Append(')');
         return sb.ToString();
+    }
+
+    // Unicode -> WinAnsi (CP1252) byte for the 0x80–0x9F range, whose code points
+    // differ from Latin-1. Outside this range, ASCII (0x20–0x7E) and Latin-1
+    // (0xA0–0xFF) map to their own code point.
+    private static readonly Dictionary<char, byte> WinAnsiHighMap = new()
+    {
+        ['€'] = 0x80, ['‚'] = 0x82, ['ƒ'] = 0x83, ['„'] = 0x84,
+        ['…'] = 0x85, ['†'] = 0x86, ['‡'] = 0x87, ['ˆ'] = 0x88,
+        ['‰'] = 0x89, ['Š'] = 0x8A, ['‹'] = 0x8B, ['Œ'] = 0x8C,
+        ['Ž'] = 0x8E, ['‘'] = 0x91, ['’'] = 0x92, ['“'] = 0x93,
+        ['”'] = 0x94, ['•'] = 0x95, ['–'] = 0x96, ['—'] = 0x97,
+        ['˜'] = 0x98, ['™'] = 0x99, ['š'] = 0x9A, ['›'] = 0x9B,
+        ['œ'] = 0x9C, ['ž'] = 0x9E, ['Ÿ'] = 0x9F,
+    };
+
+    /// <summary>Map a char to its WinAnsi (CP1252) byte, if representable.</summary>
+    private static bool TryMapToWinAnsi(char c, out byte b)
+    {
+        if (c >= 0x20 && c <= 0x7E) { b = (byte)c; return true; }   // ASCII
+        if (c >= 0xA0 && c <= 0xFF) { b = (byte)c; return true; }   // Latin-1 high == WinAnsi
+        return WinAnsiHighMap.TryGetValue(c, out b);               // CP1252 specials
     }
 
     private int GetCharWidth(char c)


### PR DESCRIPTION
## The bug (#426)
`PdfFont.EncodeString` formatted the Unicode code point in **decimal** as a `\ddd` escape — but PDF reads `\ddd` as **octal**. So:
- accented/punctuation chars serialized to the wrong byte, and
- code points > 255 (em dash `—` U+2014, etc.) were never mapped to their WinAnsi byte and came out as literal digits (`—` → `8212`).

Silent mojibake on the default base-14 path — hit repeatedly in PromptResponse.

## The fix
Map Unicode → WinAnsi (CP1252): ASCII (0x20–0x7E) and Latin-1 high (0xA0–0xFF) map to their own byte; the CP1252 0x80–0x9F specials (`– — ' ' " " … • € ™ …`) via a small table; all emitted as correct **3-digit octal**. Genuinely unrepresentable chars (e.g. CJK) **fall back to `?`** instead of invalid escapes — embed a font via `DefaultFont` (#398/#378) to keep that text.

## Tests
`WinAnsiEncodingTests`: correct octal for `é`/`·`/`–`/`—`/curly quotes, `?` fallback for CJK, and a regression assert that `—` no longer serializes as `8212`. No public-API change (private helpers). 274 Graphics+Authoring tests pass.

`Pdfe.Core`-only — no GUI suite, no flake risk.