### PR TITLE
fix(tests): kill the chronic #363 GUI host-crash by serializing the suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,20 +196,19 @@ jobs:
         # runs on main. Library changes that affect the GUI are caught by the
         # main run before any release is cut.
         #
-        # Excludes the *_MatchesBaseline visual-regression tests: they render a
-        # heavy real-world PDF through the real Skia backend (UseHeadlessDrawing
-        # =false) and, after the rest of the suite's accumulated dispatcher load,
-        # reliably crash the headless test host — the root cause of the chronic
-        # #363 "host process exited unexpectedly" failures (the blame collector
-        # named whichever test happened to be on the dispatcher, e.g.
-        # CtrlS_SavesFile, which is why it looked random). They are
-        # environment-sensitive pixel-baseline tests, the same category excluded
-        # from the Pdfe.Rendering PR gate, and are owned by the nightly
-        # visual-regression job (visual-regression-nightly.yml), not this gate.
+        # Runs the FULL suite, including the *_MatchesBaseline visual tests. The
+        # chronic #363 "host process exited unexpectedly" crash was root-caused
+        # to xunit's default collection parallelism racing SkiaSharp's
+        # process-wide native font manager (the GUI tests render with real Skia,
+        # UseHeadlessDrawing=false). The suite is now serialized via
+        # [assembly: CollectionBehavior(DisableTestParallelization = true)] in
+        # PdfEditor.Tests/AssemblyInfo.cs, which eliminates the concurrent native
+        # font access; the full suite (incl. *_MatchesBaseline) was validated
+        # crash-free across repeated runs. The earlier *_MatchesBaseline
+        # exclusion (a workaround) is therefore removed.
         if: steps.changes.outputs.gui == 'true' || github.ref == 'refs/heads/main'
         run: |
           xvfb-run -a dotnet test PdfEditor.Tests --no-build -c Debug \
-            --filter "FullyQualifiedName!~MatchesBaseline" \
             --logger "console;verbosity=normal" \
             --blame-hang-timeout 120000
 

--- a/PdfEditor.Tests/AssemblyInfo.cs
+++ b/PdfEditor.Tests/AssemblyInfo.cs
@@ -1,0 +1,19 @@
+using Xunit;
+
+// Serialize the entire PdfEditor.Tests assembly — DO NOT re-enable parallelism.
+//
+// The headless GUI tests render with REAL Skia (TestAppBuilder sets
+// UseHeadlessDrawing=false). SkiaSharp's font subsystem reaches a *process-wide*
+// native font manager that corrupts/crashes the host when multiple managed
+// threads create typefaces / measure text concurrently (see the
+// `_typefaceLoadLock` note in SkiaRenderer — the per-renderer lock only guards
+// typeface *acquisition*, not every native font path). Under xunit's default
+// 4-way collection parallelism this was the root cause of the chronic #363
+// "Test host process crashed" failures (blame blank; ~640 tests then a native
+// death in ~18s). Serializing eliminates the concurrent native-font access.
+//
+// NOTE: a xunit.runner.json previously tried to set this but was never copied to
+// the output directory, so it had no effect. This compiled-in attribute is the
+// authoritative setting (mirrors Pdfe.Cli.Tests, which serialized for an
+// analogous reason).
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/PdfEditor.Tests/xunit.runner.json
+++ b/PdfEditor.Tests/xunit.runner.json
@@ -1,8 +1,0 @@
-{
-  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
-  "parallelizeAssembly": false,
-  "parallelizeTestCollections": true,
-  "maxParallelThreads": 4,
-  "diagnosticMessages": false,
-  "shadowCopy": false
-}


### PR DESCRIPTION
## Root cause (finally nailed)
The headless GUI tests render with **real Skia** (`TestAppBuilder` sets `UseHeadlessDrawing=false`), and xunit's **default collection parallelism (4 threads)** raced SkiaSharp's **process-wide native font manager** — which the renderer's own `_typefaceLoadLock` comment warns "can corrupt or deadlock when two threads call simultaneously" (and that lock only guards typeface *acquisition*, not every native font path: paint/measure/glyph).

Result: a **native** host death — `Test host process crashed`, blame **blank**, ~640 tests in **~18 s**. The blame collector pinned it on whichever test happened to hold the dispatcher, which is why it looked like a "random" `CtrlS_SavesFile` / render-test flake.

## Fix
Serialize the whole assembly via **`[assembly: CollectionBehavior(DisableTestParallelization = true)]`** (`AssemblyInfo.cs`) — same approach `Pdfe.Cli.Tests` already uses. Also removed the pre-existing `xunit.runner.json`, which tried to configure this but **was never copied to the output dir** (dead config — which is why the suite always ran parallel regardless).

## Validation
Full suite — **including** the heavy `*_MatchesBaseline` visual tests — passed **crash-free 4/4** consecutive local runs (`760 passed / 0 failed / 6 skipped`, ~3m33s each) vs. a ~2-in-3 crash rate before.

So the `*_MatchesBaseline` PR-gate exclusion (the #417 *workaround*) is **removed** — full GUI coverage is restored on every gated run. This PR's own CI run (full serial GUI suite) is the real-world proof.

Closes #363.