### PR TITLE
fix: render single-page viewer at device resolution — crisp text on HiDPI (#682)

### DIFF
--- a/Excise.Avalonia.Tests/PublicApi/Excise.Avalonia.approved.txt
+++ b/Excise.Avalonia.Tests/PublicApi/Excise.Avalonia.approved.txt
@@ -192,7 +192,7 @@ namespace Excise.Avalonia.Imaging
 {
     public static class SkiaInterop
     {
-        public static Avalonia.Media.Imaging.WriteableBitmap? ToAvaloniaBitmap(SkiaSharp.SKBitmap? skBitmap) { }
+        public static Avalonia.Media.Imaging.WriteableBitmap? ToAvaloniaBitmap(SkiaSharp.SKBitmap? skBitmap, double bitmapDpi = 96) { }
     }
 }
 namespace Excise.Avalonia.Services

--- a/Excise.Avalonia.Tests/SinglePageRenderPlanTests.cs
+++ b/Excise.Avalonia.Tests/SinglePageRenderPlanTests.cs
@@ -1,0 +1,65 @@
+using AwesomeAssertions;
+using Excise.Avalonia.Controls;
+using Xunit;
+
+namespace Excise.Avalonia.Tests;
+
+/// <summary>
+/// Unit tests for the single-page device-resolution render plan (#682).
+/// Pure logic — no rendering — so it runs in the non-flaky viewer-lib project.
+///
+/// The whole safety argument for the HiDPI fix is the INVARIANT: rendering at
+/// device resolution and stamping the bitmap DPI accordingly leaves the bitmap's
+/// DIP size — and therefore the Image's layout size and every coordinate mapping
+/// (clicks, selection, links) — unchanged; only the pixel density improves. These
+/// tests pin exactly that, so a future edit that breaks the invariant (and would
+/// silently mis-place content or clicks) fails loudly.
+/// </summary>
+public class SinglePageRenderPlanTests
+{
+    [Theory]
+    // logicalDpi, dpr, expectedDeviceDpi, expectedBitmapDpi
+    [InlineData(120, 1.0, 120, 96.0)]   // standard display: exact no-op
+    [InlineData(96, 1.0, 96, 96.0)]
+    [InlineData(120, 2.0, 240, 192.0)]  // Retina: 2x pixels, stamped 2x DPI
+    [InlineData(96, 2.0, 192, 192.0)]
+    [InlineData(120, 1.5, 180, 144.0)]  // fractional scaling
+    [InlineData(120, 3.0, 360, 288.0)]
+    public void SinglePageRenderPlan_RendersAtDeviceResolution(
+        int logicalDpi, double dpr, int expectedDeviceDpi, double expectedBitmapDpi)
+    {
+        var (deviceDpi, bitmapDpi) = PdfViewerControl.SinglePageRenderPlan(logicalDpi, dpr);
+        deviceDpi.Should().Be(expectedDeviceDpi);
+        bitmapDpi.Should().Be(expectedBitmapDpi);
+    }
+
+    [Theory]
+    [InlineData(120, 1.0)]
+    [InlineData(120, 2.0)]
+    [InlineData(96, 2.0)]
+    [InlineData(72, 1.5)]
+    [InlineData(300, 2.0)]
+    public void SinglePageRenderPlan_KeepsDipSizeInvariant(int logicalDpi, double dpr)
+    {
+        var (deviceDpi, bitmapDpi) = PdfViewerControl.SinglePageRenderPlan(logicalDpi, dpr);
+
+        // A bitmap of N device pixels stamped at `bitmapDpi` reports a DIP size of
+        // N / (bitmapDpi / 96). Its per-point DIP scale is therefore
+        // deviceDpi / (bitmapDpi / 96), which MUST equal the logical DPI — that is
+        // what keeps the on-screen size and all coordinate mapping unchanged.
+        double dipScale = deviceDpi / (bitmapDpi / 96.0);
+        dipScale.Should().BeApproximately(logicalDpi, 0.5,
+            "the bitmap's DIP size (and thus layout + coordinates) must be invariant to the device-pixel-ratio");
+    }
+
+    [Theory]
+    [InlineData(0.0, 1.0)]    // unattached / bogus -> treated as 1.0
+    [InlineData(-2.0, 1.0)]
+    [InlineData(8.0, 4.0)]    // clamped to a sane upper bound
+    public void SinglePageRenderPlan_ClampsDpr(double dpr, double effectiveDpr)
+    {
+        var (deviceDpi, bitmapDpi) = PdfViewerControl.SinglePageRenderPlan(120, dpr);
+        deviceDpi.Should().Be((int)(120 * effectiveDpr));
+        bitmapDpi.Should().Be(96.0 * effectiveDpr);
+    }
+}

--- a/Excise.Avalonia/Controls/PdfViewerControl.axaml.cs
+++ b/Excise.Avalonia/Controls/PdfViewerControl.axaml.cs
@@ -1198,13 +1198,22 @@ public partial class PdfViewerControl : UserControl
         var doc = Document;
         var pageNumber = CurrentPage;
         var page = doc.GetPage(pageNumber);
-        var renderDpi = EffectiveSinglePageRenderDpi(page);
-        _currentSinglePageRenderDpi = renderDpi;
+        // Logical DPI drives layout and coordinate mapping (unchanged); device
+        // DPI is what we actually rasterize at so text is crisp on HiDPI (#682).
+        var logicalDpi = EffectiveSinglePageRenderDpi(page);
+        _currentSinglePageRenderDpi = logicalDpi;
+        var (renderDpi, bitmapDpi) = SinglePageRenderPlan(logicalDpi, EffectiveRenderScaling);
+        // MaxSinglePagePreviewPixels is a DEVICE-pixel (memory) ceiling, so it is
+        // NOT scaled by the device-pixel-ratio: a normal page at device resolution
+        // stays far under it (crisp), while a very large page is still capped at
+        // the same memory bound (it simply doesn't gain the HiDPI sharpening).
+        long maxPixels = MaxSinglePagePreviewPixels;
 
         // Cache hit short-circuits the renderer entirely — this is the
         // common case for backwards-paging, undoing redactions, and
         // toggling overlays. Set Image.Source immediately so the user
-        // doesn't even see a loading flicker.
+        // doesn't even see a loading flicker. The cache is keyed by the
+        // DEVICE render DPI so a monitor change (dpr) re-renders.
         if (TryGetCached(pageNumber, renderDpi, out var cached))
         {
             if (_pdfImage != null)
@@ -1238,7 +1247,7 @@ public partial class PdfViewerControl : UserControl
                 var options = new Excise.Rendering.RenderOptions
                 {
                     Dpi = renderDpi,
-                    MaxPixelCount = MaxSinglePagePreviewPixels
+                    MaxPixelCount = maxPixels
                 };
                 return _renderer.RenderPage(page, options);
             }, token);
@@ -1250,7 +1259,7 @@ public partial class PdfViewerControl : UserControl
                 // freshly-rendered new page with the stale one.
                 if (token.IsCancellationRequested) return;
 
-                var bitmap = SkiaInterop.ToAvaloniaBitmap(skBitmap);
+                var bitmap = SkiaInterop.ToAvaloniaBitmap(skBitmap, bitmapDpi);
                 if (bitmap != null)
                 {
                     AddToCache(pageNumber, renderDpi, bitmap);
@@ -1302,6 +1311,24 @@ public partial class PdfViewerControl : UserControl
         var dpi = (int)Math.Floor(Math.Sqrt(MaxSinglePagePreviewPixels / (widthPt * heightPt)) *
                                   PdfPageRect.PdfPointsPerInch);
         return Math.Clamp(dpi, MinSinglePageRenderDpi, DefaultRenderDpi);
+    }
+
+    /// <summary>
+    /// Device-resolution render plan for a single page (pure; unit-tested).
+    /// Given the logical render DPI (which drives layout and coordinate mapping)
+    /// and the display device-pixel-ratio, returns the DPI to rasterize at
+    /// (device resolution) and the DPI to stamp on the resulting bitmap so its
+    /// DIP size equals the logical size. This makes the fix invariant: display
+    /// size and every coordinate mapping are unchanged, only sharpness improves
+    /// (#682). At dpr=1 it is an exact no-op (device == logical, stamp == 96).
+    /// The invariant callers rely on: <c>deviceDpi / (bitmapDpi / 96) == logicalDpi</c>.
+    /// </summary>
+    internal static (int DeviceDpi, double BitmapDpi) SinglePageRenderPlan(int logicalDpi, double devicePixelRatio)
+    {
+        double dpr = Math.Clamp(devicePixelRatio <= 0 ? 1.0 : devicePixelRatio, 1.0, 4.0);
+        int deviceDpi = (int)Math.Round(logicalDpi * dpr);
+        double bitmapDpi = 96.0 * dpr;
+        return (deviceDpi, bitmapDpi);
     }
 
     private bool TryGetCached(int page, int dpi, out WriteableBitmap? bmp)

--- a/Excise.Avalonia/Imaging/SkiaInterop.cs
+++ b/Excise.Avalonia/Imaging/SkiaInterop.cs
@@ -24,7 +24,17 @@ public static class SkiaInterop
     /// Convert an SKBitmap to a displayable Avalonia <see cref="WriteableBitmap"/>
     /// by copying pixels directly. The caller still owns the input SKBitmap.
     /// </summary>
-    public static WriteableBitmap? ToAvaloniaBitmap(SKBitmap? skBitmap)
+    /// <param name="bitmapDpi">
+    /// The DPI to stamp on the <see cref="WriteableBitmap"/>. The default 96
+    /// makes one bitmap pixel one device-independent pixel (the continuous-view
+    /// path, which sizes tiles by explicit DIP dimensions, relies on this). The
+    /// single-page path renders at the display's *device* resolution
+    /// (logicalDpi × devicePixelRatio) and stamps <c>96 × devicePixelRatio</c>
+    /// here, so the bitmap's DIP <see cref="Bitmap.Size"/> — and therefore the
+    /// Image's layout size and all coordinate mapping — stay identical while the
+    /// raster carries the extra pixels a HiDPI display actually has (#682).
+    /// </param>
+    public static WriteableBitmap? ToAvaloniaBitmap(SKBitmap? skBitmap, double bitmapDpi = 96.0)
     {
         if (skBitmap == null || skBitmap.Width <= 0 || skBitmap.Height <= 0)
             return null;
@@ -47,10 +57,12 @@ public static class SkiaInterop
             }
 
             var size = new PixelSize(source.Width, source.Height);
-            // 96 DPI matches Avalonia's default device-independent unit; the
-            // viewer scales the image with a ScaleTransform regardless, so
-            // baking a higher DPI into the bitmap metadata is purely cosmetic.
-            var dpi = new Vector(96, 96);
+            // The stamped DPI decides how many bitmap pixels map to one DIP.
+            // 96 (default) = 1:1. The single-page path renders at device
+            // resolution and passes 96×devicePixelRatio so the raster is crisp
+            // on HiDPI while its DIP Size — and thus layout/coordinates — is
+            // unchanged (#682).
+            var dpi = new Vector(bitmapDpi, bitmapDpi);
             var wb = new WriteableBitmap(size, dpi,
                 PixelFormat.Bgra8888, AlphaFormat.Premul);
 


### PR DESCRIPTION
Completes **#682** (continuous view fixed in #684). Single-page view stamped bitmaps at 96 DPI + zoomed via a ScaleTransform, so on HiDPI/Retina text was under-resolution and upscaled — soft even at 100% (the reported 'weird spacing'; the engine is pixel-exact vs the reference renderers).

## Fix
`SinglePageRenderPlan(logicalDpi, dpr)` rasterizes at **device resolution** (`logicalDpi × dpr`) and stamps the bitmap at `96 × dpr`. The **invariant `deviceDpi / (bitmapDpi/96) == logicalDpi`** keeps the bitmap's DIP `Size` — and thus the Image layout size, the ScaleTransform, and **all coordinate mapping** (clicks/selection/links) — unchanged; only pixel density improves.

- **dpr=1 → exact no-op** (device==logical, stamp==96).
- `MaxSinglePagePreviewPixels` stays a fixed device-pixel memory ceiling (normal pages crisp, huge pages cap gracefully).
- Cache keys on device DPI (monitor change re-renders).
- `ToAvaloniaBitmap` gained an optional `bitmapDpi` (default 96 — continuous view untouched).

## Verification
- `SinglePageRenderPlanTests` pin the no-op **and the size-invariance** (the property that makes it safe).
- All **32 Excise.Avalonia** + **144 coordinate/selection/link/render App tests** pass — no dpr=1 regression.
- **Caveat:** the dpr>1 visual result is correct-by-construction (the invariant) but hasn't been checked on a real Retina display — **recommend one manual HiDPI verification** before fully trusting it.

Also buys crisp zoom up to dpr× for free; deep-zoom re-render on standard displays remains **#683**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)