### PR TITLE
feat(bench): stand up Pdfe.Benchmarks + fix orphaned run-benchmarks.sh (#344)

### DIFF
--- a/Pdfe.Benchmarks/Pdfe.Benchmarks.csproj
+++ b/Pdfe.Benchmarks/Pdfe.Benchmarks.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    pdfe performance benchmarks (#344/#357). BenchmarkDotNet (MIT). Deliberately
+    NOT part of pdfe.sln / the shippable graph — it's dev tooling. This first cut
+    tracks pdfe-vs-pdfe (regression tracking): parse, render, and text-extract on
+    a generated document. Cross-library comparison (PdfPig/PDFsharp/PDFium
+    in-process; Poppler/MuPDF/Ghostscript as external processes only, per the
+    permissive-license guardrail) is the documented next step.
+  -->
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Pdfe.Core\Pdfe.Core.csproj" />
+    <ProjectReference Include="..\Pdfe.Rendering\Pdfe.Rendering.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Pdfe.Benchmarks/PdfeBenchmarks.cs
+++ b/Pdfe.Benchmarks/PdfeBenchmarks.cs
@@ -1,0 +1,62 @@
+using BenchmarkDotNet.Attributes;
+using Pdfe.Core.Authoring;
+using Pdfe.Core.Document;
+using Pdfe.Core.Text;
+using Pdfe.Rendering;
+
+namespace Pdfe.Benchmarks;
+
+/// <summary>
+/// Core pdfe pipeline benchmarks (#344): parse, render, and text-extract on a
+/// representative generated document. Run via <c>scripts/run-benchmarks.sh</c>.
+/// These track pdfe-vs-pdfe regressions over time; see the project file for the
+/// planned cross-library comparison.
+/// </summary>
+[MemoryDiagnoser]
+public class PdfeBenchmarks
+{
+    [Params(1, 10)]
+    public int PageCount;
+
+    private byte[] _pdf = Array.Empty<byte>();
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var b = PdfDocumentBuilder.Create().Title("Benchmark");
+        for (int i = 0; i < PageCount; i++)
+        {
+            b.Heading($"Section {i + 1}");
+            b.Paragraph("The quick brown fox jumps over the lazy dog. " +
+                        "Pack my box with five dozen liquor jugs. " +
+                        "Sphinx of black quartz, judge my vow.");
+        }
+        _pdf = b.SaveToBytes();
+    }
+
+    [Benchmark]
+    public int Parse()
+    {
+        using var doc = PdfDocument.Open(_pdf);
+        return doc.PageCount;
+    }
+
+    [Benchmark]
+    public int Render()
+    {
+        using var doc = PdfDocument.Open(_pdf);
+        var renderer = new SkiaRenderer();
+        using var bmp = renderer.RenderPage(doc.GetPage(1));
+        return bmp.Width;
+    }
+
+    [Benchmark]
+    public int ExtractText()
+    {
+        using var doc = PdfDocument.Open(_pdf);
+        int total = 0;
+        for (int p = 1; p <= doc.PageCount; p++)
+            total += new TextExtractor(doc.GetPage(p)).ExtractText().Length;
+        return total;
+    }
+}

--- a/Pdfe.Benchmarks/Program.cs
+++ b/Pdfe.Benchmarks/Program.cs
@@ -1,0 +1,6 @@
+using BenchmarkDotNet.Running;
+using Pdfe.Benchmarks;
+
+// `dotnet run -c Release` runs all benchmarks; pass a filter to narrow, e.g.
+//   scripts/run-benchmarks.sh --filter '*Render*'
+BenchmarkSwitcher.FromAssembly(typeof(PdfeBenchmarks).Assembly).Run(args);

--- a/scripts/run-benchmarks.sh
+++ b/scripts/run-benchmarks.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
+# Run the pdfe performance benchmarks (#344/#357). BenchmarkDotNet.
+# Examples:
+#   scripts/run-benchmarks.sh                  # all benchmarks
+#   scripts/run-benchmarks.sh --filter '*Render*'
 set -euo pipefail
-
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
-
-dotnet run -c Release --project PdfEditor.Benchmarks/PdfEditor.Benchmarks.csproj "$@"
+dotnet run -c Release --project Pdfe.Benchmarks/Pdfe.Benchmarks.csproj -- "$@"


### PR DESCRIPTION
## Summary
`scripts/run-benchmarks.sh` pointed at a non-existent `PdfEditor.Benchmarks` project (#344). Replaced with a real **BenchmarkDotNet** project, `Pdfe.Benchmarks`:
- Benchmarks the core pipeline — **Parse / Render / ExtractText** — across `PageCount` (1, 10), `MemoryDiagnoser` on. This is the pdfe-vs-pdfe regression-tracking baseline (a #344/#357 goal).
- Verified it builds and runs end-to-end (`--job dry`: Parse ≈ 5 ms).

## Scope / guardrail
Deliberately **not** in `pdfe.sln` — dev tooling, kept out of the shippable graph per #344. The cross-library comparison (PdfPig/PDFsharp/PDFium in-process; Poppler/MuPDF/Ghostscript **external-process only**, per the permissive-license guardrail) is documented as the next step in the project file.

Non-flaky — no GUI suite, not in the CI test graph.