### PR TITLE
fix: mode-switch visual continuity — unified display scale + reading-position carry-over (#693)

### DIFF
--- a/Excise.App.Tests/UI/ModeSwitchDisplayTests.cs
+++ b/Excise.App.Tests/UI/ModeSwitchDisplayTests.cs
@@ -192,6 +192,117 @@ public class ModeSwitchDisplayTests
         }
     }
 
+    /// <summary>
+    /// #693 (size half): entering an editing mode must not change the page's
+    /// on-screen size. Continuous lays out at 96-dpi dips (pt × 96/72 × zoom);
+    /// before the fix, single-page displayed its 120-dpi layout at raw zoom —
+    /// the same page appeared 25% larger the moment a mode button was clicked.
+    /// The ZoomHost's transformed bounds ARE the displayed size.
+    /// </summary>
+    [FixedAvaloniaTheory]
+    [InlineData(1.0, 1.0)]
+    [InlineData(1.0, 2.0)]
+    [InlineData(0.6, 1.0)]
+    [InlineData(0.6, 2.0)]
+    public async Task ModeEntry_PreservesDisplayedPageSize(double zoom, double dpr)
+    {
+        var (vm, window, viewer, path) = await OpenTestDocumentAsync();
+        try
+        {
+            viewer.RenderScalingOverride = dpr;
+            vm.SetManualZoom(zoom);
+            await Task.Delay(200); window.UpdateLayout();
+
+            ModeCommand(vm, "select-text").Execute().Subscribe();
+            await PumpUntilAsync(window, () => SinglePageImage(viewer)?.Source != null);
+            window.UpdateLayout();
+
+            var zoomHost = viewer.FindControl<global::Avalonia.Controls.LayoutTransformControl>("ZoomHost")!;
+            var displayed = zoomHost.Bounds.Width;
+            var continuousEquivalent = LetterWidthPt * (96.0 / 72.0) * viewer.ZoomLevel;
+            displayed.Should().BeApproximately(continuousEquivalent, 3.0,
+                $"the single-page displayed width must equal the continuous layout width " +
+                $"(pt × 96/72 × zoom) — a jump means the mode switch rescales the page (#693); " +
+                $"zoom={viewer.ZoomLevel:F3} dpr={dpr}");
+        }
+        finally
+        {
+            window.Close();
+            TestPdfGenerator.CleanupTestFile(path);
+        }
+    }
+
+    /// <summary>
+    /// #693 (scroll half): the reading position must survive the mode switch.
+    /// Before the fix, entering an editing mode dropped the reader at the top
+    /// of the page (singleOffset 0/…) and switching back re-anchored to the
+    /// page top. Round-trip: continuous → select-text → continuous must come
+    /// back to (about) the same scroll offset, and the intermediate
+    /// single-page view must be scrolled into the page, not at its top.
+    /// </summary>
+    [FixedAvaloniaTheory]
+    [InlineData(1.0)]
+    [InlineData(2.0)]
+    public async Task ModeSwitch_PreservesReadingPosition(double dpr)
+    {
+        var (vm, window, viewer, path) = await OpenTestDocumentAsync();
+        try
+        {
+            viewer.RenderScalingOverride = dpr;
+            var cont = viewer.FindControl<ScrollViewer>("ContinuousScrollViewer")!;
+            await PumpUntilAsync(window, () => cont.Extent.Height > cont.Viewport.Height + 100);
+
+            // Scroll mid-document. A page-crossing scroll can settle snapped
+            // to the new page's top, so nudge a second time — WITHOUT
+            // crossing a page — to land mid-page, then read the settled
+            // position.
+            var target = cont.Extent.Height * 0.45;
+            cont.Offset = new global::Avalonia.Vector(cont.Offset.X, target);
+            await Task.Delay(150); window.UpdateLayout();
+            var pageHeight = cont.Extent.Height / 3; // 3-page test doc
+            cont.Offset = new global::Avalonia.Vector(cont.Offset.X, cont.Offset.Y + pageHeight * 0.4);
+            await Task.Delay(150); window.UpdateLayout();
+            var offBefore = cont.Offset.Y;
+            var pageBefore = vm.CurrentPageIndex;
+            offBefore.Should().BeGreaterThan(100, "the test must start scrolled into the document");
+
+            ModeCommand(vm, "select-text").Execute().Subscribe();
+            await PumpUntilAsync(window, () => SinglePageImage(viewer)?.Source != null);
+            var single = viewer.FindControl<ScrollViewer>("PdfScrollViewer")!;
+            // The carried fraction applies via bounded deferred retries once
+            // the freshly-rendered page has an extent — wait for it.
+            try
+            {
+                await PumpUntilAsync(window, () => single.Extent.Height > 1 && single.Offset.Y > 1,
+                    timeoutMs: 5000);
+            }
+            catch (TimeoutException)
+            {
+                var img = SinglePageImage(viewer);
+                throw new Xunit.Sdk.XunitException(
+                    "the carried reading position was not applied to the single-page scroller — " +
+                    $"extent={single.Extent} offset={single.Offset} viewport={single.Viewport} " +
+                    $"visible={single.IsVisible} page={vm.CurrentPageIndex} zoom={viewer.ZoomLevel:F3} " +
+                    $"imgW={img?.Width} imgSrc={(img?.Source != null)} offBefore={offBefore:F0} " +
+                    $"contExtent={cont.Extent.Height:F0}");
+            }
+
+            vm.CurrentPageIndex.Should().Be(pageBefore, "the mode switch must stay on the same page");
+            (single.Offset.Y / single.Extent.Height).Should().BeGreaterThan(0.05,
+                "the single-page view must open at the carried reading position, not the page top (#693)");
+
+            ModeCommand(vm, "select-text").Execute().Subscribe();
+            await PumpUntilAsync(window, () => cont.IsVisible);
+            await PumpUntilAsync(window, () => Math.Abs(cont.Offset.Y - offBefore) < 40,
+                timeoutMs: 10000);
+        }
+        finally
+        {
+            window.Close();
+            TestPdfGenerator.CleanupTestFile(path);
+        }
+    }
+
     // ── harness ─────────────────────────────────────────────────────────────
 
     private static async Task<(MainWindowViewModel vm, MainWindow window, PdfViewerControl viewer, string path)>

--- a/Excise.App.Tests/UI/PdfViewerHeadlessRenderTests.cs
+++ b/Excise.App.Tests/UI/PdfViewerHeadlessRenderTests.cs
@@ -529,16 +529,26 @@ public class PdfViewerHeadlessRenderTests
         var imageSource = (Bitmap)pdfImage!.Source!;
         var displayed = DecodeAvaloniaBitmap(imageSource);
 
-        viewer.Width = displayed.Width;
-        viewer.Height = displayed.Height;
-        window.Width = displayed.Width;
-        window.Height = displayed.Height;
-        viewer.Measure(new Size(displayed.Width, displayed.Height));
-        viewer.Arrange(new Rect(0, 0, displayed.Width, displayed.Height));
+        // Since the #693 display unification the page shows at
+        // imgDip × 96/renderDpi on screen (0.8 at the default 120), so a
+        // 96-dpi surface can never be 1:1 with the bitmap's pixels. Size the
+        // viewer to the DISPLAYED dips and sample the surface at the render
+        // DPI instead: 0.8 × (120/96) = 1.0 — the comparison stays
+        // pixel-exact with the bitmap.
+        const double displayScale = 96.0 / 120.0;
+        var dipW = displayed.Width * displayScale;
+        var dipH = displayed.Height * displayScale;
+        viewer.Width = dipW;
+        viewer.Height = dipH;
+        window.Width = dipW;
+        window.Height = dipH;
+        viewer.Measure(new Size(dipW, dipH));
+        viewer.Arrange(new Rect(0, 0, dipW, dipH));
         Dispatcher.UIThread.RunJobs();
         await Task.Delay(50);
 
-        using var renderTarget = new RenderTargetBitmap(new PixelSize(displayed.Width, displayed.Height));
+        using var renderTarget = new RenderTargetBitmap(
+            new PixelSize(displayed.Width, displayed.Height), new Vector(120, 120));
         renderTarget.Render(viewer);
         var visualSurface = DecodeAvaloniaBitmap(renderTarget);
 

--- a/Excise.App.Tests/UI/TextSelectionAlignmentTests.cs
+++ b/Excise.App.Tests/UI/TextSelectionAlignmentTests.cs
@@ -70,7 +70,7 @@ public class TextSelectionAlignmentTests
                 viewer.FindControl<Image>("PdfImage")?.Source != null && !viewer.IsLoading);
 
             // Set the zoom under test and wait for the raster to settle to it.
-            vm.ZoomLevel = zoom;
+            vm.SetManualZoom(zoom);
             await SettleAsync(window, viewer, zoom, dpr);
 
             // Find the text ink in VIEWER coordinates from a clean capture.
@@ -99,9 +99,14 @@ public class TextSelectionAlignmentTests
             var rects = layer.Children.OfType<Rectangle>()
                 .Select(r =>
                 {
+                    // Translate BOTH corners so the ZoomHost transform (zoom ×
+                    // display-scale, #693) is applied exactly rather than
+                    // approximated with a manual × zoom.
                     var tl = layer.TranslatePoint(
                         new Point(Canvas.GetLeft(r), Canvas.GetTop(r)), viewer)!.Value;
-                    return new Rect(tl.X, tl.Y, r.Width * ZoomOf(viewer), r.Height * ZoomOf(viewer));
+                    var br = layer.TranslatePoint(
+                        new Point(Canvas.GetLeft(r) + r.Width, Canvas.GetTop(r) + r.Height), viewer)!.Value;
+                    return new Rect(tl, br);
                 })
                 .ToList();
             rects.Should().NotBeEmpty();
@@ -146,7 +151,7 @@ public class TextSelectionAlignmentTests
                 viewer.FindControl<Image>("PdfImage")?.Source != null && !viewer.IsLoading);
 
             // Churn the zoom the way the live session did, then press Fit Width.
-            vm.ZoomLevel = 0.525;
+            vm.SetManualZoom(0.525);
             await SettleAsync(window, viewer, 0.525, dpr);
             vm.ZoomFitWidthCommand.Execute().Subscribe();
             await Task.Delay(200);
@@ -154,11 +159,13 @@ public class TextSelectionAlignmentTests
             var zoom = ZoomOf(viewer);
             await SettleAsync(window, viewer, zoom, dpr);
 
-            // The page's DISPLAYED width (image dip × zoom) must fit the
-            // single-page scroll viewport, and use most of it.
-            var img = viewer.FindControl<Image>("PdfImage")!;
+            // The page's DISPLAYED width must fit the single-page scroll
+            // viewport, and use most of it. The ZoomHost's transformed bounds
+            // ARE the displayed size (its scale is zoom × 96/renderDpi since
+            // the #693 display-scale unification — img.Width × zoom would
+            // overestimate by 25%).
             var scroller = viewer.FindControl<ScrollViewer>("PdfScrollViewer")!;
-            var displayedWidth = img.Width * zoom;
+            var displayedWidth = viewer.FindControl<global::Avalonia.Controls.LayoutTransformControl>("ZoomHost")!.Bounds.Width;
             var viewport = scroller.Viewport.Width;
             viewport.Should().BeGreaterThan(100, "single-page scroller must have a real viewport");
             displayedWidth.Should().BeLessThanOrEqualTo(viewport + 1,
@@ -193,17 +200,25 @@ public class TextSelectionAlignmentTests
         var deadline = Environment.TickCount64 + 20000;
         while (Environment.TickCount64 < deadline)
         {
+            window.UpdateLayout();
             var img = viewer.FindControl<Image>("PdfImage");
-            if (img?.Source is Bitmap src && !double.IsNaN(img.Width))
+            var host = viewer.FindControl<global::Avalonia.Controls.LayoutTransformControl>("ZoomHost");
+            if (img?.Source is Bitmap src && !double.IsNaN(img.Width) && host != null)
             {
                 var scale = Math.Max(1.0, zoom * dpr);
                 // The bitmap is 96-stamped (#697), so the layout dip size lives
                 // on the Image's Width; the raster is that × zoom × dpr.
-                var expected = img.Width * scale;
-                if (Math.Abs(src.PixelSize.Width - expected) <= 10) return;
+                var pxOk = Math.Abs(src.PixelSize.Width - img.Width * scale) <= 10;
+                // The raster alone cannot distinguish two zooms whose device
+                // scale clamps to the same value (e.g. fit≈0.98 and 0.6 at
+                // dpr 1 both floor to scale 1 → 900 px): also require the
+                // LAYOUT to reflect the requested zoom. Displayed width =
+                // img dips × zoom × 96/renderDpi (#693 display unification;
+                // 120 = DefaultRenderDpi for these pages).
+                var layoutOk = Math.Abs(host.Bounds.Width - img.Width * zoom * (96.0 / 120.0)) <= 2;
+                if (pxOk && layoutOk) return;
             }
             await Task.Delay(50);
-            window.UpdateLayout();
         }
     }
 
@@ -279,7 +294,7 @@ public class TextSelectionAlignmentTests
 
             // live sequence: zoom out in CONTINUOUS first, then enter the mode
             vm.CurrentPageIndex = 16;
-            vm.ZoomLevel = 0.42;
+            vm.SetManualZoom(0.42);
             await Task.Delay(400); window.UpdateLayout();
             vm.ToggleTextSelectionModeCommand.Execute().Subscribe();
             await PumpUntilAsync(window, () =>
@@ -337,8 +352,11 @@ public class TextSelectionAlignmentTests
             // ink to the image's right edge).
             var img = viewer.FindControl<Image>("PdfImage")!;
             var imgTopLeft = img.TranslatePoint(new Point(0, 0), viewer)!.Value;
-            var displayedW = img.Width * zoom;
-            var displayedH = img.Height * zoom;
+            // ZoomHost bounds = true displayed size (scale is zoom × 96/renderDpi
+            // since the #693 display-scale unification).
+            var zoomHostBounds = viewer.FindControl<global::Avalonia.Controls.LayoutTransformControl>("ZoomHost")!.Bounds;
+            var displayedW = zoomHostBounds.Width;
+            var displayedH = zoomHostBounds.Height;
             var pageInk = InkBounds(after);
             (pageInk.Top - imgTopLeft.Y).Should().BeLessThan(displayedH * 0.35,
                 $"page ink must start in the top third of the displayed image (dpr={dpr}); " +

--- a/Excise.App/ViewModels/MainWindowViewModel.cs
+++ b/Excise.App/ViewModels/MainWindowViewModel.cs
@@ -2035,6 +2035,20 @@ public partial class MainWindowViewModel : ViewModelBase
         this.RaisePropertyChanged(nameof(StatusText));
     }
 
+    /// <summary>
+    /// Set an explicit zoom level through the same path every user-initiated
+    /// zoom takes: latch <see cref="ZoomFitMode.Manual"/> so a latched
+    /// auto-fit (the default is FitWidth) cannot asynchronously re-apply
+    /// over it on the next viewport change. Tests that assign
+    /// <see cref="ZoomLevel"/> directly bypass the latch and race the refit.
+    /// </summary>
+    internal void SetManualZoom(double zoom)
+    {
+        _zoomFitMode = ZoomFitMode.Manual;
+        ZoomLevel = Math.Clamp(zoom, 0.25, 5.0);
+        this.RaisePropertyChanged(nameof(StatusText));
+    }
+
     private void ZoomFitWidth() => ZoomFitWidthInternal(latch: true);
     private void ZoomFitPage() => ZoomFitPageInternal(latch: true);
 
@@ -2092,12 +2106,15 @@ public partial class MainWindowViewModel : ViewModelBase
     }
 
     /// <summary>
-    /// Page dimensions in viewer DIPs at zoom 1.0. Reads page size from
-    /// the parsed PdfCoreDocument (in PDF points) so we don't depend on
-    /// the legacy <c>_currentPageImage</c> being populated, and converts
-    /// to DIPs at the viewer's render DPI (the bitmap is tagged 96 DPI
-    /// in WriteableBitmap so 1 bitmap-pixel = 1 DIP, and 1 page-point at
-    /// our render DPI = render-DPI/72 bitmap-pixels).
+    /// Page dimensions in DISPLAYED dips at zoom 1.0. Since the #693 fix,
+    /// both view modes show a page at pt × 96/72 × zoom on screen — the
+    /// continuous slots lay out at 96-dpi dips, and the single-page
+    /// ZoomHost applies a 96/renderDpi correction to its 120-dpi layout.
+    /// Fit-width/fit-page therefore compute zoom against 96-dpi dips;
+    /// using the 120-dpi internal size here made continuous fit-width
+    /// silently underfill the viewport by 20%. Reads page size from the
+    /// parsed PdfCoreDocument so we don't depend on the legacy
+    /// <c>_currentPageImage</c> being populated.
     /// </summary>
     private bool TryGetPageDimensionsInViewerDips(out double widthDip, out double heightDip)
     {
@@ -2110,7 +2127,7 @@ public partial class MainWindowViewModel : ViewModelBase
         var viewerRect = PdfCoordinateMapper.ToViewerDips(
             page,
             PdfPageRect.VisualPoints(pageNumber, 0, 0, page.VisualWidth, page.VisualHeight),
-            DefaultViewerRenderDpi);
+            96);
         widthDip = viewerRect.Width;
         heightDip = viewerRect.Height;
         return widthDip > 0 && heightDip > 0;

--- a/Excise.Avalonia/Controls/PdfViewerControl.Continuous.cs
+++ b/Excise.Avalonia/Controls/PdfViewerControl.Continuous.cs
@@ -140,6 +140,15 @@ public partial class PdfViewerControl
     private int _pendingContinuousAttempts;
     private bool _continuousRenderPassScheduled;
 
+    // Intra-page position carried across a view-mode switch (#693): the
+    // fraction of the current page sitting at the viewport top. Continuous
+    // uses it inside the pending-scroll retry; single-page has its own
+    // bounded retry because a ScrollViewer clamps Offset to a zero extent
+    // before layout.
+    private double _pendingContinuousFraction;
+    private double _pendingSingleFraction = -1;
+    private IDisposable? _pendingSingleFractionSub;
+
     internal int ContinuousRenderStartCount { get; private set; }
     internal int ContinuousRenderCancellationCount { get; private set; }
     internal int ContinuousRenderCacheHitCount { get; private set; }
@@ -178,6 +187,12 @@ public partial class PdfViewerControl
         Trace($"ViewMode -> {ViewMode} page={CurrentPage} zoom={ZoomLevel:F3} " +
               $"contOffset={_continuousScrollViewer?.Offset.Y:F0}/{_continuousScrollViewer?.Extent.Height:F0} " +
               $"singleOffset={_scrollViewer?.Offset.Y:F0}/{_scrollViewer?.Extent.Height:F0}");
+
+        // Capture the reader's intra-page position BEFORE flipping
+        // visibility — a hidden ScrollViewer's offset is not trustworthy.
+        // Applied to the destination view once it has laid out (#693).
+        double fraction = continuous ? SingleIntraPageFraction() : ContinuousIntraPageFraction();
+
         if (_continuousScrollViewer != null) _continuousScrollViewer.IsVisible = continuous;
         if (_scrollViewer != null) _scrollViewer.IsVisible = !continuous;
 
@@ -194,16 +209,72 @@ public partial class PdfViewerControl
             // overwritten by this deferred scroll dragging the user back to
             // wherever they were when the view mode flipped. Switching to
             // continuous and immediately jumping to a page did exactly that.
-            Dispatcher.UIThread.Post(() => ScrollToPageContinuous(CurrentPage), DispatcherPriority.Background);
+            Dispatcher.UIThread.Post(() => ScrollToPageContinuous(CurrentPage, fraction), DispatcherPriority.Background);
         }
         else
         {
             ReportActiveViewport();
             // Back to single-page: make sure the current page is rendered.
+            // The carried fraction is applied from the render-completion
+            // paths, NOT posted here: a post now would burn all its retries
+            // through the dispatcher before the async render gives the
+            // ScrollViewer a real extent, then give up.
+            _pendingSingleFraction = fraction;
             _ = RenderCurrentPageAsync();
         }
 
         UpdateViewerAutomationProperties();
+    }
+
+    /// <summary>Fraction of the current page above the viewport top in continuous view.</summary>
+    private double ContinuousIntraPageFraction()
+    {
+        if (_continuousScrollViewer == null || _continuousSlots == null) return 0;
+        int idx = CurrentPage - 1;
+        if (idx < 0 || idx >= _continuousSlots.Count) return 0;
+        var slot = _continuousSlots[idx];
+        if (slot.DisplayHeight <= 0) return 0;
+        return Math.Clamp(
+            (_continuousScrollViewer.Offset.Y - slot.TopDip) / slot.DisplayHeight, 0, 0.99);
+    }
+
+    /// <summary>Fraction of the page above the viewport top in single-page view.</summary>
+    private double SingleIntraPageFraction()
+    {
+        if (_scrollViewer == null) return 0;
+        var extent = _scrollViewer.Extent.Height;
+        if (extent <= 1) return 0;
+        return Math.Clamp(_scrollViewer.Offset.Y / extent, 0, 0.99);
+    }
+
+    /// <summary>
+    /// The single-page ScrollViewer clamps Offset to a zero extent until the
+    /// freshly-rendered page has laid out — and layout may be arbitrarily far
+    /// away (headless hosts only lay out on explicit pumps), so
+    /// dispatcher-post retries drain uselessly before it. Instead, wait on
+    /// the Extent property itself and apply the carried fraction the moment
+    /// the content gets a real size.
+    /// </summary>
+    private void ApplyPendingSingleFraction()
+    {
+        if (_pendingSingleFraction < 0 || _scrollViewer == null)
+        {
+            _pendingSingleFractionSub?.Dispose();
+            _pendingSingleFractionSub = null;
+            return;
+        }
+        var extent = _scrollViewer.Extent.Height;
+        if (extent <= 1)
+        {
+            _pendingSingleFractionSub ??= _scrollViewer
+                .GetObservable(ScrollViewer.ExtentProperty)
+                .Subscribe(new AnonymousObserver<Size>(_ => ApplyPendingSingleFraction()));
+            return;
+        }
+        _pendingSingleFractionSub?.Dispose();
+        _pendingSingleFractionSub = null;
+        _scrollViewer.Offset = new Vector(_scrollViewer.Offset.X, _pendingSingleFraction * extent);
+        _pendingSingleFraction = -1;
     }
 
     /// <summary>(Re)build the per-page slots from the current document.</summary>
@@ -281,9 +352,15 @@ public partial class PdfViewerControl
 
     // ---- Scroll <-> CurrentPage sync -----------------------------------
 
-    private void ScrollToPageContinuous(int pageNumber)
+    private void ScrollToPageContinuous(int pageNumber) => ScrollToPageContinuous(pageNumber, 0);
+
+    /// <param name="intraPageFraction">Fraction of the page to place above the
+    /// viewport top — 0 for plain navigation (outline, page number, search);
+    /// the mode switch passes the carried reading position (#693).</param>
+    private void ScrollToPageContinuous(int pageNumber, double intraPageFraction)
     {
         if (pageNumber < 1) return;
+        _pendingContinuousFraction = intraPageFraction;
 
         // The slots may not exist yet: the document has loaded but the items panel
         // has not measured. Dropping the navigation here (the old early return) is
@@ -300,7 +377,8 @@ public partial class PdfViewerControl
 
         if (pageNumber > _continuousSlots.Count) return;
 
-        var targetY = _continuousSlots[pageNumber - 1].TopDip;
+        var slot = _continuousSlots[pageNumber - 1];
+        var targetY = slot.TopDip + intraPageFraction * slot.DisplayHeight;
         var x = _continuousScrollViewer.Offset.X;
         _continuousScrollViewer.Offset = new Vector(x, targetY);
 
@@ -356,7 +434,8 @@ public partial class PdfViewerControl
 
         if (page < 1 || page > _continuousSlots.Count) { _pendingContinuousPage = null; return; }
 
-        var targetY = _continuousSlots[page - 1].TopDip;
+        var slot = _continuousSlots[page - 1];
+        var targetY = slot.TopDip + _pendingContinuousFraction * slot.DisplayHeight;
         if (ReachedContinuousTarget(targetY))
         {
             _pendingContinuousPage = null;

--- a/Excise.Avalonia/Controls/PdfViewerControl.axaml.cs
+++ b/Excise.Avalonia/Controls/PdfViewerControl.axaml.cs
@@ -797,6 +797,10 @@ public partial class PdfViewerControl : UserControl
         if (_zoomHost != null)
         {
             _zoomScaleTransform = _zoomHost.LayoutTransform as ScaleTransform;
+            // The XAML default is ScaleX/Y=1; apply the display-scale
+            // correction (see SinglePageDisplayScale) from the start so the
+            // first single-page view is already at pt × 96/72 × zoom.
+            UpdateZoomTransform();
         }
 
         // Pointer handlers — attached at the UserControl root level using
@@ -1016,13 +1020,32 @@ public partial class PdfViewerControl : UserControl
     private static string ViewModeDescription(PdfViewMode mode) =>
         mode == PdfViewMode.Continuous ? "continuous reading view" : "single-page editing view";
 
+    /// <summary>
+    /// The single-page layout is in logical-render-DPI dips (a 540pt page is
+    /// 900 dips at the default 120), while the continuous view lays out at
+    /// 96-dpi dips (PointsToDip: the same page is 720 dips). Without
+    /// correction the same ZoomLevel displays 25% larger in single-page —
+    /// the mode-entry size jump of #693. This factor makes the DISPLAYED
+    /// size pt × 96/72 × zoom in both modes, without touching the internal
+    /// 120-dpi coordinate space the overlays and hit-testing use.
+    /// </summary>
+    private double SinglePageDisplayScale =>
+        96.0 / Math.Max(1, _currentSinglePageRenderDpi);
+
+    private void UpdateZoomTransform()
+    {
+        if (_zoomScaleTransform == null) return;
+        var scale = ZoomLevel * SinglePageDisplayScale;
+        _zoomScaleTransform.ScaleX = scale;
+        _zoomScaleTransform.ScaleY = scale;
+    }
+
     private void OnZoomLevelChanged()
     {
         if (_zoomScaleTransform != null)
         {
-            Trace($"Zoom -> {ZoomLevel:F3} mode={ViewMode} page={CurrentPage}");
-            _zoomScaleTransform.ScaleX = ZoomLevel;
-            _zoomScaleTransform.ScaleY = ZoomLevel;
+            Trace($"Zoom -> {ZoomLevel:F3} mode={ViewMode} page={CurrentPage} displayScale={SinglePageDisplayScale:F3}");
+            UpdateZoomTransform();
         }
         if (ViewMode == PdfViewMode.Continuous)
         {
@@ -1219,7 +1242,15 @@ public partial class PdfViewerControl : UserControl
         // zoom) so text is crisp on HiDPI (#682) AND when zoomed in (#683),
         // bounded by the single-page memory budget.
         var logicalDpi = EffectiveSinglePageRenderDpi(page);
-        _currentSinglePageRenderDpi = logicalDpi;
+        if (logicalDpi != _currentSinglePageRenderDpi)
+        {
+            // The display-scale correction depends on the logical DPI, which
+            // can differ per page (huge pages clamp down) — keep the
+            // ZoomHost transform in sync so the on-screen size stays
+            // pt × 96/72 × zoom regardless.
+            _currentSinglePageRenderDpi = logicalDpi;
+            UpdateZoomTransform();
+        }
         var box = page.CropBox.Normalize();
         var widthPt = page.Rotation is 90 or 270 ? box.Height : box.Width;
         var heightPt = page.Rotation is 90 or 270 ? box.Width : box.Height;
@@ -1249,6 +1280,11 @@ public partial class PdfViewerControl : UserControl
                 _pdfImage.Height = cachedDip.Height;
                 _pdfImage.Source = cachedBitmap;
                 Trace($"ImageSet(cache) page={pageNumber} imgWidth={_pdfImage.Width:F0} srcDip={cachedDip.Width:F0} srcPx={cachedBitmap.PixelSize.Width} zoom={ZoomLevel:F3}");
+                if (_pendingSingleFraction >= 0)
+                {
+                    // Mode switch waiting to restore the reading position (#693).
+                    Dispatcher.UIThread.Post(ApplyPendingSingleFraction, DispatcherPriority.Loaded);
+                }
             }
             HasError = false;
             ErrorMessage = null;
@@ -1307,6 +1343,12 @@ public partial class PdfViewerControl : UserControl
                         _pdfImage.Height = dip.Height;
                         _pdfImage.Source = bitmap;
                     }
+                    // A mode switch may be waiting to restore the carried
+                    // reading position (#693); the ScrollViewer only gets a
+                    // real extent after THIS render lands, so re-arm the
+                    // bounded retry from here (Loaded runs post-layout).
+                    if (_pendingSingleFraction >= 0)
+                        Dispatcher.UIThread.Post(ApplyPendingSingleFraction, DispatcherPriority.Loaded);
                 }
             }
             finally


### PR DESCRIPTION
Fixes both halves of #693 — the last open defect from the original "something weird happens to the display" report (after #696's overlay fix and #698's dpi-stamp fix).

## Size half: the 25% mode-entry jump

Continuous lays out pages at 96-dpi dips (`pt × 96/72 × zoom`); single-page laid out at logical-render-DPI dips (120 → 900 for a 540pt page) and applied raw zoom — the same page displayed 25% larger the moment any editing mode was entered. The ZoomHost transform now applies `zoom × 96/renderDpi`, so the **displayed** size is `pt × 96/72 × zoom` in both modes. The internal 120-dpi coordinate space (overlays, hit-testing, render plan) is untouched.

Bonus: fit-width/fit-page now compute against 96-dpi dims — fit-width was silently underfilling the viewport by 20% (live: initial fit zoom went 1.024 → 1.281; the page actually fills the window now).

## Scroll half: reading position carried across the switch

The intra-page fraction at the viewport top is captured before the visibility flip and applied to the destination view: continuous via the existing pending-scroll retry (`ScrollToPageContinuous` gains an `intraPageFraction`; plain navigation passes 0), single-page via an Extent-property subscription — dispatcher-post retries drain before layout ever runs in headless hosts, a real timing lesson baked into the code comment.

## Supporting changes

- `MainWindowViewModel.SetManualZoom`: the user-zoom path (latch Manual + set); tests assigning `ZoomLevel` directly raced the latched auto-fit re-apply.
- Visual-surface test helper samples at the render DPI (`0.8 × 120/96 = 1.0`) so bitmap-vs-surface comparisons stay pixel-exact.
- Layout-aware `SettleAsync`: raster pixel-count alone cannot distinguish two zooms whose device scale clamps identically.

## Verification

- **Red-checked**: `ModeEntry_PreservesDisplayedPageSize` (zoom × dpr, 4 combos) and `ModeSwitch_PreservesReadingPosition` (dpr 1/2) — all 6 fail on the unfixed viewer, pass with the fix.
- **Live-verified** on the real GUI via the automation burst: size parity entering select-text at 52% zoom, true fit-width fill (screenshots v1–v6), same session that live-confirmed and closed #697.
- Full `Excise.App.Tests` green (237 UI + 782 non-UI + display sweep in 4 shards), `test-tier.sh t0` green.
- Filed along the way: #700 (continuous zoom doesn't anchor the viewport — pre-existing, observed in the burst trace).

Closes #693.

🤖 Generated with [Claude Code](https://claude.com/claude-code)