### PR TITLE
release: v2.11.0 — PDF/A-1b conformance (#425) + sharp high-zoom (#371) + benchmarks (#344)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to pdfe are documented here. Format roughly follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this project uses
 semantic versioning.
 
+## [2.11.0] — 2026-06-08
+
+Archival conformance + viewer-quality release. Additive; no breaking changes.
+
+### Added
+- **PDF/A-1b conformance (#425).** Embedded subset CID fonts now emit a `/CIDSet`
+  in the FontDescriptor (covering all glyph slots of the retain-gid subset, as
+  PDF/A-2 §6.2.11.4.2 requires it be complete). `PdfDocumentBuilder.PdfA(PdfA1B)`
+  and `PdfA(PdfA2B)` output now both validate as conformant under veraPDF 1.30.2.
+  A veraPDF conformance gate test covers both flavours.
+- **Sharp high-zoom in the continuous reading view (#371 pt1).** Continuous mode
+  now renders each page at a zoom-aware DPI (scaling with zoom, capped to bound
+  memory) and caches by `(page, dpi)`, so zoomed reading stays crisp instead of
+  upscaling a fixed-DPI bitmap. (Full visible-region tiling remains a future
+  refinement.)
+
+### Developer tooling
+- **`Pdfe.Benchmarks` (#344).** A BenchmarkDotNet project measuring parse /
+  render / text-extract (replacing the orphaned `run-benchmarks.sh` target);
+  kept out of the shippable graph.
+
 ## [2.10.0] — 2026-06-08
 
 Library DX + authoring-correctness release. Additive; no breaking changes

--- a/Pdfe.Avalonia/Pdfe.Avalonia.csproj
+++ b/Pdfe.Avalonia/Pdfe.Avalonia.csproj
@@ -21,7 +21,7 @@
   <!-- NuGet package metadata (packed explicitly via `dotnet pack`, not on build). -->
   <PropertyGroup>
     <PackageId>Pdfe.Avalonia</PackageId>
-    <Version>2.10.0</Version>
+    <Version>2.11.0</Version>
     <Authors>Marc Jones</Authors>
     <Description>A reusable, pure-managed PDF viewer control for Avalonia. Renders with SkiaSharp (no native PDFium), supports zoom/pan, page navigation, text selection, search highlights, annotations, links, and form-field overlays. Built on Pdfe.Core + Pdfe.Rendering.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Pdfe.Core/Pdfe.Core.csproj
+++ b/Pdfe.Core/Pdfe.Core.csproj
@@ -10,7 +10,7 @@
 
   <PropertyGroup>
     <PackageId>Pdfe.Core</PackageId>
-    <Version>2.10.0</Version>
+    <Version>2.11.0</Version>
     <Authors>Marc Jones</Authors>
     <Description>Pure-managed PDF parser, document model, and writer for .NET. Open/edit/save PDFs, extract text/links/annotations/forms, and perform true glyph-level redaction. No native dependencies; cross-platform and trim/AOT-friendlier.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Pdfe.Rendering/Pdfe.Rendering.csproj
+++ b/Pdfe.Rendering/Pdfe.Rendering.csproj
@@ -10,7 +10,7 @@
 
   <PropertyGroup>
     <PackageId>Pdfe.Rendering</PackageId>
-    <Version>2.10.0</Version>
+    <Version>2.11.0</Version>
     <Authors>Marc Jones</Authors>
     <Description>Pure-managed, SkiaSharp-based PDF render API for .NET. Render pages to SKBitmap or PNG with DPI/clip/rotation support and cancellable rendering. Framework-neutral engine behind Pdfe.Avalonia; no native PDFium. Cross-platform, trim/AOT-friendlier.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
Version bump to 2.11.0 + CHANGELOG. Bundles the non-flaky work merged since v2.10.0: PDF/A-1b conformance via subset-font /CIDSet (#425), sharp high-zoom in the continuous reading view (#371 pt1), and the Pdfe.Benchmarks harness (#344). AOT investigations (#342/#343) delivered as recommendations on those issues. Tag v2.11.0 after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)