### PR TITLE
ci: make veraPDF setup failures explicit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,21 +46,18 @@ jobs:
 
       - name: Install veraPDF
         # veraPDF drives the PDF/UA-1 conformance gate (PdfUaConformanceTests,
-        # #413) and the corpus tests. The UA test skips gracefully if veraPDF is
-        # absent, so a download/installer outage must not fail the whole job —
-        # keep the install best-effort. (The old pinned 1.28.1 URL 404'd; use the
-        # versionless latest installer.)
-        continue-on-error: true
+        # #413) and the corpus tests. Treat it as a CI prerequisite so the
+        # validator tests either run or the setup failure is reported directly;
+        # best-effort installation made their skip state depend on network luck.
+        # The old pinned 1.28.1 URL 404'd; use the versionless latest installer.
         run: |
-          set -uo pipefail
+          set -euo pipefail
           # Download veraPDF. curl -f fails on HTTP errors (so we never unzip an
           # error page), with retries for transient flakiness.
           curl -fSL --retry 3 --connect-timeout 30 \
             https://software.verapdf.org/releases/verapdf-installer.zip \
-            -o /tmp/verapdf.zip \
-            || { echo "::warning::veraPDF download failed; skipping veraPDF setup"; exit 0; }
-          unzip -q /tmp/verapdf.zip -d /tmp/verapdf-installer \
-            || { echo "::warning::veraPDF archive invalid; skipping veraPDF setup"; exit 0; }
+            -o /tmp/verapdf.zip
+          unzip -q /tmp/verapdf.zip -d /tmp/verapdf-installer
 
           # Create installation response file for silent install.
           # Unquoted heredoc so $HOME expands (izpack doesn't expand env vars; a
@@ -88,14 +85,13 @@ jobs:
           cd /tmp/verapdf-installer
           INSTALLER=$(find . \( -name "verapdf-izpack-installer-*.jar" -o -name "verapdf-greenfield-*.jar" -o -name "verapdf-*installer*.jar" \) | head -1)
           if [ -z "$INSTALLER" ]; then
-            echo "::warning::veraPDF installer jar not found; skipping veraPDF setup"
-            exit 0
+            echo "veraPDF installer jar not found" >&2
+            exit 1
           fi
-          java -jar "$INSTALLER" /tmp/auto-install.xml || \
-            { echo "::warning::veraPDF install failed; continuing without it"; exit 0; }
+          java -jar "$INSTALLER" /tmp/auto-install.xml
 
-          # Verify installation (non-fatal)
-          ~/verapdf/verapdf --version || true
+          # Verify that the validator is available for the conformance tests.
+          ~/verapdf/verapdf --version
 
       - name: Install xvfb for headless UI tests
         if: steps.changes.outputs.gui == 'true' || github.ref == 'refs/heads/main'


### PR DESCRIPTION
# ci: make veraPDF setup failures explicit

## Summary

The best-effort veraPDF installer allowed the validator-dependent tests to alternate between skipping and running based on transient download success. That made the skip-budget result nondeterministic. CI now treats veraPDF as a required setup dependency, so an installation problem fails clearly at setup time instead of changing test-skip state.

Fixes #666

## Changes

- Remove error swallowing and `continue-on-error` from the veraPDF installation step.
- Verify the installed validator so the conformance tests consistently execute in CI.

## Testing

- `git diff --check` — passed.
- `sandbox-run "dotnet test Pdfe.Core.Tests --no-build -c Debug --filter 'FullyQualifiedName~PdfATests|FullyQualifiedName~PdfUaConformanceTests' --logger 'console;verbosity=normal'"` — could not run because the sandbox image does not provide `dotnet` (`dotnet: command not found`).
- Attempted YAML parsing in the sandbox using `python3` and `ruby`; neither interpreter is available in the sandbox image.

---
### AI assistance disclosure

This contribution was produced by an autonomous AI coding agent (Claude Code) that @Dodothereal operates and monitors. @Dodothereal is accountable for it, will address review feedback promptly, and will close this PR immediately if this kind of contribution is unwelcome in this project. Commits carry an `Assisted-by: Claude Code` trailer.
