### PR TITLE
feat(viewer): sharp high-zoom in continuous mode via zoom-aware render DPI (#371 pt1)

### DIFF
--- a/Pdfe.Avalonia.Tests/ContinuousDpiTests.cs
+++ b/Pdfe.Avalonia.Tests/ContinuousDpiTests.cs
@@ -1,0 +1,22 @@
+using AwesomeAssertions;
+using Pdfe.Avalonia.Controls;
+using Xunit;
+
+namespace Pdfe.Avalonia.Tests;
+
+/// <summary>
+/// Unit tests for the zoom-aware continuous-render DPI selection (#371 pt1).
+/// Pure logic — no rendering — so it runs in the non-flaky viewer-lib project.
+/// </summary>
+public class ContinuousDpiTests
+{
+    [Theory]
+    [InlineData(1.0, 120)]   // at 100% zoom, render at the base DPI
+    [InlineData(1.5, 180)]   // scales with zoom -> crisper
+    [InlineData(2.0, 240)]   // at the cap
+    [InlineData(4.0, 240)]   // deep zoom is clamped to the cap (bounds memory)
+    [InlineData(0.5, 120)]   // never below the base DPI
+    public void EffectiveContinuousDpi_ScalesWithZoom_AndClamps(double zoom, int expected)
+        => PdfViewerControl.EffectiveContinuousDpi(120, zoom, PdfViewerControl.MaxContinuousDpi)
+            .Should().Be(expected);
+}

--- a/Pdfe.Avalonia/Controls/PdfViewerControl.Continuous.cs
+++ b/Pdfe.Avalonia/Controls/PdfViewerControl.Continuous.cs
@@ -31,11 +31,23 @@ public partial class PdfViewerControl
     // may still be bound to a realized (visible) Image, and disposing it would
     // crash the render. Dropping the reference lets the GC reclaim it once no
     // slot/Image holds it. Full disposal happens only on document change.
-    private readonly LinkedList<(int Page, WriteableBitmap Bmp)> _continuousCache = new();
+    private readonly LinkedList<(int Page, int Dpi, WriteableBitmap Bmp)> _continuousCache = new();
     private readonly Dictionary<int, CancellationTokenSource> _continuousRenderCts = new();
-    private const int ContinuousCacheCapacity = 16;
+    private const int ContinuousCacheCapacity = 10;
     internal const double PointsToDip = 96.0 / 72.0;
     private const double PageGapDip = 12.0;   // matches the DataTemplate Border bottom margin
+
+    // Sharp high-zoom (#371 pt1): render each continuous page at a DPI that scales
+    // with zoom so it stays crisp instead of upscaling a fixed-DPI bitmap, capped
+    // so a deep zoom can't blow up memory (a full-page bitmap at the cap is the
+    // bound; true visible-region tiling is a future refinement).
+    internal const int MaxContinuousDpi = 240;
+    private int ContinuousRenderDpi =>
+        (int)Math.Clamp(Math.Round(DefaultRenderDpi * ZoomLevel), DefaultRenderDpi, MaxContinuousDpi);
+
+    /// <summary>The render DPI chosen for a given zoom (pure; unit-tested).</summary>
+    internal static int EffectiveContinuousDpi(int baseDpi, double zoom, int maxDpi) =>
+        (int)Math.Clamp(Math.Round(baseDpi * zoom), baseDpi, maxDpi);
 
     // Guards the scroll -> CurrentPage -> scroll feedback loop.
     private bool _syncingPageFromScroll;
@@ -109,11 +121,20 @@ public partial class PdfViewerControl
         _continuousCache.Clear();
     }
 
-    /// <summary>Resize every slot to the new zoom (bindings re-layout the borders).</summary>
+    /// <summary>
+    /// Resize every slot to the new zoom (bindings re-layout the borders) and
+    /// re-render the currently-realized pages at the new zoom-aware DPI so they
+    /// stay sharp. Off-screen pages re-render lazily when realized.
+    /// </summary>
     private void ApplyContinuousZoom()
     {
         if (_continuousSlots == null) return;
         foreach (var slot in _continuousSlots) slot.ApplyZoom(ZoomLevel);
+
+        if (_continuousItems == null) return;
+        foreach (var container in _continuousItems.GetRealizedContainers())
+            if (container.DataContext is PdfPageSlot slot)
+                _ = RenderContinuousAsync(slot);
     }
 
     // ---- Scroll <-> CurrentPage sync -----------------------------------
@@ -186,7 +207,8 @@ public partial class PdfViewerControl
         var doc = Document;
         if (doc == null || slot.PageNumber < 1 || slot.PageNumber > doc.PageCount) return;
 
-        if (TryGetContinuousCached(slot.PageNumber, out var cached))
+        int dpi = ContinuousRenderDpi;
+        if (TryGetContinuousCached(slot.PageNumber, dpi, out var cached))
         {
             slot.Bitmap = cached;
             return;
@@ -210,7 +232,7 @@ public partial class PdfViewerControl
                 // instance state and is not reentrant, and continuous mode may
                 // render several pages around the viewport concurrently.
                 var renderer = new SkiaRenderer();
-                return renderer.RenderPage(page, new RenderOptions { Dpi = DefaultRenderDpi });
+                return renderer.RenderPage(page, new RenderOptions { Dpi = dpi });
             }, token);
 
             try
@@ -219,7 +241,7 @@ public partial class PdfViewerControl
                 var bitmap = Imaging.SkiaInterop.ToAvaloniaBitmap(skBitmap);
                 if (bitmap != null)
                 {
-                    AddToContinuousCache(pageNumber, bitmap);
+                    AddToContinuousCache(pageNumber, dpi, bitmap);
                     slot.Bitmap = bitmap;
                 }
             }
@@ -243,11 +265,11 @@ public partial class PdfViewerControl
         }
     }
 
-    private bool TryGetContinuousCached(int page, out WriteableBitmap? bmp)
+    private bool TryGetContinuousCached(int page, int dpi, out WriteableBitmap? bmp)
     {
         for (var node = _continuousCache.First; node != null; node = node.Next)
         {
-            if (node.Value.Page == page)
+            if (node.Value.Page == page && node.Value.Dpi == dpi)
             {
                 _continuousCache.Remove(node);
                 _continuousCache.AddFirst(node);
@@ -259,13 +281,13 @@ public partial class PdfViewerControl
         return false;
     }
 
-    private void AddToContinuousCache(int page, WriteableBitmap bmp)
+    private void AddToContinuousCache(int page, int dpi, WriteableBitmap bmp)
     {
         for (var node = _continuousCache.First; node != null; node = node.Next)
         {
-            if (node.Value.Page == page) { _continuousCache.Remove(node); break; }
+            if (node.Value.Page == page && node.Value.Dpi == dpi) { _continuousCache.Remove(node); break; }
         }
-        _continuousCache.AddFirst((page, bmp));
+        _continuousCache.AddFirst((page, dpi, bmp));
         // Drop (don't dispose) the LRU tail — see field comment on why.
         while (_continuousCache.Count > ContinuousCacheCapacity)
             _continuousCache.RemoveLast();

--- a/Pdfe.Avalonia/Pdfe.Avalonia.csproj
+++ b/Pdfe.Avalonia/Pdfe.Avalonia.csproj
@@ -11,6 +11,13 @@
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
   </PropertyGroup>
 
+  <!-- Expose internals to the non-GUI viewer-lib test project so pure helpers
+       (e.g. the zoom-aware DPI selection) can be unit-tested without enlarging
+       the public API. -->
+  <ItemGroup>
+    <InternalsVisibleTo Include="Pdfe.Avalonia.Tests" />
+  </ItemGroup>
+
   <!-- NuGet package metadata (packed explicitly via `dotnet pack`, not on build). -->
   <PropertyGroup>
     <PackageId>Pdfe.Avalonia</PackageId>


### PR DESCRIPTION
## Summary
Completes #371's remaining half (the "tiling / sharp high-zoom" goal), in the pragmatic, bounded form. The continuous reading view rendered every page at a fixed DPI and upscaled the bitmap → blurry when zoomed.

Now it renders at a **zoom-aware DPI** (`DefaultRenderDpi * zoom`), **clamped to `[base, 240]`** so a deep zoom can't blow up memory, and the continuous bitmap cache is keyed by `(page, dpi)`. On zoom change the **currently-realized** pages re-render at the new DPI; off-screen pages re-render lazily when scrolled into view.

Full visible-region **tiling** (sharp at *arbitrary* zoom without a full-page bitmap) remains a future refinement — the DPI cap bounds memory in the meantime.

## Tests
- `ContinuousDpiTests` (in the non-flaky `Pdfe.Avalonia.Tests`) cover the pure DPI-selection logic: scales with zoom, never below base, clamped at the cap. Exposed via `InternalsVisibleTo` — **no public-API change**.
- Continuous view-mode GUI tests still pass.

Touches only `Pdfe.Avalonia` + its non-GUI test project → **no flaky GUI suite**.