### PR TITLE
test: mode-switch display invariants across modes and device pixel ratios (+FixedAvaloniaTheory)

### DIFF
--- a/Excise.App.Tests/UI/GuiWorkflowCoverageMatrixTests.cs
+++ b/Excise.App.Tests/UI/GuiWorkflowCoverageMatrixTests.cs
@@ -51,6 +51,7 @@ public class GuiWorkflowCoverageMatrixTests
         new("Audit hidden text with clear user-facing states", typeof(RevealHiddenTextTests)),
         new("Audit signatures with clear user-facing states", typeof(SignatureVerificationWorkflowServiceTests)),
         new("Toolbar and menu command bindings", typeof(CommandBindingSweepTests)),
+        new("Interaction-mode toolbar buttons: display invariants across modes and device pixel ratios", typeof(ModeSwitchDisplayTests)),
         new("Keyboard shortcuts", typeof(KeyboardShortcutTests)),
         new("Mouse link activation", typeof(InPageLinkClickTests)),
         new("Outline tree navigation", typeof(OutlineTreeNavigationTests)),
@@ -73,7 +74,9 @@ public class GuiWorkflowCoverageMatrixTests
 
     private static bool IsRunnableFact(Attribute attr)
     {
-        if (attr.GetType().Name is not ("FactAttribute" or "FixedAvaloniaFactAttribute"))
+        if (attr.GetType().Name is not (
+            "FactAttribute" or "FixedAvaloniaFactAttribute" or
+            "TheoryAttribute" or "FixedAvaloniaTheoryAttribute"))
         {
             return false;
         }

--- a/Excise.App.Tests/UI/ModeSwitchDisplayTests.cs
+++ b/Excise.App.Tests/UI/ModeSwitchDisplayTests.cs
@@ -1,0 +1,225 @@
+using System;
+using System.IO;
+using System.Reactive.Linq;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using AwesomeAssertions;
+using Excise.Avalonia.Controls;
+using Excise.App.Tests.Utilities;
+using Excise.App.ViewModels;
+using Excise.App.Views;
+using ReactiveUI;
+using Xunit;
+
+namespace Excise.App.Tests.UI;
+
+/// <summary>
+/// Display-state invariants for the interaction-mode toolbar buttons
+/// (Redact / Select Text / Typewriter / Form Authoring). Prompted by a live
+/// report of "something weird happens to the display" when clicking these.
+///
+/// Every editing mode forces the viewer from the default Continuous view into
+/// SinglePage — which is exactly the render path reworked for device-resolution
+/// output (#682/#683/#685/#686). Those changes are a functional no-op at
+/// devicePixelRatio 1 (all the headless test host reports), so this battery
+/// runs each mode switch at BOTH dpr 1.0 and a simulated Retina dpr 2.0 (via
+/// <see cref="PdfViewerControl.RenderScalingOverride"/>) and asserts the
+/// invariants that make the mode switch visually sane:
+///
+///   • the single-page image appears, with a Source;
+///   • its layout (DIP) size equals the page's logical size — INDEPENDENT of
+///     dpr (the size-invariance contract of the device-resolution render);
+///   • its backing pixels scale WITH dpr (the crispness contract);
+///   • mode flags are mutually exclusive; toggling off returns to Continuous.
+/// </summary>
+[Collection("AvaloniaTests")]
+public class ModeSwitchDisplayTests
+{
+    private const double LetterWidthPt = 612;
+
+    public static TheoryData<string, double> ModeByDpr()
+    {
+        var data = new TheoryData<string, double>();
+        foreach (var mode in new[] { "redact", "select-text", "typewriter", "form-authoring" })
+        foreach (var dpr in new[] { 1.0, 2.0 })
+            data.Add(mode, dpr);
+        return data;
+    }
+
+    [FixedAvaloniaTheory]
+    [MemberData(nameof(ModeByDpr))]
+    public async Task ModeSwitch_ShowsSinglePage_WithSizeInvariantImage(string mode, double dpr)
+    {
+        var (vm, window, viewer, path) = await OpenTestDocumentAsync();
+        try
+        {
+            viewer.RenderScalingOverride = dpr;
+            vm.ViewMode.Should().Be(PdfViewMode.Continuous, "reading view is the default");
+
+            ModeCommand(vm, mode).Execute().Subscribe();
+            await PumpUntilAsync(window, () => SinglePageImage(viewer)?.Source != null);
+
+            // The switch lands in single-page with a rendered page.
+            vm.ViewMode.Should().Be(PdfViewMode.SinglePage,
+                $"{mode} mode is single-page only");
+            ModeFlag(vm, mode).Should().BeTrue();
+
+            var img = SinglePageImage(viewer)!;
+            img.IsVisible.Should().BeTrue();
+            var source = img.Source!;
+
+            // SIZE INVARIANCE: layout size equals the page's logical size no
+            // matter the display density. A dpr-dependent layout size is
+            // exactly the class of "weird display" this battery exists to catch.
+            var logicalDpi = 120; // DefaultRenderDpi for a normal page
+            var expectedDipWidth = LetterWidthPt * logicalDpi / 72.0;
+            img.Width.Should().BeApproximately(expectedDipWidth, 2.0,
+                "the page's on-screen size must not depend on the device pixel ratio");
+            source.Size.Width.Should().BeApproximately(expectedDipWidth, 2.0,
+                "the bitmap's DIP size must equal the logical page size");
+
+            // CRISPNESS: the backing pixels match the on-screen magnification —
+            // the app enters modes at its current (often fit-width) zoom, so the
+            // device scale is zoom × dpr, floored at 1 (never below base render).
+            var deviceScale = Math.Max(1.0, viewer.ZoomLevel * dpr);
+            var pixelWidth = ((global::Avalonia.Media.Imaging.Bitmap)source).PixelSize.Width;
+            pixelWidth.Should().BeCloseTo((int)Math.Round(expectedDipWidth * deviceScale), 8,
+                $"the raster must carry zoom×dpr pixels (zoom={viewer.ZoomLevel:F2}, dpr={dpr}) so text is crisp");
+            if (dpr > 1)
+                pixelWidth.Should().BeGreaterThan((int)expectedDipWidth,
+                    "on HiDPI the raster must exceed the logical size — otherwise it upscales and softens");
+
+            // Only this mode is active.
+            foreach (var other in new[] { "redact", "select-text", "typewriter", "form-authoring" })
+                if (other != mode)
+                    ModeFlag(vm, other).Should().BeFalse($"{other} must be off while {mode} is active");
+
+            // Toggling off returns to the reading view.
+            ModeCommand(vm, mode).Execute().Subscribe();
+            await PumpUntilAsync(window, () => vm.ViewMode == PdfViewMode.Continuous);
+            ModeFlag(vm, mode).Should().BeFalse();
+        }
+        finally
+        {
+            window.Close();
+            TestPdfGenerator.CleanupTestFile(path);
+        }
+    }
+
+    [FixedAvaloniaTheory]
+    [InlineData(1.0)]
+    [InlineData(2.0)]
+    public async Task SwitchingBetweenModes_KeepsSinglePageAndImageStable(double dpr)
+    {
+        var (vm, window, viewer, path) = await OpenTestDocumentAsync();
+        try
+        {
+            viewer.RenderScalingOverride = dpr;
+
+            ModeCommand(vm, "redact").Execute().Subscribe();
+            await PumpUntilAsync(window, () => SinglePageImage(viewer)?.Source != null);
+            var widthInRedact = SinglePageImage(viewer)!.Width;
+
+            // Hop directly between editing modes — no bounce through continuous.
+            foreach (var next in new[] { "select-text", "typewriter", "form-authoring", "redact" })
+            {
+                ModeCommand(vm, next).Execute().Subscribe();
+                await PumpUntilAsync(window, () => ModeFlag(vm, next));
+                vm.ViewMode.Should().Be(PdfViewMode.SinglePage,
+                    $"switching to {next} must stay in single-page view");
+                var img = SinglePageImage(viewer)!;
+                img.Source.Should().NotBeNull($"the page image must survive switching to {next}");
+                img.Width.Should().BeApproximately(widthInRedact, 2.0,
+                    $"the page's on-screen size must not jump when switching to {next}");
+            }
+        }
+        finally
+        {
+            window.Close();
+            TestPdfGenerator.CleanupTestFile(path);
+        }
+    }
+
+    [FixedAvaloniaTheory]
+    [InlineData(1.0)]
+    [InlineData(2.0)]
+    public async Task ZoomInsideMode_KeepsLayoutSize_AndSharpensPixels(double dpr)
+    {
+        var (vm, window, viewer, path) = await OpenTestDocumentAsync();
+        try
+        {
+            viewer.RenderScalingOverride = dpr;
+            ModeCommand(vm, "redact").Execute().Subscribe();
+            await PumpUntilAsync(window, () => SinglePageImage(viewer)?.Source != null);
+
+            var img = SinglePageImage(viewer)!;
+            var dipBefore = img.Width;
+            var pixelsBefore = ((global::Avalonia.Media.Imaging.Bitmap)img.Source!).PixelSize.Width;
+
+            viewer.ZoomLevel = 2.0;
+            await PumpUntilAsync(window, () =>
+                SinglePageImage(viewer)?.Source is global::Avalonia.Media.Imaging.Bitmap b &&
+                b.PixelSize.Width > pixelsBefore);
+
+            // #683: zoom re-renders at higher resolution, but layout (pre-
+            // ScaleTransform) size is unchanged — coordinates stay valid.
+            img.Width.Should().BeApproximately(dipBefore, 2.0,
+                "zoom must not change the image's layout size (the ScaleTransform handles magnification)");
+        }
+        finally
+        {
+            window.Close();
+            TestPdfGenerator.CleanupTestFile(path);
+        }
+    }
+
+    // ── harness ─────────────────────────────────────────────────────────────
+
+    private static async Task<(MainWindowViewModel vm, MainWindow window, PdfViewerControl viewer, string path)>
+        OpenTestDocumentAsync()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"excise-mode-switch-{Guid.NewGuid():N}.pdf");
+        TestPdfGenerator.CreateMultiPagePdf(path, pageCount: 3);
+        var vm = new MainWindowViewModel { ThumbnailPrewarmEnabled = false };
+        var window = new MainWindow { DataContext = vm, Width = 1280, Height = 900 };
+        window.Show();
+        await vm.LoadDocumentAsync(path);
+        var viewer = window.FindControl<PdfViewerControl>("PdfViewerControl");
+        viewer.Should().NotBeNull("MainWindow must host the PdfViewerControl");
+        return (vm, window, viewer!, path);
+    }
+
+    private static ReactiveCommand<System.Reactive.Unit, System.Reactive.Unit> ModeCommand(MainWindowViewModel vm, string mode) => mode switch
+    {
+        "redact" => vm.ToggleRedactionModeCommand,
+        "select-text" => vm.ToggleTextSelectionModeCommand,
+        "typewriter" => vm.ToggleTypewriterModeCommand,
+        "form-authoring" => vm.ToggleFormAuthoringModeCommand,
+        _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, null),
+    };
+
+    private static bool ModeFlag(MainWindowViewModel vm, string mode) => mode switch
+    {
+        "redact" => vm.IsRedactionMode,
+        "select-text" => vm.IsTextSelectionMode,
+        "typewriter" => vm.IsTypewriterMode,
+        "form-authoring" => vm.IsFormAuthoringMode,
+        _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, null),
+    };
+
+    private static Image? SinglePageImage(PdfViewerControl viewer) =>
+        viewer.FindControl<Image>("PdfImage");
+
+    private static async Task PumpUntilAsync(Window window, Func<bool> condition, int timeoutMs = 20000)
+    {
+        var deadline = Environment.TickCount64 + timeoutMs;
+        while (!condition())
+        {
+            if (Environment.TickCount64 > deadline)
+                throw new TimeoutException("condition not met while pumping the dispatcher");
+            await Task.Delay(50);
+            window.UpdateLayout();
+        }
+    }
+}

--- a/Excise.App.Tests/Utilities/FixedAvaloniaTheory.cs
+++ b/Excise.App.Tests/Utilities/FixedAvaloniaTheory.cs
@@ -1,0 +1,76 @@
+// Theory counterpart of [FixedAvaloniaFact] (see FixedAvaloniaFact.cs for the
+// upstream Avalonia.Headless.XUnit bug this works around). Until now the suite
+// had no way to run PARAMETERIZED tests on the headless Avalonia dispatcher —
+// every UI test was a Fact, so batteries like "every interaction mode × every
+// device-pixel-ratio" (ModeSwitchDisplayTests) had to either loop inside one
+// Fact (losing per-case reporting) or not exist. This discoverer reuses
+// FixedAvaloniaTestCase, which already carries testMethodArguments.
+//
+// Tracking: #337 — delete alongside FixedAvaloniaFact when upstream ships.
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Sdk;
+using Xunit.v3;
+
+namespace Excise.App.Tests;
+
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+[XunitTestCaseDiscoverer(typeof(FixedAvaloniaTheoryDiscoverer))]
+public sealed class FixedAvaloniaTheoryAttribute : TheoryAttribute
+{
+    public FixedAvaloniaTheoryAttribute(
+        [CallerFilePath] string? sourceFilePath = null,
+        [CallerLineNumber] int sourceLineNumber = -1)
+        : base(sourceFilePath, sourceLineNumber) { }
+}
+
+public class FixedAvaloniaTheoryDiscoverer : TheoryDiscoverer
+{
+    protected override ValueTask<IReadOnlyCollection<IXunitTestCase>> CreateTestCasesForDataRow(
+        ITestFrameworkDiscoveryOptions discoveryOptions,
+        IXunitTestMethod testMethod,
+        ITheoryAttribute theoryAttribute,
+        ITheoryDataRow dataRow,
+        object?[] testMethodArguments)
+    {
+        var details = TestIntrospectionHelper.GetTestCaseDetailsForTheoryDataRow(
+            discoveryOptions, testMethod, theoryAttribute, dataRow, testMethodArguments);
+
+        // Same trait projection as FixedAvaloniaFactDiscoverer, plus any
+        // row-level traits the data row contributes.
+        var traits = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
+        foreach (var (key, values) in testMethod.Traits)
+            traits[key] = new HashSet<string>(values);
+        if (dataRow.Traits != null)
+            foreach (var (key, values) in dataRow.Traits)
+            {
+                if (!traits.TryGetValue(key, out var set))
+                    traits[key] = set = new HashSet<string>();
+                foreach (var v in values) set.Add(v);
+            }
+
+        IReadOnlyCollection<IXunitTestCase> cases = new IXunitTestCase[]
+        {
+            new FixedAvaloniaTestCase(
+                details.ResolvedTestMethod,
+                details.TestCaseDisplayName,
+                details.UniqueID,
+                details.Explicit,
+                details.SkipExceptions,
+                details.SkipReason,
+                details.SkipType,
+                details.SkipUnless,
+                details.SkipWhen,
+                traits,
+                testMethodArguments,
+                details.SourceFilePath,
+                details.SourceLineNumber,
+                details.Timeout),
+        };
+        return new(cases);
+    }
+}

--- a/Excise.Avalonia/Controls/PdfViewerControl.Continuous.cs
+++ b/Excise.Avalonia/Controls/PdfViewerControl.Continuous.cs
@@ -117,7 +117,16 @@ public partial class PdfViewerControl
     /// The display's device-pixel-ratio (2.0 on a Retina/HiDPI screen, 1.0 on a
     /// standard one), or 1.0 before the control is attached to a visual root.
     /// </summary>
-    private double EffectiveRenderScaling => TopLevel.GetTopLevel(this)?.RenderScaling ?? 1.0;
+    private double EffectiveRenderScaling =>
+        RenderScalingOverride ?? TopLevel.GetTopLevel(this)?.RenderScaling ?? 1.0;
+
+    /// <summary>
+    /// Test hook: simulate a HiDPI display in the headless test host (which
+    /// always reports RenderScaling 1.0). The #682/#683 device-resolution
+    /// paths are a functional no-op at dpr=1, so without this override no
+    /// automated test can exercise the code Retina users actually run.
+    /// </summary>
+    internal double? RenderScalingOverride { get; set; }
 
     // Guards the scroll -> CurrentPage -> scroll feedback loop.
     private bool _syncingPageFromScroll;


### PR DESCRIPTION
Prompted by a live report: *'when I click select text / type / redact mode something weird happens to the display.'*

Every editing mode forces Continuous → SinglePage — exactly the render path reworked in #682/#683, which is a **functional no-op at dpr=1** (all the headless host reports). So no existing test could exercise the code Retina users actually run. This PR closes that hole:

- **`RenderScalingOverride`** (internal): simulate any device-pixel-ratio headless.
- **`ModeSwitchDisplayTests`** — all 4 mode toggles × dpr {1, 2}: single-page lands with a rendered image whose **layout size is dpr-independent** (size-invariance contract), raster carries **zoom×dpr pixels** (crispness contract), mode flags mutually exclusive, toggle-off restores Continuous; mode-to-mode hopping stability; zoom-inside-mode (layout stable, pixels sharpen). 12 cases.
- **`FixedAvaloniaTheory`** — theory counterpart of `FixedAvaloniaFact` (#337); the suite previously had **no way to run parameterized tests on the headless Avalonia dispatcher**.
- Coverage matrix: battery registered; `IsRunnableFact` now counts theories.

**Finding:** the battery's first run flagged the raster size at dpr=2 — root-caused to a naive test expectation (the app enters modes at its fit-width zoom, not 1.0; the render was correctly zoom×dpr device-exact). With the corrected assert, **all invariants pass at dpr 1 and 2** — the reported weirdness is *not* a size/scale defect in the mode switch. Remaining candidates (need a repro description): the by-design continuous→single-page view jump, or a transient blank/flash while the first single-page render lands.

52/52 across the affected suites; Avalonia suite 46/46; builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)