### PR TITLE
feat(pdfa): reach PDF/A-1b conformance via subset-font /CIDSet (#425)

### DIFF
--- a/Pdfe.Core.Tests/PdfATests.cs
+++ b/Pdfe.Core.Tests/PdfATests.cs
@@ -1,4 +1,8 @@
+using System;
+using System.Diagnostics;
+using System.IO;
 using System.Text;
+using AwesomeAssertions;
 using Pdfe.Core.Authoring;
 using Pdfe.Core.Graphics;
 using Xunit;
@@ -8,28 +12,31 @@ namespace Pdfe.Core.Tests;
 /// <summary>
 /// Verifies <see cref="PdfDocumentBuilder.PdfA"/> emits the document-level
 /// structures PDF/A requires: an XMP packet with the pdfaid identifier, an sRGB
-/// OutputIntent, a trailer /ID, and an embedded font (no base-14). Full
-/// conformance is validated externally with veraPDF (PDF/A-2b: 144/144 rules).
+/// OutputIntent, a trailer /ID, an embedded font (no base-14), and — for
+/// subset CID fonts — a /CIDSet (required by PDF/A-1b §6.3.5). Full conformance
+/// is validated with veraPDF when present (both PDF/A-1b and -2b PASS).
 /// </summary>
 public class PdfATests
 {
-    private static byte[] BuildPdfA()
+    private const string Dejavu = "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf";
+
+    private static byte[] BuildPdfA(PdfAConformance conformance)
     {
-        var font = PdfFont.FromFile("/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf", 11);
+        var font = PdfFont.FromFile(Dejavu, 11);
         return PdfDocumentBuilder.Create()
             .Language("en-US")
             .Title("Archival Test")
             .DefaultFont(font)
-            .PdfA(PdfAConformance.PdfA2B)
+            .PdfA(conformance)
             .Heading("Archival Test")
             .Paragraph("Body text — with an em dash and unicode: café.")
             .SaveToBytes();
     }
 
     [Fact]
-    public void PdfA_EmitsXmpPdfaId_OutputIntent_AndTrailerId()
+    public void PdfA2B_EmitsXmpPdfaId_OutputIntent_AndTrailerId()
     {
-        var latin1 = Encoding.Latin1.GetString(BuildPdfA());
+        var latin1 = Encoding.Latin1.GetString(BuildPdfA(PdfAConformance.PdfA2B));
 
         Assert.Contains("pdfaid:part>2", latin1);
         Assert.Contains("pdfaid:conformance>B", latin1);
@@ -39,9 +46,72 @@ public class PdfATests
     }
 
     [Fact]
+    public void PdfA1B_EmitsPart1AndCidSet()
+    {
+        Assert.SkipUnless(File.Exists(Dejavu), "DejaVuSans (embedding font) not installed");
+        var latin1 = Encoding.Latin1.GetString(BuildPdfA(PdfAConformance.PdfA1B));
+
+        Assert.Contains("pdfaid:part>1", latin1);
+        // PDF/A-1b requires a /CIDSet for the embedded subset CID font.
+        Assert.Contains("/CIDSet", latin1);
+    }
+
+    [Fact]
     public void NewDocument_AlwaysGetsATrailerId()
     {
         var bytes = PdfDocumentBuilder.Create().Heading("Hi").SaveToBytes();
         Assert.Contains("/ID", Encoding.Latin1.GetString(bytes));
+    }
+
+    [Theory]
+    [InlineData(PdfAConformance.PdfA1B, "1b")]
+    [InlineData(PdfAConformance.PdfA2B, "2b")]
+    public void PdfA_Output_IsConformant_PerVeraPdf(PdfAConformance conformance, string flavour)
+    {
+        Assert.SkipUnless(File.Exists(Dejavu), "DejaVuSans (embedding font) not installed");
+        var verapdf = FindVeraPdf();
+        Assert.SkipWhen(verapdf is null, "veraPDF not installed (~/verapdf/verapdf or PATH)");
+
+        var path = Path.Combine(Path.GetTempPath(), $"pdfa_{flavour}_{Guid.NewGuid():N}.pdf");
+        File.WriteAllBytes(path, BuildPdfA(conformance));
+        try
+        {
+            var psi = new ProcessStartInfo(verapdf!)
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            psi.ArgumentList.Add("--format");
+            psi.ArgumentList.Add("xml");
+            psi.ArgumentList.Add("-f");
+            psi.ArgumentList.Add(flavour);
+            psi.ArgumentList.Add(path);
+
+            using var proc = Process.Start(psi)!;
+            string report = proc.StandardOutput.ReadToEnd();
+            proc.WaitForExit(120_000);
+
+            report.Should().Contain("isCompliant=\"true\"",
+                $"the builder's PdfA({conformance}) output must be PDF/A-{flavour} conformant. Report:\n" +
+                report.Substring(0, Math.Min(report.Length, 4000)));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    private static string? FindVeraPdf()
+    {
+        var home = Environment.GetEnvironmentVariable("HOME") ?? "";
+        var local = Path.Combine(home, "verapdf", "verapdf");
+        if (File.Exists(local)) return local;
+        foreach (var dir in (Environment.GetEnvironmentVariable("PATH") ?? "").Split(Path.PathSeparator))
+        {
+            var p = Path.Combine(dir, "verapdf");
+            if (File.Exists(p)) return p;
+        }
+        return null;
     }
 }

--- a/Pdfe.Core/Document/PdfField.cs
+++ b/Pdfe.Core/Document/PdfField.cs
@@ -81,9 +81,11 @@ public sealed class PdfField
     /// <summary>The non-<c>Off</c> appearance-state names under a widget's <c>/AP /N</c>.</summary>
     private IEnumerable<string> GetWidgetOnStates(PdfDictionary widget)
     {
-        if (_document.Resolve(widget.GetOptional("AP")) is not PdfDictionary ap)
+        var apObj = widget.GetOptional("AP");
+        if (apObj == null || _document.Resolve(apObj) is not PdfDictionary ap)
             yield break;
-        if (_document.Resolve(ap.GetOptional("N")) is not PdfDictionary normal)
+        var nObj = ap.GetOptional("N");
+        if (nObj == null || _document.Resolve(nObj) is not PdfDictionary normal)
             yield break;
         foreach (var key in normal.Keys)
             if (key.Value != "Off")

--- a/Pdfe.Core/Graphics/PdfTrueTypeFont.cs
+++ b/Pdfe.Core/Graphics/PdfTrueTypeFont.cs
@@ -129,6 +129,19 @@ internal sealed class PdfTrueTypeFont : PdfFont
             fd["FontFile2"] = fontFileRef;
         var fdRef = document.AddIndirectObject(fd);
 
+        // CIDSet — PDF/A-1b §6.3.5 requires it for an embedded subset CID font (a
+        // bitmap of which CIDs are present). Only for TrueType (glyf): that is the
+        // path PDF/A-1 permits and that we genuinely subset. For CFF we embed the
+        // full font, and CIDSet is optional in PDF/A-2; emitting an incomplete one
+        // would FAIL PDF/A-2 §6.2.11.4.2, so we omit it. Placeholder now; the
+        // pre-save action fills it once the used-CID set is final.
+        PdfStream? cidSetStream = null;
+        if (!_ttf.IsCff)
+        {
+            cidSetStream = new PdfStream(new PdfDictionary(), Array.Empty<byte>());
+            fd["CIDSet"] = document.AddIndirectObject(cidSetStream);
+        }
+
         // 3. /W advance widths for every glyph: [0 [w0 w1 w2 …]].
         var widths = new PdfArray();
         for (int g = 0; g < _ttf.GlyphCount; g++)
@@ -171,7 +184,7 @@ internal sealed class PdfTrueTypeFont : PdfFont
         // Defer subsetting to save time (when _usedGids is complete).
         // For CFF, TrueTypeSubsetter will return the original unchanged, which is fine
         // (full OTTO embedded). For TrueType, it subsets to used glyphs.
-        document.RegisterPreSaveAction(() => FinalizeSubset(fontFileStream, fd, cid, type0, tu, toGlyphSpace));
+        document.RegisterPreSaveAction(() => FinalizeSubset(fontFileStream, fd, cid, type0, tu, cidSetStream, toGlyphSpace));
         return type0;
     }
 
@@ -182,7 +195,7 @@ internal sealed class PdfTrueTypeFont : PdfFont
     /// Idempotent.
     /// </summary>
     private void FinalizeSubset(PdfStream fontFileStream, PdfDictionary fd, PdfDictionary cid,
-        PdfDictionary type0, PdfStream toUnicode, double toGlyphSpace)
+        PdfDictionary type0, PdfStream toUnicode, PdfStream? cidSet, double toGlyphSpace)
     {
         // For TrueType, subset to used glyphs. For CFF, TrueTypeSubsetter returns original.
         byte[] subset = TrueTypeSubsetter.Subset(_ttf.Data, _usedGids);
@@ -217,6 +230,25 @@ internal sealed class PdfTrueTypeFont : PdfFont
             w.Add((PdfObject)one);
         }
         cid["W"] = w;
+
+        // CIDSet bitmap: bit i (MSB-first) set when CID i is present. We subset
+        // "retain-gid" (CIDToGIDMap Identity, numGlyphs unchanged), so every glyph
+        // index 0..numGlyphs-1 is still an addressable slot in the embedded
+        // program — non-retained ones are valid empty glyphs. PDF/A-2 §6.2.11.4.2
+        // requires the CIDSet to list ALL glyphs present in the program, so we set
+        // every bit up to numGlyphs (an incomplete CIDSet from just the used set
+        // is rejected).
+        if (cidSet != null)
+        {
+            int n = _ttf.GlyphCount;
+            var bits = new byte[(n + 7) / 8];
+            for (int i = 0; i < n; i++)
+                bits[i / 8] |= (byte)(0x80 >> (i % 8));
+            byte[] cidSetComp = Deflate(bits);
+            cidSet.SetEncodedData(cidSetComp);
+            cidSet.SetName("Filter", "FlateDecode");
+            cidSet.SetInt("Length", cidSetComp.Length);
+        }
     }
 
     /// <summary>Deterministic 6-uppercase-letter subset tag from the used glyphs.</summary>


### PR DESCRIPTION
## Summary
Closes the PDF/A-1b gap from #425 (PDF/A-2b already validated). Embedded subset CID fonts now emit a `/CIDSet` in the FontDescriptor, required by **PDF/A-1b §6.3.5**.

## Detail
We subset **retain-gid** (`CIDToGIDMap Identity`, `numGlyphs` unchanged), so every glyph index `0..numGlyphs-1` remains an addressable slot in the embedded program. The CIDSet therefore sets a bit for each — satisfying **PDF/A-2 §6.2.11.4.2** ("the CIDSet shall identify all glyphs present in the program"). A used-glyphs-only CIDSet is rejected as *incomplete* (that was the first attempt's failure).

Only emitted for **TrueType (glyf)** — the path PDF/A-1 permits and that we genuinely subset. For full-embedded **CFF** the CIDSet is optional in PDF/A-2 and an incomplete one would fail, so it's omitted.

## Verification (veraPDF 1.30.2, local)
- `PdfA(PdfA1B)` → **PASS 1b**
- `PdfA(PdfA2B)` → **PASS 2b** (still 144/144)

New `PdfATests`: a veraPDF conformance gate `[Theory]` over both 1b and 2b (skips when veraPDF/DejaVu absent), plus a 1b structural assertion (`pdfaid:part>1` + `/CIDSet`). Also fixes a nullable warning in the #424 helper. No public-API change.

`Pdfe.Core`-only — no GUI suite, no flake risk.