### PR TITLE
feat: thumbnail viewport window — eviction, prefetch, idle pre-warm, disk trim (#687–#690)

### DIFF
--- a/Excise.App.Tests/UI/ThumbnailWindowLifecycleTests.cs
+++ b/Excise.App.Tests/UI/ThumbnailWindowLifecycleTests.cs
@@ -1,0 +1,173 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using AwesomeAssertions;
+using Excise.App.Services;
+using Excise.App.Tests.Utilities;
+using Excise.App.ViewModels;
+using Xunit;
+
+namespace Excise.App.Tests.UI;
+
+/// <summary>
+/// Thumbnail viewport-window lifecycle (#687 eviction, #688 prefetch,
+/// #689 cache-only pre-warm, #690 disk trim). The window math is pure; the
+/// lifecycle tests drive the real VM the way the View does — via
+/// <c>NotifyThumbnailViewport</c> / <c>EnsureThumbnailLoadedAsync</c>.
+/// </summary>
+[Collection("AvaloniaTests")]
+public class ThumbnailWindowLifecycleTests
+{
+    // ── #687/#688: pure window math ─────────────────────────────────────────
+
+    [Theory]
+    // visMin, visMax, pages, expected: pf, pt, kf, kt (margins 12 / 48)
+    [InlineData(0, 5, 100, 0, 17, 0, 53)]      // top of the doc: clamped at 0
+    [InlineData(55, 59, 60, 43, 59, 7, 59)]    // bottom of the doc: clamped at end
+    [InlineData(50, 55, 200, 38, 67, 2, 103)]  // middle: symmetric margins
+    [InlineData(0, 0, 1, 0, 0, 0, 0)]          // single page
+    public void ComputeThumbnailWindow_ClampsToDocument(
+        int visMin, int visMax, int pages, int pf, int pt, int kf, int kt)
+        => MainWindowViewModel.ComputeThumbnailWindow(visMin, visMax, pages)
+            .Should().Be((pf, pt, kf, kt));
+
+    [Fact]
+    public void ComputeThumbnailWindow_EmptyInputs_ProduceEmptyWindows()
+    {
+        MainWindowViewModel.ComputeThumbnailWindow(3, 2, 100).Should().Be((0, -1, 0, -1));
+        MainWindowViewModel.ComputeThumbnailWindow(0, 5, 0).Should().Be((0, -1, 0, -1));
+    }
+
+    [Fact]
+    public void KeepMargin_ExceedsPrefetchMargin_ForHysteresis()
+        => MainWindowViewModel.ThumbnailKeepMargin.Should().BeGreaterThan(
+            MainWindowViewModel.ThumbnailPrefetchMargin * 2,
+            "eviction must lag prefetch by enough that boundary jitter cannot thrash load/evict cycles");
+
+    // ── #687 + #688 + #689: end-to-end against the real VM ──────────────────
+
+    [FixedAvaloniaFact(Timeout = 180000)]
+    public async Task ScrollFarAway_EvictsDistantThumbnails_AndPrefetchesNearby()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"excise-thumb-window-{Guid.NewGuid():N}.pdf");
+        TestPdfGenerator.CreateMultiPagePdf(path, pageCount: 60);
+        var vm = new MainWindowViewModel { ThumbnailPrewarmEnabled = false };
+        try
+        {
+            await vm.LoadDocumentAsync(path);
+            vm.PageThumbnails.Count.Should().Be(60);
+
+            // The user looks at the top of the sidebar.
+            for (int i = 0; i <= 5; i++)
+            {
+                vm.NotifyThumbnailViewport(i, isVisible: true);
+                await vm.EnsureThumbnailLoadedAsync(i);
+            }
+            vm.PageThumbnails[0].ThumbnailImage.Should().NotBeNull();
+
+            // …then jumps to the bottom (55–59 visible, top scrolled out).
+            for (int i = 0; i <= 5; i++) vm.NotifyThumbnailViewport(i, isVisible: false);
+            for (int i = 55; i <= 59; i++) vm.NotifyThumbnailViewport(i, isVisible: true);
+
+            // Let the coalesced Background-priority window pass (and its
+            // prefetch chain) run to completion.
+            await FlushDispatcherAsync();
+            if (vm.ThumbnailPrefetchTask is { } prefetch)
+                await prefetch.WaitAsync(TimeSpan.FromSeconds(60));
+            await FlushDispatcherAsync();
+
+            // #687: pages 0..5 are outside keep window [7,59] → bitmaps released.
+            for (int i = 0; i <= 5; i++)
+                vm.PageThumbnails[i].ThumbnailImage.Should().BeNull(
+                    $"page {i} is outside the keep window and its bitmap must be released");
+
+            // #688: the prefetch window [43,59] is fully loaded — including
+            // pages never reported visible.
+            for (int i = 43; i <= 59; i++)
+                vm.PageThumbnails[i].ThumbnailImage.Should().NotBeNull(
+                    $"page {i} is inside the prefetch window and should be loaded ahead of scrolling");
+
+            // Scrolling back re-populates instantly from the disk cache.
+            await vm.EnsureThumbnailLoadedAsync(0);
+            vm.PageThumbnails[0].ThumbnailImage.Should().NotBeNull();
+        }
+        finally
+        {
+            TestPdfGenerator.CleanupTestFile(path);
+        }
+    }
+
+    [FixedAvaloniaFact(Timeout = 180000)]
+    public async Task Prewarm_PopulatesDiskCacheOnly_NeverSidebarMemory()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"excise-thumb-prewarm-{Guid.NewGuid():N}.pdf");
+        TestPdfGenerator.CreateMultiPagePdf(path, pageCount: 12);
+        var vm = new MainWindowViewModel(); // prewarm enabled (default)
+        try
+        {
+            await vm.LoadDocumentAsync(path);
+            vm.ThumbnailPrewarmTask.Should().NotBeNull("first open should queue the idle pre-warm (#689)");
+            await vm.ThumbnailPrewarmTask!.WaitAsync(TimeSpan.FromSeconds(120));
+
+            // Cache-only: the sweep must not have loaded bitmaps into the
+            // sidebar (that would defeat the #687 memory bound).
+            foreach (var thumb in vm.PageThumbnails)
+                thumb.ThumbnailImage.Should().BeNull("pre-warm populates the DISK cache, not sidebar memory");
+        }
+        finally
+        {
+            TestPdfGenerator.CleanupTestFile(path);
+        }
+    }
+
+    private static async Task FlushDispatcherAsync()
+    {
+        // Two Background-priority hops: one lets a queued window pass run,
+        // the second lets work it posted (evict-dispose, prefetch start) run.
+        for (int i = 0; i < 2; i++)
+            await global::Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(
+                () => { }, global::Avalonia.Threading.DispatcherPriority.ApplicationIdle);
+    }
+
+    // ── #690: disk LRU trim ─────────────────────────────────────────────────
+
+    [Fact]
+    public void TrimCacheRoot_DeletesOldest_KeepsProtected_StopsUnderCap()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"excise-trim-{Guid.NewGuid():N}");
+        try
+        {
+            // Three per-file dirs of 1MB each, distinct ages; cap at 2MB.
+            var old = MakeCacheDir(root, "aaa-oldest", ageDays: 30);
+            var mid = MakeCacheDir(root, "bbb-middle", ageDays: 10);
+            var current = MakeCacheDir(root, "ccc-current", ageDays: 0);
+
+            ThumbnailCacheService.TrimCacheRoot(root, capBytes: 2 * 1024 * 1024, protectDirName: "ccc-current");
+
+            Directory.Exists(old).Should().BeFalse("the least-recently-used dir must be trimmed first");
+            Directory.Exists(mid).Should().BeTrue("trimming stops once under the cap");
+            Directory.Exists(current).Should().BeTrue();
+
+            // Protected dir survives even when it alone exceeds the cap.
+            ThumbnailCacheService.TrimCacheRoot(root, capBytes: 1, protectDirName: "ccc-current");
+            Directory.Exists(current).Should().BeTrue("the open document's cache is never trimmed");
+            Directory.Exists(mid).Should().BeFalse();
+        }
+        finally
+        {
+            try { Directory.Delete(root, recursive: true); } catch { }
+        }
+    }
+
+    private static string MakeCacheDir(string root, string name, int ageDays)
+    {
+        var dir = Path.Combine(root, name);
+        Directory.CreateDirectory(dir);
+        var file = Path.Combine(dir, "p00001.webp");
+        File.WriteAllBytes(file, new byte[1024 * 1024]);
+        var stamp = DateTime.UtcNow.AddDays(-ageDays);
+        File.SetLastWriteTimeUtc(file, stamp);
+        File.SetLastAccessTimeUtc(file, stamp);
+        return dir;
+    }
+}

--- a/Excise.App/Services/ThumbnailCacheService.cs
+++ b/Excise.App/Services/ThumbnailCacheService.cs
@@ -5,6 +5,7 @@ using SkiaSharp;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
@@ -56,9 +57,82 @@ public sealed class ThumbnailCacheService : IDisposable
         _logger = logger;
         _thumbnailDpi = thumbnailDpi;
         var identity = BuildCacheIdentity(pdfPath, thumbnailDpi, RendererCacheIdentity, cacheSalt);
-        _cacheDir = Path.Combine(GetCacheRoot(), "thumbnails", "v3", identity);
+        var versionRoot = Path.Combine(GetCacheRoot(), "thumbnails", "v3");
+        _cacheDir = Path.Combine(versionRoot, identity);
         _logger.LogInformation("Thumbnail cache for {File} → {Dir}",
             Path.GetFileName(pdfPath), _cacheDir);
+
+        // LRU trim (#690): the cache grows across every file ever opened, and
+        // until now nothing ever deleted anything (reads touch mtimes for
+        // exactly this). Best-effort, off the open path, never touching the
+        // document we just opened.
+        var protectDir = identity;
+        _ = Task.Run(() => TrimCacheRoot(versionRoot, DefaultCacheCapBytes, protectDir, _logger));
+    }
+
+    /// <summary>Disk budget for the whole thumbnail cache across all files (#690).</summary>
+    internal const long DefaultCacheCapBytes = 500L * 1024 * 1024;
+
+    /// <summary>
+    /// Delete least-recently-used per-file cache directories until the version
+    /// root is under <paramref name="capBytes"/> (#690). Recency is the newest
+    /// last-access/mtime of any file in the directory — reads touch mtimes for
+    /// exactly this purpose. <paramref name="protectDirName"/> (the currently
+    /// open document) is never deleted. Best-effort: IO races with another
+    /// instance are swallowed; a trimmed file simply re-renders on next open.
+    /// </summary>
+    internal static void TrimCacheRoot(string versionRoot, long capBytes, string? protectDirName, ILogger? logger = null)
+    {
+        try
+        {
+            if (!Directory.Exists(versionRoot)) return;
+
+            var entries = new List<(string Dir, long Bytes, DateTime LastUsed)>();
+            foreach (var dir in Directory.EnumerateDirectories(versionRoot))
+            {
+                long bytes = 0;
+                var lastUsed = DateTime.MinValue;
+                try
+                {
+                    foreach (var file in Directory.EnumerateFiles(dir))
+                    {
+                        var info = new FileInfo(file);
+                        bytes += info.Length;
+                        var used = info.LastAccessTimeUtc > info.LastWriteTimeUtc
+                            ? info.LastAccessTimeUtc : info.LastWriteTimeUtc;
+                        if (used > lastUsed) lastUsed = used;
+                    }
+                }
+                catch { continue; }
+                entries.Add((dir, bytes, lastUsed));
+            }
+
+            var total = entries.Sum(e => e.Bytes);
+            if (total <= capBytes) return;
+
+            foreach (var entry in entries.OrderBy(e => e.LastUsed))
+            {
+                if (total <= capBytes) break;
+                if (protectDirName != null &&
+                    string.Equals(Path.GetFileName(entry.Dir), protectDirName, StringComparison.Ordinal))
+                    continue;
+                try
+                {
+                    Directory.Delete(entry.Dir, recursive: true);
+                    total -= entry.Bytes;
+                    logger?.LogInformation("Thumbnail cache trim: removed {Dir} ({Bytes} bytes)",
+                        Path.GetFileName(entry.Dir), entry.Bytes);
+                }
+                catch (Exception ex)
+                {
+                    logger?.LogDebug(ex, "Thumbnail cache trim: could not remove {Dir}", entry.Dir);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            logger?.LogDebug(ex, "Thumbnail cache trim failed (best-effort)");
+        }
     }
 
     /// <summary>Path on disk where this document's thumbnails are stored.</summary>

--- a/Excise.App/ViewModels/MainWindowViewModel.Thumbnails.cs
+++ b/Excise.App/ViewModels/MainWindowViewModel.Thumbnails.cs
@@ -1,0 +1,238 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia.Threading;
+using Microsoft.Extensions.Logging;
+
+namespace Excise.App.ViewModels;
+
+/// <summary>
+/// Thumbnail sidebar lifecycle: viewport tracking, prefetch, eviction, and
+/// idle pre-warm (issues #687/#688/#689; baseline profile on #601).
+///
+/// The View reports per-item visibility via <see cref="NotifyThumbnailViewport"/>
+/// (from Avalonia's EffectiveViewportChanged). From the visible set this partial
+/// derives two windows around the viewport:
+///
+///   prefetch window  (±<see cref="ThumbnailPrefetchMargin"/>)  — pages loaded
+///     ahead of scrolling so the user never sees placeholder frames (#688);
+///   keep window      (±<see cref="ThumbnailKeepMargin"/>)      — pages outside
+///     it have their decoded bitmap RELEASED (#687), bounding sidebar memory by
+///     the window rather than the document length (a 1,000-page document would
+///     otherwise accumulate ~0.5 GB of never-released thumbnails).
+///
+/// Eviction is safe because re-entry is effectively free: the on-disk WebP
+/// cache (ThumbnailCacheService) decodes in well under a millisecond, so a
+/// scrolled-back page repopulates instantly. The keep margin is deliberately
+/// several times the prefetch margin (hysteresis) so boundary jitter cannot
+/// thrash load/evict cycles.
+/// </summary>
+public partial class MainWindowViewModel
+{
+    /// <summary>Pages beyond the visible range to load ahead (#688).</summary>
+    internal const int ThumbnailPrefetchMargin = 12;
+
+    /// <summary>Pages beyond the visible range to keep decoded in memory (#687).</summary>
+    internal const int ThumbnailKeepMargin = 48;
+
+    private readonly HashSet<int> _visibleThumbnailIndices = new();
+    private readonly object _thumbnailViewportLock = new();
+    private bool _thumbnailWindowPassScheduled;
+    private CancellationTokenSource? _thumbnailPrefetchCts;
+    private CancellationTokenSource? _thumbnailPrewarmCts;
+
+    /// <summary>Test hook: the currently-running prefetch chain, if any.</summary>
+    internal Task? ThumbnailPrefetchTask { get; private set; }
+
+    /// <summary>Test hook: the currently-running idle pre-warm sweep, if any.</summary>
+    internal Task? ThumbnailPrewarmTask { get; private set; }
+
+    /// <summary>Idle pre-warm on/off (#689). Mirrors AdjacentPagePrefetchEnabled.</summary>
+    internal bool ThumbnailPrewarmEnabled { get; set; } = true;
+
+    /// <summary>
+    /// The prefetch/keep windows for a visible range (pure; unit-tested).
+    /// Both are clamped to [0, pageCount).
+    /// </summary>
+    internal static (int PrefetchFrom, int PrefetchTo, int KeepFrom, int KeepTo) ComputeThumbnailWindow(
+        int visibleMin, int visibleMax, int pageCount,
+        int prefetchMargin = ThumbnailPrefetchMargin,
+        int keepMargin = ThumbnailKeepMargin)
+    {
+        if (pageCount <= 0 || visibleMin > visibleMax)
+            return (0, -1, 0, -1);
+        int pf = Math.Max(0, visibleMin - prefetchMargin);
+        int pt = Math.Min(pageCount - 1, visibleMax + prefetchMargin);
+        int kf = Math.Max(0, visibleMin - keepMargin);
+        int kt = Math.Min(pageCount - 1, visibleMax + keepMargin);
+        return (pf, pt, kf, kt);
+    }
+
+    /// <summary>
+    /// Called by the View whenever a thumbnail item's effective viewport
+    /// changes. <paramref name="isVisible"/> is false when the item scrolled
+    /// out (empty viewport). Coalesces bursts of events into one window pass
+    /// per UI-thread Background dispatch.
+    /// </summary>
+    public void NotifyThumbnailViewport(int pageIndex, bool isVisible)
+    {
+        lock (_thumbnailViewportLock)
+        {
+            var changed = isVisible
+                ? _visibleThumbnailIndices.Add(pageIndex)
+                : _visibleThumbnailIndices.Remove(pageIndex);
+            if (!changed || _thumbnailWindowPassScheduled)
+                return;
+            _thumbnailWindowPassScheduled = true;
+        }
+        Dispatcher.UIThread.Post(RunThumbnailWindowPass, DispatcherPriority.Background);
+    }
+
+    private void RunThumbnailWindowPass()
+    {
+        int visMin, visMax;
+        lock (_thumbnailViewportLock)
+        {
+            _thumbnailWindowPassScheduled = false;
+            if (_visibleThumbnailIndices.Count == 0)
+                return; // sidebar hidden or between documents — leave state alone
+            visMin = _visibleThumbnailIndices.Min();
+            visMax = _visibleThumbnailIndices.Max();
+        }
+
+        var pageCount = PageThumbnails.Count;
+        var (pf, pt, kf, kt) = ComputeThumbnailWindow(visMin, visMax, pageCount);
+        if (pt < pf)
+            return;
+
+        // ── Evict (#687): release decoded bitmaps far outside the viewport. ──
+        // Runs on the UI thread (we're a Dispatcher.Post). Dispose is deferred
+        // to a later Background dispatch so any in-flight render pass that
+        // still referenced the bitmap has unbound first.
+        List<global::Avalonia.Media.Imaging.Bitmap>? evicted = null;
+        for (int i = 0; i < pageCount; i++)
+        {
+            if (i >= kf && i <= kt) continue;
+            var thumb = PageThumbnails[i];
+            var bmp = thumb.ThumbnailImage;
+            if (bmp == null) continue;
+            thumb.ThumbnailImage = null;
+            (evicted ??= new()).Add(bmp);
+        }
+        if (evicted != null)
+        {
+            _logger.LogDebug("Thumbnail eviction: released {Count} bitmaps outside keep window [{From},{To}]",
+                evicted.Count, kf, kt);
+            Dispatcher.UIThread.Post(() =>
+            {
+                foreach (var bmp in evicted)
+                    try { bmp.Dispose(); } catch { }
+            }, DispatcherPriority.Background);
+        }
+
+        // ── Prefetch (#688): load the ±margin window, nearest-first, one at a
+        // time so an on-screen demand load is never more than one thumbnail
+        // render behind. Replacing the CTS abandons a stale chain when the
+        // viewport moves again. ──
+        var toLoad = new List<int>();
+        for (int i = pf; i <= pt; i++)
+        {
+            if (PageThumbnails[i].ThumbnailImage == null)
+                toLoad.Add(i);
+        }
+        if (toLoad.Count == 0)
+            return;
+        int center = (visMin + visMax) / 2;
+        toLoad.Sort((a, b) => Math.Abs(a - center).CompareTo(Math.Abs(b - center)));
+
+        _thumbnailPrefetchCts?.Cancel();
+        var cts = new CancellationTokenSource();
+        _thumbnailPrefetchCts = cts;
+        ThumbnailPrefetchTask = PrefetchThumbnailsAsync(toLoad, cts.Token);
+    }
+
+    private async Task PrefetchThumbnailsAsync(IReadOnlyList<int> indices, CancellationToken ct)
+    {
+        try
+        {
+            foreach (var index in indices)
+            {
+                if (ct.IsCancellationRequested) return;
+                await EnsureThumbnailLoadedAsync(index, ct);
+            }
+        }
+        catch (OperationCanceledException) { /* viewport moved on */ }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Thumbnail prefetch chain stopped");
+        }
+    }
+
+    private void CancelThumbnailWindowWork()
+    {
+        _thumbnailPrefetchCts?.Cancel();
+        _thumbnailPrewarmCts?.Cancel();
+        lock (_thumbnailViewportLock)
+        {
+            _visibleThumbnailIndices.Clear();
+        }
+    }
+
+    /// <summary>
+    /// Idle pre-warm (#689): after a document opens, walk every page once in
+    /// the background so the WebP disk cache is fully populated — the first
+    /// full sidebar scroll then shows no placeholders, and every future open
+    /// of this file is 100% sub-ms cache hits. Cache-only: the decoded bitmap
+    /// is disposed immediately, so this never violates the #687 memory bound.
+    /// Yields to demand: it waits while any visible-demand load is in flight
+    /// and throttles between pages.
+    /// </summary>
+    private void QueueThumbnailPrewarm(Services.ThumbnailCacheService thumbnailCache)
+    {
+        _thumbnailPrewarmCts?.Cancel();
+        if (!ThumbnailPrewarmEnabled)
+            return;
+        var cts = new CancellationTokenSource();
+        _thumbnailPrewarmCts = cts;
+        var pageCount = PageThumbnails.Count;
+        ThumbnailPrewarmTask = Task.Run(async () =>
+        {
+            try
+            {
+                for (int i = 0; i < pageCount; i++)
+                {
+                    if (cts.Token.IsCancellationRequested) return;
+
+                    // Yield to on-screen demand: don't queue behind the render
+                    // gate while a viewport-driven load is pending.
+                    while (true)
+                    {
+                        bool demandBusy;
+                        lock (_thumbnailLoadLock) { demandBusy = _thumbnailLoadTasks.Count > 0; }
+                        if (!demandBusy) break;
+                        await Task.Delay(50, cts.Token);
+                    }
+
+                    // Already decoded in memory (visible/prefetched) — its disk
+                    // write is queued by the cache service; nothing to do.
+                    if (i < PageThumbnails.Count && PageThumbnails[i].ThumbnailImage != null)
+                        continue;
+
+                    using var sk = await thumbnailCache.GetThumbnailAsync(i, cts.Token);
+                    // Bitmap intentionally discarded: this sweep exists to
+                    // populate the DISK cache, not sidebar memory (#687).
+
+                    await Task.Delay(25, cts.Token); // throttle: idle work
+                }
+                _logger.LogInformation("Thumbnail pre-warm complete: {Pages} pages cached", pageCount);
+            }
+            catch (OperationCanceledException) { /* document changed/closed */ }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Thumbnail pre-warm stopped");
+            }
+        }, CancellationToken.None);
+    }
+}

--- a/Excise.App/ViewModels/MainWindowViewModel.cs
+++ b/Excise.App/ViewModels/MainWindowViewModel.cs
@@ -1006,6 +1006,13 @@ public partial class MainWindowViewModel : ViewModelBase
             await LoadPageThumbnailsAsync();
             thumbnailPlaceholdersReadyElapsedMs = openSw.ElapsedMilliseconds;
 
+            // Idle pre-warm (#689): populate the disk cache for every page in
+            // the background so the first full sidebar scroll (and every
+            // future open of this file) is all cache hits. First-open only —
+            // the mutation path re-keys its cache per edit, and re-sweeping
+            // every page after every redaction would be wasted work.
+            QueueThumbnailPrewarm(_thumbnailCache);
+
             // Parse the document's table-of-contents outline (if any).
             // Cheap — just a tree walk over the catalog's /Outlines, no
             // text extraction needed. Populates the left-sidebar tree.
@@ -2606,6 +2613,9 @@ public partial class MainWindowViewModel : ViewModelBase
         {
             _thumbnailLoadTasks.Clear();
         }
+        // Stop viewport-window work targeting the outgoing document/state
+        // (prefetch chain, idle pre-warm, visible-set tracking — #687/#688/#689).
+        CancelThumbnailWindowWork();
     }
 
     /// <summary>

--- a/Excise.App/Views/MainWindow.axaml.cs
+++ b/Excise.App/Views/MainWindow.axaml.cs
@@ -222,7 +222,14 @@ public partial class MainWindow : Window
         if (sender is not Image img) return;
         if (DataContext is not MainWindowViewModel vm) return;
         if (img.Tag is not int pageIndex) return;
-        if (e.EffectiveViewport.Width <= 0 || e.EffectiveViewport.Height <= 0) return;
+
+        var visible = e.EffectiveViewport.Width > 0 && e.EffectiveViewport.Height > 0;
+
+        // Both transitions feed the VM's viewport window: visible items anchor
+        // the ±prefetch window (#688), items scrolled far out get their decoded
+        // bitmap released (#687).
+        vm.NotifyThumbnailViewport(pageIndex, visible);
+        if (!visible) return;
 
         // Fire-and-forget — VM handles its own dispatching to the UI thread.
         _ = vm.EnsureThumbnailLoadedAsync(pageIndex);


### PR DESCRIPTION
Implements all four issues in the **Thumbnail Responsiveness and Caching** milestone, measured against the #601 baseline (first render 68 ms, disk hit ~0 ms).

| Issue | Change |
|---|---|
| **#687** memory bound | View reports scroll-**out** too; VM keeps a window (visible ±48) and **releases** decoded bitmaps outside it (deferred dispose). Sidebar memory now bounded by the window, not doc length (was ~0.5 GB on 1,000 pages). Re-entry is a sub-ms WebP decode. |
| **#688** prefetch | Visible ±12 loads ahead, nearest-first, one-at-a-time (demand loads never wait more than one render), CTS-abandoned when the viewport moves. Keep ≫ prefetch margin = hysteresis (asserted by test). |
| **#689** idle pre-warm | After first open, a throttled background sweep renders every page **to the disk cache only** (bitmaps discarded — preserves the #687 bound), yields to demand loads, cancels on doc change. First full scroll + every future open = all cache hits. First-open only (mutation path re-keys its cache per edit). |
| **#690** disk trim | `TrimCacheRoot`: LRU-delete per-file cache dirs until the root is under 500 MB; never touches the open document. (mtimes were already touched on read for a trim that never existed.) |

## Verification
- **9 new tests**: pure window math (clamping + hysteresis invariant), end-to-end evict+prefetch on the real VM, pre-warm cache-only memory-safety, trim LRU/protection.
- **34 thumbnail/GUI-workflow regression tests green** (incl. the #601 perf-report with pre-warm active).
- App builds 0 warnings.

Worth a manual feel-check: fast-scroll the sidebar of a large doc (no placeholder flicker on warm cache), and memory stays flat while scrolling a many-hundred-page doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)