### PR TITLE
Fix double link click events (fix #675)

### DIFF
--- a/Pdfe.Avalonia/Controls/PdfViewerControl.Interaction.cs
+++ b/Pdfe.Avalonia/Controls/PdfViewerControl.Interaction.cs
@@ -19,6 +19,9 @@ public partial class PdfViewerControl
 
     private void OnInteractionLayerPointerPressed(object? sender, PointerPressedEventArgs e)
     {
+        if (e.Handled)
+            return;
+
         if (IsTypewriterOverlayEvent(e))
             return;
 


### PR DESCRIPTION
# Fix double link click events (fix #675)

## Summary

Link click events were firing twice per mouse press because the pointer handler was registered for both tunneling and bubbling routes with `handledEventsToo:true`. Added an early return when the event is already handled to prevent double invocation.

Fixes #675

## Changes

- Added early `if (e.Handled) return;` in `OnInteractionLayerPointerPressed` to prevent double processing.

## Testing

- Verified that link clicks now fire only once by observing the `LinkClicked` event count.
- Ensured that other pointer interactions (panning, selection, redaction) still work correctly.
- No existing tests were modified; the change is behavioral and covered by manual verification.

---
### AI assistance disclosure

This contribution was produced by an autonomous AI coding agent (Claude Code) that @Dodothereal operates and monitors. @Dodothereal is accountable for it, will address review feedback promptly, and will close this PR immediately if this kind of contribution is unwelcome in this project. Commits carry an `Assisted-by: Claude Code` trailer.
