### PR TITLE
release: v2.10.0 — viewer API gate (#384) + radio export values (#424) + WinAnsi fix (#426)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to pdfe are documented here. Format roughly follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this project uses
 semantic versioning.
 
+## [2.10.0] — 2026-06-08
+
+Library DX + authoring-correctness release. Additive; no breaking changes
+(public-API gates confirmed).
+
+### Added
+- **Public-API gate for the viewer libraries (#384).** A new lightweight,
+  non-GUI `Pdfe.Avalonia.Tests` project snapshots the public surface of
+  `Pdfe.Avalonia` and `Pdfe.Rendering` against committed baselines (same
+  treatment `Pdfe.Core` got in #383) — any API change now fails CI until the
+  baseline is intentionally regenerated. It is deliberately separate from the
+  heavy headless GUI suite, so viewer-library changes get reliable per-PR
+  coverage.
+- **`PdfField.ButtonExportValues` (#424).** For a Button field (e.g. a radio
+  group), the selectable "on" export values — the appearance-state names from
+  each widget's `/AP /N` other than `Off`. Lets a form importer map a radio
+  group to a choice/dropdown instead of a generic boolean.
+
+### Fixed
+- **Base-14 text encoding mojibake (#426).** `PdfFont.EncodeString` formatted the
+  Unicode code point in decimal as a `\ddd` escape, but PDF reads `\ddd` as
+  octal — so `é`, `—`, `·`, curly quotes etc. came out as garbage (and code
+  points above 255 were never mapped to their WinAnsi byte). The encoder now maps
+  Unicode → WinAnsi (CP1252) and emits correct octal, falling back to `?` for
+  characters genuinely unrepresentable in base-14 (embed a font via `DefaultFont`
+  to keep those). No public-API change.
+
 ## [2.9.0] — 2026-06-08
 
 Viewer + macOS-reader + archival release. Additive; no breaking changes

--- a/Pdfe.Avalonia/Pdfe.Avalonia.csproj
+++ b/Pdfe.Avalonia/Pdfe.Avalonia.csproj
@@ -14,7 +14,7 @@
   <!-- NuGet package metadata (packed explicitly via `dotnet pack`, not on build). -->
   <PropertyGroup>
     <PackageId>Pdfe.Avalonia</PackageId>
-    <Version>2.9.0</Version>
+    <Version>2.10.0</Version>
     <Authors>Marc Jones</Authors>
     <Description>A reusable, pure-managed PDF viewer control for Avalonia. Renders with SkiaSharp (no native PDFium), supports zoom/pan, page navigation, text selection, search highlights, annotations, links, and form-field overlays. Built on Pdfe.Core + Pdfe.Rendering.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Pdfe.Core/Pdfe.Core.csproj
+++ b/Pdfe.Core/Pdfe.Core.csproj
@@ -10,7 +10,7 @@
 
   <PropertyGroup>
     <PackageId>Pdfe.Core</PackageId>
-    <Version>2.9.0</Version>
+    <Version>2.10.0</Version>
     <Authors>Marc Jones</Authors>
     <Description>Pure-managed PDF parser, document model, and writer for .NET. Open/edit/save PDFs, extract text/links/annotations/forms, and perform true glyph-level redaction. No native dependencies; cross-platform and trim/AOT-friendlier.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Pdfe.Rendering/Pdfe.Rendering.csproj
+++ b/Pdfe.Rendering/Pdfe.Rendering.csproj
@@ -10,7 +10,7 @@
 
   <PropertyGroup>
     <PackageId>Pdfe.Rendering</PackageId>
-    <Version>2.9.0</Version>
+    <Version>2.10.0</Version>
     <Authors>Marc Jones</Authors>
     <Description>Pure-managed, SkiaSharp-based PDF render API for .NET. Render pages to SKBitmap or PNG with DPI/clip/rotation support and cancellable rendering. Framework-neutral engine behind Pdfe.Avalonia; no native PDFium. Cross-platform, trim/AOT-friendlier.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
Version bump to 2.10.0 + CHANGELOG. Bundles the non-flaky work merged since v2.9.0: viewer-library public-API gate & new Pdfe.Avalonia.Tests project (#384), PdfField.ButtonExportValues for radio groups (#424), and the base-14 WinAnsi encoding fix (#426). Tag v2.10.0 after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)