### PR TITLE
fix: anchor the continuous viewport across zoom re-layouts; register class handlers once (#700)

### DIFF
--- a/Excise.App.Tests/UI/ModeSwitchDisplayTests.cs
+++ b/Excise.App.Tests/UI/ModeSwitchDisplayTests.cs
@@ -233,6 +233,91 @@ public class ModeSwitchDisplayTests
     }
 
     /// <summary>
+    /// #700: zooming in continuous view must anchor the viewport. Before the
+    /// fix, a re-layout kept the numeric scroll offset while every slot
+    /// changed size — zooming out slid the viewport pages away from the
+    /// reading position, and because Offset never changed, no scroll event
+    /// fired and CurrentPage silently froze (live: four zoom-outs left the
+    /// label on page 17 while the screen showed page ~22). Correct anchoring
+    /// preserves the offset/extent RATIO (slots scale uniformly) and keeps
+    /// CurrentPage truthful.
+    /// </summary>
+    [FixedAvaloniaTheory]
+    [InlineData(0.5)]
+    [InlineData(2.0)]
+    public async Task ContinuousZoom_AnchorsTheViewportAndKeepsPageSync(double zoomFactor)
+    {
+        var (vm, window, viewer, path) = await OpenTestDocumentAsync();
+        try
+        {
+            var cont = viewer.FindControl<ScrollViewer>("ContinuousScrollViewer")!;
+            await PumpUntilAsync(window, () => cont.Extent.Height > cont.Viewport.Height + 100);
+
+            // Scroll mid-document, then nudge to land mid-page (see the
+            // reading-position test for why the two-step dance).
+            cont.Offset = new global::Avalonia.Vector(cont.Offset.X, cont.Extent.Height * 0.45);
+            await Task.Delay(150); window.UpdateLayout();
+            cont.Offset = new global::Avalonia.Vector(cont.Offset.X, cont.Offset.Y + cont.Extent.Height / 3 * 0.4);
+            await Task.Delay(150); window.UpdateLayout();
+
+            var pageBefore = vm.CurrentPageIndex;
+            var ratioBefore = cont.Offset.Y / cont.Extent.Height;
+            ratioBefore.Should().BeGreaterThan(0.1, "the test must start scrolled into the document");
+
+            var zoomBefore = viewer.ZoomLevel;
+            var extentBefore = cont.Extent.Height;
+            var offsetAtZoom = cont.Offset.Y;
+            vm.SetManualZoom(viewer.ZoomLevel * zoomFactor);
+            // The anchored offset is applied once layout gives the
+            // ScrollViewer its new extent — wait for convergence rather
+            // than a fixed delay.
+            // Correct anchoring preserves the offset/extent ratio, EXCEPT
+            // when the position is no longer reachable (deep zoom-out near
+            // the document end: the viewport covers proportionally more, so
+            // the max scroll ratio shrinks) — then pinning at max IS the
+            // anchor.
+            double ExpectedRatio() => Math.Min(ratioBefore,
+                Math.Max(0, cont.Extent.Height - cont.Viewport.Height) / cont.Extent.Height);
+            try
+            {
+                await PumpUntilAsync(window, () =>
+                    Math.Abs(cont.Offset.Y / cont.Extent.Height - ExpectedRatio()) <= 0.03,
+                    timeoutMs: 10000);
+            }
+            catch (TimeoutException)
+            {
+                throw new Xunit.Sdk.XunitException(
+                    $"anchor never converged: offset {offsetAtZoom:F0}->{cont.Offset.Y:F0} " +
+                    $"extent {extentBefore:F0}->{cont.Extent.Height:F0} " +
+                    $"ratio {ratioBefore:F3}->{cont.Offset.Y / cont.Extent.Height:F3} " +
+                    $"(expected {ExpectedRatio():F3}) " +
+                    $"zoom {zoomBefore:F3}->{viewer.ZoomLevel:F3} page={vm.CurrentPageIndex} " +
+                    $"viewport={cont.Viewport.Height:F0}");
+            }
+
+            var ratioAfter = cont.Offset.Y / cont.Extent.Height;
+            ratioAfter.Should().BeApproximately(ExpectedRatio(), 0.03,
+                $"zooming ×{zoomFactor} must keep the same document position at the viewport top " +
+                $"(offset/extent ratio {ratioBefore:F3} → {ratioAfter:F3}); a drift means the " +
+                "re-layout kept the numeric offset and slid the reader pages away (#700)");
+            // The page label must stay truthful across the re-layout: it must
+            // equal the page actually at the viewport top now (for reachable
+            // anchors that is the page we were on; when pinned at max the
+            // sync may legitimately land later in the document).
+            var pageAfter = vm.CurrentPageIndex;
+            if (Math.Abs(ratioAfter - ratioBefore) <= 0.03)
+                pageAfter.Should().Be(pageBefore,
+                    "the page label must stay truthful across a zoom re-layout — a frozen sync " +
+                    "reports a page the user is no longer looking at (#700)");
+        }
+        finally
+        {
+            window.Close();
+            TestPdfGenerator.CleanupTestFile(path);
+        }
+    }
+
+    /// <summary>
     /// #693 (scroll half): the reading position must survive the mode switch.
     /// Before the fix, entering an editing mode dropped the reader at the top
     /// of the page (singleOffset 0/…) and switching back re-anchored to the

--- a/Excise.App.Tests/UI/MouseInputTests.cs
+++ b/Excise.App.Tests/UI/MouseInputTests.cs
@@ -215,6 +215,7 @@ public class MouseInputTests
         var interaction = FindNamedDescendant<Canvas>(viewer!, "InteractionLayer");
         interaction.Should().NotBeNull("InteractionLayer must exist");
         var page = vm.PdfCoreDocument!.GetPage(linkPage);
+        await ScrollContentRectIntoView(window, scrollViewer!, viewer!, targetLink.Rect, page);
         var pointInWindow = ToWindowPoint(targetLink.Rect, page, interaction!, window);
 
         bool linkFired = false;
@@ -716,6 +717,7 @@ public class MouseInputTests
         var interaction = FindNamedDescendant<Canvas>(viewer!, "InteractionLayer");
         interaction.Should().NotBeNull("InteractionLayer must exist");
         var page = vm.PdfCoreDocument!.GetPage(linkPage);
+        await ScrollContentRectIntoView(window, scrollViewer!, viewer!, targetLink.Rect, page);
         var hoverPoint = ToWindowPoint(targetLink.Rect, page, interaction!, window);
 
         // Simulate hover (MouseMove without click).
@@ -818,6 +820,27 @@ public class MouseInputTests
     #endregion
 
     #region Helpers
+
+    /// <summary>
+    /// Scroll the single-page viewport so the given content rect is visible.
+    /// Since the #693 display unification made fit-width actually fill the
+    /// viewport, a link deep in the page can lie below the fold — a
+    /// click/hover point translated to window coordinates would then land
+    /// outside the viewer entirely and the event never reaches it.
+    /// </summary>
+    private static async Task ScrollContentRectIntoView(
+        Window window, ScrollViewer scroller, PdfViewerControl viewer,
+        PdfRectangle contentRect, PdfPage page)
+    {
+        var viewerRect = PdfCoordinateMapper.ToViewerDips(
+            page, PdfPageRect.FromContentPoints(page.PageNumber, contentRect), RenderDpi);
+        // Displayed position = viewer dips x zoom x 96/renderDpi (#693).
+        var displayScale = viewer.ZoomLevel * 96.0 / 120.0;
+        var targetY = Math.Max(0, viewerRect.Y * displayScale - scroller.Viewport.Height / 2);
+        scroller.Offset = new Vector(scroller.Offset.X, targetY);
+        await Task.Delay(100);
+        window.UpdateLayout();
+    }
 
     private static Point ToWindowPoint(Letter l, PdfPage page, Canvas overlay, Window window)
     {

--- a/Excise.Avalonia/Controls/PdfViewerControl.Continuous.cs
+++ b/Excise.Avalonia/Controls/PdfViewerControl.Continuous.cs
@@ -172,6 +172,18 @@ public partial class PdfViewerControl
             _continuousViewportSubscription = _continuousScrollViewer
                 .GetObservable(ScrollViewer.ViewportProperty)
                 .Subscribe(new AnonymousObserver<Size>(OnContinuousViewportChanged));
+            // Permanent: re-apply a pending zoom anchor once layout gives the
+            // ScrollViewer its post-re-layout extent. POSTED, not applied
+            // synchronously — an Offset write inside the extent-change
+            // notification is re-clamped by the ScrollViewer's own layout
+            // coercion and silently lost (#700).
+            _continuousExtentSubscription = _continuousScrollViewer
+                .GetObservable(ScrollViewer.ExtentProperty)
+                .Subscribe(new AnonymousObserver<Size>(_ =>
+                {
+                    if (_pendingZoomAnchorPage > 0)
+                        Dispatcher.UIThread.Post(ApplyPendingZoomAnchor, DispatcherPriority.Loaded);
+                }));
         }
     }
 
@@ -255,7 +267,26 @@ public partial class PdfViewerControl
     /// the Extent property itself and apply the carried fraction the moment
     /// the content gets a real size.
     /// </summary>
+    private bool _applyingSingleFraction;
+
     private void ApplyPendingSingleFraction()
+    {
+        // Same re-entrancy guard as ApplyPendingZoomAnchor: GetObservable
+        // emits the current value synchronously on subscribe, which would
+        // re-enter here before the subscription field is assigned.
+        if (_applyingSingleFraction) return;
+        _applyingSingleFraction = true;
+        try
+        {
+            ApplyPendingSingleFractionCore();
+        }
+        finally
+        {
+            _applyingSingleFraction = false;
+        }
+    }
+
+    private void ApplyPendingSingleFractionCore()
     {
         if (_pendingSingleFraction < 0 || _scrollViewer == null)
         {
@@ -335,9 +366,92 @@ public partial class PdfViewerControl
     private void ApplyContinuousZoom()
     {
         if (_continuousSlots == null) return;
+
+        // Anchor the viewport across the re-layout (#700). Re-laying the
+        // slots at a new zoom while keeping the NUMERIC scroll offset slides
+        // the viewport pages away from what the user was reading — and since
+        // Offset never changes, no scroll event fires and the scroll→
+        // CurrentPage sync silently freezes (live trace: four zoom-outs left
+        // the label on page 17 while the screen showed page ~22). Capture
+        // page + intra-page fraction at the viewport top against the OLD
+        // layout, re-layout, then restore that reading position — the offset
+        // assignment also fires the sync. A pending programmatic navigation
+        // wins over anchoring.
+        int anchorPage = 0;
+        double anchorFraction = 0;
+        if (_continuousScrollViewer != null && _pendingContinuousPage == null)
+        {
+            var y = _continuousScrollViewer.Offset.Y;
+            for (int i = 0; i < _continuousSlots.Count; i++)
+            {
+                var s = _continuousSlots[i];
+                if (y < s.TopDip + s.DisplayHeight + PageGapDip || i == _continuousSlots.Count - 1)
+                {
+                    anchorPage = i + 1;
+                    anchorFraction = s.DisplayHeight > 0
+                        ? Math.Clamp((y - s.TopDip) / s.DisplayHeight, 0, 1)
+                        : 0;
+                    break;
+                }
+            }
+        }
+
         ApplyContinuousSlotLayout(_continuousSlots);
 
+        if (anchorPage > 0 && _continuousScrollViewer != null)
+        {
+            // The ScrollViewer clamps Offset against the PRE-layout extent
+            // until the next layout pass, so a zoom-IN target (which grows)
+            // would silently clamp short — and dispatcher-post retries drain
+            // before layout ever runs (the #693 lesson). Apply via the
+            // Extent observable instead.
+            _pendingZoomAnchorPage = anchorPage;
+            _pendingZoomAnchorFraction = anchorFraction;
+            ApplyPendingZoomAnchor();
+        }
+
         RenderVisibleContinuousTiles();
+    }
+
+    private int _pendingZoomAnchorPage;
+    private double _pendingZoomAnchorFraction;
+
+
+    private void ApplyPendingZoomAnchor()
+    {
+        if (_pendingZoomAnchorPage <= 0 || _continuousScrollViewer == null || _continuousSlots == null ||
+            _pendingZoomAnchorPage > _continuousSlots.Count)
+        {
+            return;
+        }
+
+        var slot = _continuousSlots[_pendingZoomAnchorPage - 1];
+        var target = slot.TopDip + _pendingZoomAnchorFraction * slot.DisplayHeight;
+        // The reachable maximum. If the target lies beyond it (deep zoom-out
+        // near the end of the document), pinning to the max IS the anchor —
+        // the viewport now covers proportionally more document.
+        var max = Math.Max(0, _continuousScrollViewer.Extent.Height - _continuousScrollViewer.Viewport.Height);
+        var reachable = Math.Min(target, max);
+        _continuousScrollViewer.Offset = new Vector(_continuousScrollViewer.Offset.X, reachable);
+
+        if (Math.Abs(_continuousScrollViewer.Offset.Y - target) <= 1.0 ||
+            (reachable < target && Math.Abs(_continuousScrollViewer.Offset.Y - reachable) <= 1.0 && ExtentReflectsSlots()))
+        {
+            // Anchored (or correctly pinned at the true max). Done — the
+            // permanent extent subscription stops re-posting once this is 0.
+            _pendingZoomAnchorPage = 0;
+        }
+        // else: the extent still reflects the pre-re-layout world; the extent
+        // subscription in InitializeContinuous posts us again when it updates.
+    }
+
+    /// <summary>The ScrollViewer's extent matches the freshly-laid-out slots.</summary>
+    private bool ExtentReflectsSlots()
+    {
+        if (_continuousScrollViewer == null || _continuousSlots == null || _continuousSlots.Count == 0)
+            return true;
+        var last = _continuousSlots[^1];
+        return Math.Abs(_continuousScrollViewer.Extent.Height - (last.TopDip + last.DisplayHeight + PageGapDip)) < 2.0;
     }
 
     private void ApplyContinuousSlotLayout(IReadOnlyList<PdfPageSlot> slots)

--- a/Excise.Avalonia/Controls/PdfViewerControl.axaml.cs
+++ b/Excise.Avalonia/Controls/PdfViewerControl.axaml.cs
@@ -333,8 +333,21 @@ public partial class PdfViewerControl : UserControl
         Focusable = true;
         UpdateViewerAutomationProperties();
         DetachedFromVisualTree += OnDetachedFromVisualTreeHandler;
+    }
 
-        // Subscribe to property changes
+    /// <summary>
+    /// ⚠️ Class handlers are STATIC scope — one registration fires for every
+    /// instance of the control. These lived in the instance constructor for a
+    /// long time, which meant every constructed viewer added a duplicate
+    /// handler set: with N viewers ever created in the process, one property
+    /// change invoked each handler N times. The app creates a single viewer
+    /// so it never noticed; the test host creates dozens, and the duplicate
+    /// OnZoomLevelChanged invocations re-entered ApplyContinuousZoom and
+    /// destroyed the #700 zoom anchor mid-flight (plus N-fold duplicate
+    /// renders everywhere else). Register once, in the static constructor.
+    /// </summary>
+    static PdfViewerControl()
+    {
         DocumentProperty.Changed.AddClassHandler<PdfViewerControl>((control, e) =>
             control.OnDocumentChanged());
         CurrentPageProperty.Changed.AddClassHandler<PdfViewerControl>((control, e) =>
@@ -387,6 +400,8 @@ public partial class PdfViewerControl : UserControl
         _continuousOffsetSubscription = null;
         _continuousViewportSubscription?.Dispose();
         _continuousViewportSubscription = null;
+        _continuousExtentSubscription?.Dispose();
+        _continuousExtentSubscription = null;
 
         if (_continuousItems != null)
         {
@@ -883,6 +898,7 @@ public partial class PdfViewerControl : UserControl
     private IDisposable? _viewportSubscription;
     private IDisposable? _continuousOffsetSubscription;
     private IDisposable? _continuousViewportSubscription;
+    private IDisposable? _continuousExtentSubscription;
 
     private void OnScrollViewerViewportChanged(Size newViewport)
     {


### PR DESCRIPTION
Fixes #700 — the last open bug in track 3 (Reader).

## The anchor

Zooming in continuous view re-laid every slot while keeping the numeric scroll offset: the viewport slid pages away from the reading position, and because `Offset` never changed, no scroll event fired and the page label froze (live trace: four zoom-outs left the label on page 17 while the screen showed page ~22). `ApplyContinuousZoom` now captures page + intra-page fraction at the viewport top against the old layout and restores it after re-layout — with two hard-won mechanics:

- The restore is re-applied from a **permanent Extent subscription via a dispatcher post**: the ScrollViewer clamps `Offset` against the pre-layout extent until layout catches up, and a write *inside* the extent-change notification gets re-clamped by the ScrollViewer's own coercion.
- When the anchor is genuinely unreachable (deep zoom-out near the document end shrinks the max scroll below it), pinning at max **is** the correct anchor.

## The bycatch: duplicate class-handler registrations

The anchor's batch-only test failures exposed a long-latent bug: every `AddClassHandler` registration lived in the **instance** constructor, but class handlers are static scope — each constructed viewer added a duplicate handler set firing for **all** instances. The app creates one viewer and never noticed; the test host creates dozens, so one zoom change invoked `OnZoomLevelChanged` 17×, re-entering `ApplyContinuousZoom` and destroying the anchor mid-flight (and N-plicating document/page/render handlers behind assorted UI-test flakiness). Registrations moved to a static constructor.

## Verification

- `ContinuousZoom_AnchorsTheViewportAndKeepsPageSync` (×0.5 / ×2): offset/extent ratio preserved, with the unreachable-max carve-out; **red-checked** (both fail on the unfixed viewer).
- **Live-verified** with the automation burst: scroll into page 17 → zoom out ×4 → the same text line sits at the viewport top at 41%, label truthful → zoom in ×4 restores the exact original view, pixel-identical.
- Full sweep green: 239 UI + 782 non-UI + display sweep (4 shards) + t0.
- MouseInput link click/hover tests now scroll their target into view (fit-width truly filling the viewport since #693 pushes deep links below the fold); the pre-existing order-dependent Hover flake is filed as #706.

🤖 Generated with [Claude Code](https://claude.com/claude-code)