### PR TITLE
fix: single-page viewer re-renders at zoom resolution — crisp text at any zoom (#683)

### DIFF
--- a/Excise.Avalonia.Tests/SinglePageRenderPlanTests.cs
+++ b/Excise.Avalonia.Tests/SinglePageRenderPlanTests.cs
@@ -5,30 +5,30 @@ using Xunit;
 namespace Excise.Avalonia.Tests;
 
 /// <summary>
-/// Unit tests for the single-page device-resolution render plan (#682).
+/// Unit tests for the single-page device-resolution render plan (#682/#683).
 /// Pure logic — no rendering — so it runs in the non-flaky viewer-lib project.
 ///
-/// The whole safety argument for the HiDPI fix is the INVARIANT: rendering at
-/// device resolution and stamping the bitmap DPI accordingly leaves the bitmap's
-/// DIP size — and therefore the Image's layout size and every coordinate mapping
-/// (clicks, selection, links) — unchanged; only the pixel density improves. These
-/// tests pin exactly that, so a future edit that breaks the invariant (and would
-/// silently mis-place content or clicks) fails loudly.
+/// The whole safety argument for the HiDPI/zoom fix is the INVARIANT: rendering
+/// at the on-screen magnification and stamping the bitmap DPI accordingly leaves
+/// the bitmap's DIP size — and therefore the Image's layout size and every
+/// coordinate mapping (clicks, selection, links) — unchanged; only the pixel
+/// density improves. These tests pin exactly that, plus the memory cap.
 /// </summary>
 public class SinglePageRenderPlanTests
 {
+    private const double Uncapped = 1000.0;
+
     [Theory]
-    // logicalDpi, dpr, expectedDeviceDpi, expectedBitmapDpi
-    [InlineData(120, 1.0, 120, 96.0)]   // standard display: exact no-op
+    // logicalDpi, scale (dpr×zoom), expectedDeviceDpi, expectedBitmapDpi
+    [InlineData(120, 1.0, 120, 96.0)]   // 100% on a standard display: exact no-op
     [InlineData(96, 1.0, 96, 96.0)]
-    [InlineData(120, 2.0, 240, 192.0)]  // Retina: 2x pixels, stamped 2x DPI
-    [InlineData(96, 2.0, 192, 192.0)]
-    [InlineData(120, 1.5, 180, 144.0)]  // fractional scaling
-    [InlineData(120, 3.0, 360, 288.0)]
-    public void SinglePageRenderPlan_RendersAtDeviceResolution(
-        int logicalDpi, double dpr, int expectedDeviceDpi, double expectedBitmapDpi)
+    [InlineData(120, 2.0, 240, 192.0)]  // Retina @100%, or standard @200% zoom
+    [InlineData(120, 1.5, 180, 144.0)]
+    [InlineData(120, 4.0, 480, 384.0)]  // Retina @200% zoom -> device resolution
+    public void SinglePageRenderPlan_RastersAtOnScreenMagnification(
+        int logicalDpi, double scale, int expectedDeviceDpi, double expectedBitmapDpi)
     {
-        var (deviceDpi, bitmapDpi) = PdfViewerControl.SinglePageRenderPlan(logicalDpi, dpr);
+        var (deviceDpi, bitmapDpi) = PdfViewerControl.SinglePageRenderPlan(logicalDpi, scale, Uncapped);
         deviceDpi.Should().Be(expectedDeviceDpi);
         bitmapDpi.Should().Be(expectedBitmapDpi);
     }
@@ -36,30 +36,58 @@ public class SinglePageRenderPlanTests
     [Theory]
     [InlineData(120, 1.0)]
     [InlineData(120, 2.0)]
-    [InlineData(96, 2.0)]
+    [InlineData(96, 3.0)]
     [InlineData(72, 1.5)]
-    [InlineData(300, 2.0)]
-    public void SinglePageRenderPlan_KeepsDipSizeInvariant(int logicalDpi, double dpr)
+    public void SinglePageRenderPlan_KeepsDipSizeInvariant(int logicalDpi, double scale)
     {
-        var (deviceDpi, bitmapDpi) = PdfViewerControl.SinglePageRenderPlan(logicalDpi, dpr);
+        var (deviceDpi, bitmapDpi) = PdfViewerControl.SinglePageRenderPlan(logicalDpi, scale, Uncapped);
 
         // A bitmap of N device pixels stamped at `bitmapDpi` reports a DIP size of
-        // N / (bitmapDpi / 96). Its per-point DIP scale is therefore
-        // deviceDpi / (bitmapDpi / 96), which MUST equal the logical DPI — that is
-        // what keeps the on-screen size and all coordinate mapping unchanged.
+        // N / (bitmapDpi / 96); its per-point DIP scale, deviceDpi / (bitmapDpi/96),
+        // MUST equal the logical DPI — that keeps on-screen size + coordinates fixed.
         double dipScale = deviceDpi / (bitmapDpi / 96.0);
         dipScale.Should().BeApproximately(logicalDpi, 0.5,
-            "the bitmap's DIP size (and thus layout + coordinates) must be invariant to the device-pixel-ratio");
+            "the bitmap's DIP size (and thus layout + coordinates) must be invariant to zoom/dpr");
     }
 
     [Theory]
-    [InlineData(0.0, 1.0)]    // unattached / bogus -> treated as 1.0
-    [InlineData(-2.0, 1.0)]
-    [InlineData(8.0, 4.0)]    // clamped to a sane upper bound
-    public void SinglePageRenderPlan_ClampsDpr(double dpr, double effectiveDpr)
+    [InlineData(0.5, 1.0)]     // never below 1 (would down-res the base render)
+    [InlineData(8.0, 5.0)]     // capped to the memory budget
+    [InlineData(3.0, 5.0)]     // under the cap -> unaffected
+    public void SinglePageRenderPlan_ClampsScaleToBudget(double scale, double maxScale)
     {
-        var (deviceDpi, bitmapDpi) = PdfViewerControl.SinglePageRenderPlan(120, dpr);
-        deviceDpi.Should().Be((int)(120 * effectiveDpr));
-        bitmapDpi.Should().Be(96.0 * effectiveDpr);
+        var (deviceDpi, bitmapDpi) = PdfViewerControl.SinglePageRenderPlan(120, scale, maxScale);
+        double effective = System.Math.Clamp(scale <= 0 ? 1.0 : scale, 1.0, maxScale);
+        deviceDpi.Should().Be((int)System.Math.Round(120 * effective));
+        bitmapDpi.Should().Be(96.0 * effective);
+    }
+
+    [Fact]
+    public void MaxSinglePageRenderScale_IsAtLeastOne_AndShrinksForHugePages()
+    {
+        // A normal Letter page at 120 DPI (~1.35M px) has plenty of headroom.
+        var letter = PdfViewerControl.MaxSinglePageRenderScale(612, 792, 120);
+        letter.Should().BeGreaterThan(3.0);
+
+        // A very large page is capped so the raster stays within the memory budget.
+        var huge = PdfViewerControl.MaxSinglePageRenderScale(5000, 6000, 120);
+        huge.Should().BeGreaterThanOrEqualTo(1.0);
+        huge.Should().BeLessThan(letter, "a bigger page must allow less extra scaling");
+
+        // Degenerate input is safe.
+        PdfViewerControl.MaxSinglePageRenderScale(0, 0, 120).Should().Be(1.0);
+    }
+
+    [Fact]
+    public void MaxSinglePageRenderScale_KeepsRasterWithinBudget()
+    {
+        const double w = 612, h = 792;
+        const int dpi = 120;
+        double maxScale = PdfViewerControl.MaxSinglePageRenderScale(w, h, dpi);
+        var (deviceDpi, _) = PdfViewerControl.SinglePageRenderPlan(dpi, maxScale + 5, maxScale);
+
+        double pixels = (w * deviceDpi / 72.0) * (h * deviceDpi / 72.0);
+        pixels.Should().BeLessThanOrEqualTo(64L * 1024 * 1024 * 1.02,
+            "the capped device render must not exceed the single-page pixel budget");
     }
 }

--- a/Excise.Avalonia/Controls/PdfViewerControl.axaml.cs
+++ b/Excise.Avalonia/Controls/PdfViewerControl.axaml.cs
@@ -1020,7 +1020,18 @@ public partial class PdfViewerControl : UserControl
             _zoomScaleTransform.ScaleY = ZoomLevel;
         }
         if (ViewMode == PdfViewMode.Continuous)
+        {
             ApplyContinuousZoom();
+        }
+        else
+        {
+            // Single-page: the ScaleTransform above gives instant visual zoom;
+            // re-render at the new zoom's device resolution so text re-crisps
+            // instead of upscaling the previous raster (#683). RenderCurrentPageAsync
+            // cancels any in-flight render, so a fast zoom coalesces to the last
+            // level; a cache hit at an already-seen zoom is instant.
+            _ = RenderCurrentPageAsync();
+        }
         UpdateViewerAutomationProperties();
     }
 
@@ -1198,11 +1209,18 @@ public partial class PdfViewerControl : UserControl
         var doc = Document;
         var pageNumber = CurrentPage;
         var page = doc.GetPage(pageNumber);
-        // Logical DPI drives layout and coordinate mapping (unchanged); device
-        // DPI is what we actually rasterize at so text is crisp on HiDPI (#682).
+        // Logical DPI drives layout and coordinate mapping (unchanged); the
+        // raster is produced at the on-screen magnification (device-pixel-ratio ×
+        // zoom) so text is crisp on HiDPI (#682) AND when zoomed in (#683),
+        // bounded by the single-page memory budget.
         var logicalDpi = EffectiveSinglePageRenderDpi(page);
         _currentSinglePageRenderDpi = logicalDpi;
-        var (renderDpi, bitmapDpi) = SinglePageRenderPlan(logicalDpi, EffectiveRenderScaling);
+        var box = page.CropBox.Normalize();
+        var widthPt = page.Rotation is 90 or 270 ? box.Height : box.Width;
+        var heightPt = page.Rotation is 90 or 270 ? box.Width : box.Height;
+        double scale = ZoomLevel * EffectiveRenderScaling;
+        double maxScale = MaxSinglePageRenderScale(widthPt, heightPt, logicalDpi);
+        var (renderDpi, bitmapDpi) = SinglePageRenderPlan(logicalDpi, scale, maxScale);
         // MaxSinglePagePreviewPixels is a DEVICE-pixel (memory) ceiling, so it is
         // NOT scaled by the device-pixel-ratio: a normal page at device resolution
         // stays far under it (crisp), while a very large page is still capped at
@@ -1315,20 +1333,37 @@ public partial class PdfViewerControl : UserControl
 
     /// <summary>
     /// Device-resolution render plan for a single page (pure; unit-tested).
-    /// Given the logical render DPI (which drives layout and coordinate mapping)
-    /// and the display device-pixel-ratio, returns the DPI to rasterize at
-    /// (device resolution) and the DPI to stamp on the resulting bitmap so its
-    /// DIP size equals the logical size. This makes the fix invariant: display
-    /// size and every coordinate mapping are unchanged, only sharpness improves
-    /// (#682). At dpr=1 it is an exact no-op (device == logical, stamp == 96).
-    /// The invariant callers rely on: <c>deviceDpi / (bitmapDpi / 96) == logicalDpi</c>.
+    /// <paramref name="scale"/> is the on-screen magnification the raster must
+    /// resolve — the display device-pixel-ratio times the zoom level — so text
+    /// stays crisp both on HiDPI displays (#682) and when zoomed in (#683). It
+    /// returns the DPI to rasterize at (device resolution) and the DPI to stamp
+    /// on the resulting bitmap so its DIP size equals the *logical* size. That
+    /// invariant — <c>deviceDpi / (bitmapDpi / 96) == logicalDpi</c> — is what
+    /// keeps the Image layout size, the ScaleTransform, and every coordinate
+    /// mapping unchanged; only pixel density changes. <paramref name="maxScale"/>
+    /// caps the raster at the single-page memory budget: beyond it the
+    /// ScaleTransform upscales (soft at extreme zoom) rather than allocating an
+    /// unbounded bitmap. At scale=1 it is an exact no-op (device == logical,
+    /// stamp == 96).
     /// </summary>
-    internal static (int DeviceDpi, double BitmapDpi) SinglePageRenderPlan(int logicalDpi, double devicePixelRatio)
+    internal static (int DeviceDpi, double BitmapDpi) SinglePageRenderPlan(int logicalDpi, double scale, double maxScale)
     {
-        double dpr = Math.Clamp(devicePixelRatio <= 0 ? 1.0 : devicePixelRatio, 1.0, 4.0);
-        int deviceDpi = (int)Math.Round(logicalDpi * dpr);
-        double bitmapDpi = 96.0 * dpr;
+        double s = Math.Clamp(scale <= 0 ? 1.0 : scale, 1.0, Math.Max(1.0, maxScale));
+        int deviceDpi = (int)Math.Round(logicalDpi * s);
+        double bitmapDpi = 96.0 * s;
         return (deviceDpi, bitmapDpi);
+    }
+
+    /// <summary>
+    /// The largest render scale that keeps a single page's raster within the
+    /// device-pixel (memory) budget (pure; unit-tested). Always ≥ 1.
+    /// </summary>
+    internal static double MaxSinglePageRenderScale(double widthPt, double heightPt, int logicalDpi)
+    {
+        double logicalPixels = (widthPt * logicalDpi / PdfPageRect.PdfPointsPerInch) *
+                               (heightPt * logicalDpi / PdfPageRect.PdfPointsPerInch);
+        if (logicalPixels <= 0) return 1.0;
+        return Math.Max(1.0, Math.Sqrt(MaxSinglePagePreviewPixels / logicalPixels));
     }
 
     private bool TryGetCached(int page, int dpi, out WriteableBitmap? bmp)


### PR DESCRIPTION
Builds on #682/#685. Single-page zoom drove only the ScaleTransform, so zooming in upscaled the base raster (soft text past devicePixelRatio× zoom, and past 100% on standard displays).

## Fix
The single page now rasterizes at the **on-screen magnification**: `SinglePageRenderPlan` takes `scale = ZoomLevel × devicePixelRatio` and stamps the bitmap DPI by the same factor, so its DIP `Size` — and thus layout, the ScaleTransform, and **all coordinate mapping** — stay invariant (`deviceDpi/(bitmapDpi/96) == logicalDpi`); only sharpness changes. `MaxSinglePageRenderScale` **caps the raster at the single-page memory budget**; beyond it the ScaleTransform upscales (soft at extreme zoom) rather than allocating an unbounded bitmap. `OnZoomLevelChanged` re-renders on zoom (ScaleTransform = instant feedback; `_renderCts` coalesces fast zoom; cached zoom levels are instant).

## Verification
- Invariant + budget cap **unit-tested**; scale=1 is an exact no-op.
- **46 Excise.Avalonia + 161 zoom/coordinate/selection/link/render App tests** pass; gate-asymmetry clean.
- **Caveat:** dpr>1 sharpening still wants one manual HiDPI check. The re-render-on-zoom uses `_renderCts` cancellation for coalescing; a debounce could further reduce churn during a continuous pinch-zoom gesture (follow-up if traces show it).

Closes #683 (deep-zoom crispness); the interactive smoothness of re-render-on-zoom is worth a manual feel-check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)