### PR TITLE
fix: render continuous viewer at device-pixel resolution — crisp text on HiDPI/zoom (#682, #683)

### DIFF
--- a/Excise.Avalonia.Tests/ContinuousCacheMemoryTests.cs
+++ b/Excise.Avalonia.Tests/ContinuousCacheMemoryTests.cs
@@ -103,7 +103,7 @@ public class ContinuousCacheMemoryTests
                         slot, new Vector(offsetX, offsetY), new Size(vp.Width, vp.Height), 0, zoom, out var request);
                     if (!ok) continue;
 
-                    int dpi = PdfViewerControl.EffectiveContinuousDpi(BaseRenderDpi, zoom, PdfViewerControl.MaxContinuousDpi);
+                    int dpi = PdfViewerControl.EffectiveContinuousDpi(BaseRenderDpi, zoom, PdfViewerControl.MaxContinuousDpi, renderScaling: 1.0);
 
                     // Reproduces SkiaRenderer.RenderPage's own device-pixel sizing:
                     // scale = dpi/72, pixel width/height = ceil(clipRect dimension * scale).

--- a/Excise.Avalonia.Tests/ContinuousDpiTests.cs
+++ b/Excise.Avalonia.Tests/ContinuousDpiTests.cs
@@ -13,13 +13,21 @@ namespace Excise.Avalonia.Tests;
 public class ContinuousDpiTests
 {
     [Theory]
-    [InlineData(1.0, 120)]   // at 100% zoom, render at the base DPI
-    [InlineData(1.5, 180)]   // scales with zoom -> crisper
-    [InlineData(2.0, 240)]   // at the cap
-    [InlineData(4.0, 240)]   // deep zoom is clamped to the cap (bounds memory)
-    [InlineData(0.5, 120)]   // never below the base DPI
-    public void EffectiveContinuousDpi_ScalesWithZoom_AndClamps(double zoom, int expected)
-        => PdfViewerControl.EffectiveContinuousDpi(120, zoom, PdfViewerControl.MaxContinuousDpi)
+    // zoom, renderScaling (device-pixel-ratio), expected DPI
+    // --- standard display (dpr 1.0): behaviour is unchanged from before #682 ---
+    [InlineData(1.0, 1.0, 120)]   // at 100% zoom, render at the base DPI
+    [InlineData(1.5, 1.0, 180)]   // scales with zoom -> crisper
+    [InlineData(2.0, 1.0, 240)]   // at the cap
+    [InlineData(4.0, 1.0, 240)]   // deep zoom is clamped to the cap (bounds memory)
+    [InlineData(0.5, 1.0, 120)]   // never below the base DPI
+    // --- HiDPI / Retina (dpr 2.0): render scales with the device pixel ratio (#682/#683) ---
+    [InlineData(1.0, 2.0, 240)]   // 100% on a 2x display -> 2x pixels = crisp, not upscaled
+    [InlineData(1.5, 2.0, 360)]
+    [InlineData(2.0, 2.0, 480)]   // the cap scales with dpr, so the same *visual* zoom stays crisp
+    [InlineData(4.0, 2.0, 480)]   // clamped to the dpr-scaled cap
+    [InlineData(0.5, 2.0, 240)]   // floor also scales with dpr
+    public void EffectiveContinuousDpi_ScalesWithZoomAndDpr_AndClamps(double zoom, double dpr, int expected)
+        => PdfViewerControl.EffectiveContinuousDpi(120, zoom, PdfViewerControl.MaxContinuousDpi, dpr)
             .Should().Be(expected);
 
     [Fact]

--- a/Excise.Avalonia/Controls/PdfViewerControl.Continuous.cs
+++ b/Excise.Avalonia/Controls/PdfViewerControl.Continuous.cs
@@ -91,11 +91,33 @@ public partial class PdfViewerControl
     // through RenderOptions.ClipRect rather than allocating a full-page bitmap.
     internal const int MaxContinuousDpi = 240;
     private int ContinuousRenderDpi =>
-        (int)Math.Clamp(Math.Round(DefaultRenderDpi * ZoomLevel), DefaultRenderDpi, MaxContinuousDpi);
+        EffectiveContinuousDpi(DefaultRenderDpi, ZoomLevel, MaxContinuousDpi, EffectiveRenderScaling);
 
-    /// <summary>The render DPI chosen for a given zoom (pure; unit-tested).</summary>
-    internal static int EffectiveContinuousDpi(int baseDpi, double zoom, int maxDpi) =>
-        (int)Math.Clamp(Math.Round(baseDpi * zoom), baseDpi, maxDpi);
+    /// <summary>
+    /// The render DPI chosen for a given zoom and display device-pixel-ratio
+    /// (pure; unit-tested). Multiplying by <paramref name="renderScaling"/> makes
+    /// text crisp on HiDPI/Retina displays (#682): at 100% zoom on a 2× display,
+    /// a page point occupies ~2.67 device pixels, so a 120-DPI raster upscales and
+    /// softens — rendering at baseDpi×dpr gives the pixels the display actually has.
+    /// The tile is laid out by its DIP dimensions, so more render pixels change
+    /// only sharpness, never geometry. The cap scales with dpr too, so zoom stays
+    /// crisp to the same *visual* zoom on every display (#683); the byte-budgeted
+    /// tile cache (#615) absorbs the larger tiles.
+    /// </summary>
+    internal static int EffectiveContinuousDpi(int baseDpi, double zoom, int maxDpi, double renderScaling)
+    {
+        double dpr = Math.Clamp(renderScaling <= 0 ? 1.0 : renderScaling, 1.0, 4.0);
+        return (int)Math.Clamp(
+            Math.Round(baseDpi * zoom * dpr),
+            Math.Round(baseDpi * dpr),
+            Math.Round(maxDpi * dpr));
+    }
+
+    /// <summary>
+    /// The display's device-pixel-ratio (2.0 on a Retina/HiDPI screen, 1.0 on a
+    /// standard one), or 1.0 before the control is attached to a visual root.
+    /// </summary>
+    private double EffectiveRenderScaling => TopLevel.GetTopLevel(this)?.RenderScaling ?? 1.0;
 
     // Guards the scroll -> CurrentPage -> scroll feedback loop.
     private bool _syncingPageFromScroll;


### PR DESCRIPTION
## Problem
The viewer chose render DPI from zoom alone (base 120, cap 240), **ignoring the display device-pixel-ratio**. On Retina/HiDPI a page point spans ~2.67 device pixels, so the 120-DPI raster was upscaled and softened **even at 100% zoom** — blurry text / 'weird' letter spacing. (The engine itself is pixel-exact vs mutool/gs/cairo with subpixel + linear metrics; this was purely under-resolution.)

## Fix
`EffectiveContinuousDpi` now takes the device-pixel-ratio and scales target/floor/cap by it:
- **dpr=1: byte-for-byte unchanged** (every existing expectation holds — no regression).
- **dpr=2: 100% zoom renders at 240 DPI (crisp)**; the cap scales so the same *visual* zoom stays crisp.
- Tiles are laid out by DIP dimensions → extra render pixels change **sharpness only, never geometry**; the byte-budgeted cache (#615) absorbs larger tiles; the tile cache key includes DPI so moving between monitors re-renders correctly.

## Scope
Fixes the **default continuous view** (#682 fully; #683's HiDPI cap). **Single-page view** still zooms via a pure `ScaleTransform` without re-rendering — a riskier refactor (touches the render/scale/coordinate triad) with a HiDPI result that can't be headless-tested, so it's left as tracked follow-up on #683.

## Tests
`ContinuousDpiTests` now covers dpr=1 (unchanged) + dpr=2 (doubled/clamped); all 32 `Excise.Avalonia` tests pass; solution builds clean; gate-asymmetry clean. Manual HiDPI verification recommended before the single-page follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)