### PR TITLE
fix: 96-stamp single-page bitmaps — Avalonia mispaints dpi-stamped bitmaps as a magnified crop (#697)

### DIFF
--- a/Excise.App.Tests/UI/DpiStampedBitmapPaintProbeTests.cs
+++ b/Excise.App.Tests/UI/DpiStampedBitmapPaintProbeTests.cs
@@ -1,0 +1,85 @@
+using System;
+using System.IO;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Media.Imaging;
+using Avalonia.Platform;
+using AwesomeAssertions;
+using Excise.App.Tests.Utilities;
+using SkiaSharp;
+using Xunit;
+
+namespace Excise.App.Tests.UI;
+
+/// <summary>
+/// Probe for the #697 mechanism: an <see cref="Image"/> whose Source is a
+/// WriteableBitmap stamped at a DPI other than 96. The bitmap's dip Size is
+/// px×96/dpi; Image lays out at that Size. If the paint path confuses dip and
+/// pixel units for the source rect, only the top-left (96/dpi)² fraction of
+/// the pixels is painted, magnified — which is exactly what the live app
+/// showed after Fit at dpr 2 (single-page bitmaps are stamped 96×zoom×dpr).
+/// </summary>
+[Collection("AvaloniaTests")]
+public class DpiStampedBitmapPaintProbeTests
+{
+    /// <remarks>
+    /// This test PINS THE BUGGY BEHAVIOR of the installed Avalonia version —
+    /// it is the assumption PdfViewerControl's single-page path works around
+    /// by always stamping 96 and sizing the Image explicitly. If this test
+    /// ever FAILS, Avalonia fixed dpi-aware Image painting: the workaround
+    /// still renders correctly, but the stamp restriction can be lifted.
+    /// </remarks>
+    [FixedAvaloniaFact]
+    public void Image_WithDpiStampedBitmap_MispaintsAsMagnifiedTopLeftCrop()
+    {
+        // 200×200 px bitmap stamped 192 dpi → dip Size 100×100.
+        // Pixels: left half black, right half white.
+        var wb = new WriteableBitmap(new PixelSize(200, 200), new Vector(192, 192),
+            PixelFormat.Bgra8888, AlphaFormat.Premul);
+        using (var fb = wb.Lock())
+        {
+            var row = new byte[fb.RowBytes];
+            for (int x = 0; x < 200; x++)
+            {
+                byte v = x < 100 ? (byte)0x00 : (byte)0xFF;
+                row[x * 4 + 0] = v; row[x * 4 + 1] = v; row[x * 4 + 2] = v;
+                row[x * 4 + 3] = 0xFF;
+            }
+            for (int y = 0; y < 200; y++)
+                System.Runtime.InteropServices.Marshal.Copy(
+                    row, 0, fb.Address + y * fb.RowBytes, fb.RowBytes);
+        }
+        wb.Size.Width.Should().BeApproximately(100, 0.5, "192-dpi stamp halves the dip size");
+
+        var img = new Image { Source = wb, Width = 100, Height = 100, Stretch = global::Avalonia.Media.Stretch.Fill };
+        var window = new Window { Width = 120, Height = 120, Content = img };
+        window.Show();
+        try
+        {
+            window.UpdateLayout();
+            using var rt = new RenderTargetBitmap(new PixelSize(100, 100));
+            rt.Render(img);
+            using var ms = new MemoryStream();
+            rt.Save(ms);
+            ms.Position = 0;
+            using var cap = SKBitmap.Decode(ms)!;
+
+            // Correct dpi-aware painting would show the whole bitmap: left half
+            // black, right half white → (75,50) WHITE. The installed Avalonia
+            // instead paints only the top-left 100×100 PIXELS magnified — all
+            // black → (75,50) BLACK. We pin the buggy behavior (see remarks).
+            var right = cap.GetPixel(75, 50);
+            var left = cap.GetPixel(25, 50);
+            (left.Red + left.Green + left.Blue).Should().BeLessThan(100, "left half is black ink");
+            (right.Red + right.Green + right.Blue).Should().BeLessThan(100,
+                "the installed Avalonia paints a dpi-stamped bitmap as a magnified top-left pixel " +
+                "crop (#697). If this assert FAILS, Avalonia now paints dpi-aware — the 96-stamp " +
+                "workaround in PdfViewerControl.RenderCurrentPageAsync/SkiaInterop is then " +
+                "optional (still correct) and this probe should be flipped to assert full painting");
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+}

--- a/Excise.App.Tests/UI/ModeSwitchDisplayTests.cs
+++ b/Excise.App.Tests/UI/ModeSwitchDisplayTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.IO;
 using System.Reactive.Linq;
-using System.Reactive.Linq;
 using System.Threading.Tasks;
 using Avalonia.Controls;
 using AwesomeAssertions;
@@ -76,8 +75,11 @@ public class ModeSwitchDisplayTests
             var expectedDipWidth = LetterWidthPt * logicalDpi / 72.0;
             img.Width.Should().BeApproximately(expectedDipWidth, 2.0,
                 "the page's on-screen size must not depend on the device pixel ratio");
-            source.Size.Width.Should().BeApproximately(expectedDipWidth, 2.0,
-                "the bitmap's DIP size must equal the logical page size");
+            (source as global::Avalonia.Media.Imaging.Bitmap)!.Size.Width.Should().BeApproximately(
+                (source as global::Avalonia.Media.Imaging.Bitmap)!.PixelSize.Width, 0.5,
+                "the bitmap must be 96-dpi-stamped (Size == PixelSize) — Avalonia's Image " +
+                "mispaints non-96-stamped bitmaps as a magnified top-left crop (#697); " +
+                "the logical page size lives on the Image's Width instead");
 
             // CRISPNESS: the backing pixels match the on-screen magnification —
             // the app enters modes at its current (often fit-width) zoom, so the

--- a/Excise.App.Tests/UI/TextSelectionAlignmentTests.cs
+++ b/Excise.App.Tests/UI/TextSelectionAlignmentTests.cs
@@ -193,11 +193,13 @@ public class TextSelectionAlignmentTests
         var deadline = Environment.TickCount64 + 20000;
         while (Environment.TickCount64 < deadline)
         {
-            var src = viewer.FindControl<Image>("PdfImage")?.Source as Bitmap;
-            if (src != null)
+            var img = viewer.FindControl<Image>("PdfImage");
+            if (img?.Source is Bitmap src && !double.IsNaN(img.Width))
             {
                 var scale = Math.Max(1.0, zoom * dpr);
-                var expected = src.Size.Width * scale; // dip × scale = device px
+                // The bitmap is 96-stamped (#697), so the layout dip size lives
+                // on the Image's Width; the raster is that × zoom × dpr.
+                var expected = img.Width * scale;
                 if (Math.Abs(src.PixelSize.Width - expected) <= 10) return;
             }
             await Task.Delay(50);
@@ -325,6 +327,25 @@ public class TextSelectionAlignmentTests
             inkNearHighlight.Should().BeGreaterThan(0,
                 $"after Fit the highlight (viewer {tl}) must still sit on rendered text, " +
                 "not float over blank space (live repro: diag-after-fit.png)");
+
+            // 3) the displayed page must be the WHOLE page, not a magnified
+            // top-left pixel crop (#697: Avalonia's Image mispaints dpi-stamped
+            // bitmaps; at dpr 2 post-fit the crop-zoom is ~2×, live screenshot
+            // step4_postfit). Discriminators: the book page's ink must start
+            // near the top of the displayed image (crop pushes it ~halfway
+            // down) and must leave the page's right margin visible (crop fills
+            // ink to the image's right edge).
+            var img = viewer.FindControl<Image>("PdfImage")!;
+            var imgTopLeft = img.TranslatePoint(new Point(0, 0), viewer)!.Value;
+            var displayedW = img.Width * zoom;
+            var displayedH = img.Height * zoom;
+            var pageInk = InkBounds(after);
+            (pageInk.Top - imgTopLeft.Y).Should().BeLessThan(displayedH * 0.35,
+                $"page ink must start in the top third of the displayed image (dpr={dpr}); " +
+                "starting halfway down means a magnified top-left crop is being painted (#697)");
+            pageInk.Right.Should().BeLessThan(imgTopLeft.X + displayedW * 0.97,
+                $"the page's right margin must be visible inside the displayed image (dpr={dpr}); " +
+                "ink flush to the image edge means a magnified crop is being painted (#697)");
         }
         finally
         {

--- a/Excise.Avalonia/Controls/PdfViewerControl.axaml.cs
+++ b/Excise.Avalonia/Controls/PdfViewerControl.axaml.cs
@@ -297,7 +297,11 @@ public partial class PdfViewerControl : UserControl
     // instant. Capped small — bitmaps for a 200-page book can be ~6 MB
     // each in BGRA, so we trade a few tens of MB for snappy navigation.
     private const int PageCacheCapacity = 6;
-    private readonly LinkedList<(int Page, int Dpi, WriteableBitmap Bmp)> _pageCache = new();
+    // Dip is the Image's LAYOUT size for the entry (logical page dips). It is
+    // carried separately because the bitmap itself is stamped 96 DPI —
+    // Avalonia's Image mispaints non-96-stamped bitmaps as a magnified
+    // top-left pixel crop (#697; DpiStampedBitmapPaintProbeTests).
+    private readonly LinkedList<(int Page, int Dpi, WriteableBitmap Bmp, Size Dip)> _pageCache = new();
 
     // Tracks the in-flight render so rapid paging cancels stale work.
     private CancellationTokenSource? _renderCts;
@@ -1235,16 +1239,16 @@ public partial class PdfViewerControl : UserControl
         // toggling overlays. Set Image.Source immediately so the user
         // doesn't even see a loading flicker. The cache is keyed by the
         // DEVICE render DPI so a monitor change (dpr) re-renders.
-        if (TryGetCached(pageNumber, renderDpi, out var cached))
+        if (TryGetCached(pageNumber, renderDpi, out var cached, out var cachedDip))
         {
             Trace($"SinglePageRender page={pageNumber} CACHE-HIT dpi={renderDpi}");
             if (_pdfImage != null)
             {
                 var cachedBitmap = cached!;
-                _pdfImage.Width = cachedBitmap.Size.Width;
-                _pdfImage.Height = cachedBitmap.Size.Height;
+                _pdfImage.Width = cachedDip.Width;
+                _pdfImage.Height = cachedDip.Height;
                 _pdfImage.Source = cachedBitmap;
-                Trace($"ImageSet(cache) page={pageNumber} imgWidth={_pdfImage.Width:F0} srcDip={cachedBitmap.Size.Width:F0} srcPx={cachedBitmap.PixelSize.Width} zoom={ZoomLevel:F3}");
+                Trace($"ImageSet(cache) page={pageNumber} imgWidth={_pdfImage.Width:F0} srcDip={cachedDip.Width:F0} srcPx={cachedBitmap.PixelSize.Width} zoom={ZoomLevel:F3}");
             }
             HasError = false;
             ErrorMessage = null;
@@ -1282,17 +1286,25 @@ public partial class PdfViewerControl : UserControl
                 // freshly-rendered new page with the stale one.
                 if (token.IsCancellationRequested) return;
 
-                var bitmap = SkiaInterop.ToAvaloniaBitmap(skBitmap, bitmapDpi);
+                // Stamp 96 (dip Size == PixelSize) and carry the layout size
+                // separately: Avalonia's Image paints a non-96-stamped bitmap
+                // as a top-left pixel crop magnified by stamp/96 (#697;
+                // DpiStampedBitmapPaintProbeTests). The plan's invariant
+                // px × 96 / bitmapDpi == logical page dips still sizes the
+                // layout, so coordinates and the ScaleTransform are unchanged.
+                var bitmap = SkiaInterop.ToAvaloniaBitmap(skBitmap);
                 if (bitmap != null)
                 {
-                    Trace($"SinglePageRender page={pageNumber} RENDERED px={bitmap.PixelSize.Width}x{bitmap.PixelSize.Height} dip={bitmap.Size.Width:F0}x{bitmap.Size.Height:F0}");
-                    AddToCache(pageNumber, renderDpi, bitmap);
+                    var dip = new Size(bitmap.PixelSize.Width * 96.0 / bitmapDpi,
+                                       bitmap.PixelSize.Height * 96.0 / bitmapDpi);
+                    Trace($"SinglePageRender page={pageNumber} RENDERED px={bitmap.PixelSize.Width}x{bitmap.PixelSize.Height} dip={dip.Width:F0}x{dip.Height:F0}");
+                    AddToCache(pageNumber, renderDpi, bitmap, dip);
                     Trace($"ContVis={_continuousScrollViewer?.IsVisible} SingleVis={_scrollViewer?.IsVisible}");
-                    Trace($"ImageSet page={pageNumber} imgWidth={_pdfImage?.Width:F0} srcDip={bitmap.Size.Width:F0}x{bitmap.Size.Height:F0} srcPx={bitmap.PixelSize.Width} zoom={ZoomLevel:F3}");
+                    Trace($"ImageSet page={pageNumber} imgWidth={_pdfImage?.Width:F0} srcDip={dip.Width:F0}x{dip.Height:F0} srcPx={bitmap.PixelSize.Width} zoom={ZoomLevel:F3}");
                     if (_pdfImage != null)
                     {
-                        _pdfImage.Width = bitmap.Size.Width;
-                        _pdfImage.Height = bitmap.Size.Height;
+                        _pdfImage.Width = dip.Width;
+                        _pdfImage.Height = dip.Height;
                         _pdfImage.Source = bitmap;
                     }
                 }
@@ -1344,11 +1356,16 @@ public partial class PdfViewerControl : UserControl
     /// <paramref name="scale"/> is the on-screen magnification the raster must
     /// resolve — the display device-pixel-ratio times the zoom level — so text
     /// stays crisp both on HiDPI displays (#682) and when zoomed in (#683). It
-    /// returns the DPI to rasterize at (device resolution) and the DPI to stamp
-    /// on the resulting bitmap so its DIP size equals the *logical* size. That
-    /// invariant — <c>deviceDpi / (bitmapDpi / 96) == logicalDpi</c> — is what
-    /// keeps the Image layout size, the ScaleTransform, and every coordinate
-    /// mapping unchanged; only pixel density changes. <paramref name="maxScale"/>
+    /// returns the DPI to rasterize at (device resolution) and the BitmapDpi
+    /// divisor that maps the raster back to the *logical* layout size
+    /// (px × 96 / bitmapDpi). That invariant —
+    /// <c>deviceDpi / (bitmapDpi / 96) == logicalDpi</c> — is what keeps the
+    /// Image layout size, the ScaleTransform, and every coordinate mapping
+    /// unchanged; only pixel density changes. BitmapDpi is NOT stamped on the
+    /// bitmap: Avalonia's Image mispaints non-96-stamped bitmaps as a magnified
+    /// top-left pixel crop (#697; DpiStampedBitmapPaintProbeTests) — the bitmap
+    /// stays 96-stamped and the Image's Width/Height carry the layout size
+    /// instead. <paramref name="maxScale"/>
     /// caps the raster at the single-page memory budget: beyond it the
     /// ScaleTransform upscales (soft at extreme zoom) rather than allocating an
     /// unbounded bitmap. At scale=1 it is an exact no-op (device == logical,
@@ -1374,7 +1391,7 @@ public partial class PdfViewerControl : UserControl
         return Math.Max(1.0, Math.Sqrt(MaxSinglePagePreviewPixels / logicalPixels));
     }
 
-    private bool TryGetCached(int page, int dpi, out WriteableBitmap? bmp)
+    private bool TryGetCached(int page, int dpi, out WriteableBitmap? bmp, out Size dip)
     {
         for (var node = _pageCache.First; node != null; node = node.Next)
         {
@@ -1384,14 +1401,16 @@ public partial class PdfViewerControl : UserControl
                 _pageCache.Remove(node);
                 _pageCache.AddFirst(node);
                 bmp = node.Value.Bmp;
+                dip = node.Value.Dip;
                 return true;
             }
         }
         bmp = null;
+        dip = default;
         return false;
     }
 
-    private void AddToCache(int page, int dpi, WriteableBitmap bmp)
+    private void AddToCache(int page, int dpi, WriteableBitmap bmp, Size dip)
     {
         // Replace existing entry for same key (e.g. re-render after edit).
         for (var node = _pageCache.First; node != null; node = node.Next)
@@ -1403,7 +1422,7 @@ public partial class PdfViewerControl : UserControl
                 break;
             }
         }
-        _pageCache.AddFirst((page, dpi, bmp));
+        _pageCache.AddFirst((page, dpi, bmp, dip));
         while (_pageCache.Count > PageCacheCapacity)
         {
             var last = _pageCache.Last!;

--- a/Excise.Avalonia/Imaging/SkiaInterop.cs
+++ b/Excise.Avalonia/Imaging/SkiaInterop.cs
@@ -58,10 +58,12 @@ public static class SkiaInterop
 
             var size = new PixelSize(source.Width, source.Height);
             // The stamped DPI decides how many bitmap pixels map to one DIP.
-            // 96 (default) = 1:1. The single-page path renders at device
-            // resolution and passes 96×devicePixelRatio so the raster is crisp
-            // on HiDPI while its DIP Size — and thus layout/coordinates — is
-            // unchanged (#682).
+            // 96 (default) = 1:1. ⚠️ Avalonia's Image control mispaints bitmaps
+            // stamped at any other DPI — it takes the dip-sized source rect in
+            // PIXEL units, painting only a magnified top-left crop (#697;
+            // DpiStampedBitmapPaintProbeTests). Callers that render at device
+            // resolution must keep the 96 stamp and set the Image's
+            // Width/Height to the logical dip size instead.
             var dpi = new Vector(bitmapDpi, bitmapDpi);
             var wb = new WriteableBitmap(size, dpi,
                 PixelFormat.Bgra8888, AlphaFormat.Premul);


### PR DESCRIPTION
Fixes the fit-after-selection display corruption (#697): oversized (~2×) text, blank space, and seemingly orphaned selection highlights after pressing Fit in select-text mode at dpr 2.

## Root cause

**Avalonia's `Image` mispaints any bitmap stamped at a DPI other than 96** — it applies the dip-sized source rect in *pixel* units, painting only the top-left `(96/stamp)²` fraction of the pixels, magnified by `stamp/96`. Pinned in isolation by the new `DpiStampedBitmapPaintProbeTests`.

The single-page path stamped bitmaps `96×zoom×dpr` (#682/#683 crispness plan), so at dpr 2 with fit-width zoom the stamp was ~197 → a 2.05× magnified top-left crop. At dpr 1, or zoomed out below 50%, the stamp clamps to ≈96 and the bug is invisible — which is why it presented as "fit-after-selection" and why the headless test passed. The selection overlay painted correctly the whole time (verified against the live screenshots to ±3 px); the image content moved out from under it. #696's overlay fix stands.

Full evidence trail (live burst trace, CLI render exoneration of the renderer, pixel forensics) in the #697 comment.

## Fix

Never hand the compositor a non-96 bitmap — the rule the continuous tile path already follows. Single-page bitmaps are always 96-stamped; the logical layout size (`px × 96 / bitmapDpi`, numerically identical to the previously stamped Size) is set explicitly on the Image and carried in the page cache. Render plan, coordinates, and ScaleTransform are unchanged.

## Tests

- `DpiStampedBitmapPaintProbeTests` (new) — pins the Avalonia behavior the workaround rests on; if it ever fails, Avalonia fixed dpi-aware painting and the workaround can be simplified.
- `FitAfterSelection_KeepsHighlightsOnRenderedText` — strengthened with crop discriminators (page ink must start in the top third of the displayed image and leave the right margin visible). **Red-checked**: fails at dpr 2 on the unfixed viewer, passes at dpr 1 — the exact live signature.
- `ModeSwitchDisplayTests` — size-invariance assert moved to the new invariant (96 stamp; layout size lives on `Image.Width`).
- Ran: TextSelectionAlignmentTests + probe (11/11), ModeSwitch* + PdfViewerHeadless* (32/32), `test-tier.sh t0` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)