### PR TITLE
fix: restore Avalonia.Controls.DataGrid — FluentAvaloniaTheme requires it at startup (#593 regression)

### DIFF
--- a/Excise.App.Tests/UI/AppThemeCanaryTests.cs
+++ b/Excise.App.Tests/UI/AppThemeCanaryTests.cs
@@ -1,0 +1,66 @@
+using System;
+using System.IO;
+using AwesomeAssertions;
+using Excise.App.Tests.Utilities;
+using Xunit;
+
+namespace Excise.App.Tests.UI;
+
+/// <summary>
+/// Canary for the app's REAL theme load path. #593 excluded
+/// Avalonia.Controls.DataGrid as "unused" and every headless test stayed
+/// green while the shipped app died at startup with
+/// <c>FileNotFoundException: Avalonia.Controls.DataGrid</c> —
+/// <c>FluentAvaloniaTheme</c>'s compiled XAML hard-references DataGrid
+/// control themes in its constructor. Two lessons are encoded here:
+///
+///  1. The headless host boots a bare TestApp that never loads
+///     FluentAvaloniaTheme, so constructing the REAL theme is asserted
+///     explicitly.
+///  2. A test-host assertion cannot see APP-output packaging: the test
+///     project's own dependency closure always copies DataGrid.dll into the
+///     TEST bin, so the theme constructs here even when the APP's output is
+///     broken (a first version of this canary "passed" against the exact
+///     csproj that crashed the app). The packaging half therefore asserts on
+///     Excise.App's build output directory itself.
+/// </summary>
+[Collection("AvaloniaTests")]
+public class AppThemeCanaryTests
+{
+    [FixedAvaloniaFact]
+    public void FluentAvaloniaTheme_TheAppsRealTheme_Constructs()
+    {
+        var construct = () => new FluentAvalonia.Styling.FluentAvaloniaTheme();
+        construct.Should().NotThrow(
+            "App.axaml instantiates FluentAvaloniaTheme at startup; if this throws, " +
+            "the shipped app cannot launch at all");
+    }
+
+    [Fact]
+    public void AppOutput_ShipsFluentAvaloniaThemeRuntimeDependencies()
+    {
+        var appBin = FindAppOutputDirectory();
+        File.Exists(Path.Combine(appBin, "Excise.App.dll")).Should().BeTrue(
+            $"the app must have been built into {appBin} (it is a project reference of this test project)");
+
+        File.Exists(Path.Combine(appBin, "Avalonia.Controls.DataGrid.dll")).Should().BeTrue(
+            "FluentAvaloniaTheme's compiled XAML hard-references DataGrid control themes in its " +
+            "CONSTRUCTOR — without this assembly in the APP's output the app dies at first " +
+            "launch with FileNotFoundException (#593 regression: an ExcludeAssets=\"all\" on " +
+            "the transitive reference passed every headless test and broke the real app)");
+    }
+
+    /// <summary>
+    /// Excise.App's bin directory for the same configuration this test runs
+    /// under (test bin: Excise.App.Tests/bin/{config}/net10.0 → app bin:
+    /// Excise.App/bin/{config}/net10.0).
+    /// </summary>
+    private static string FindAppOutputDirectory()
+    {
+        var testBin = AppContext.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar);
+        var tfmDir = Path.GetFileName(testBin);                       // net10.0
+        var config = Path.GetFileName(Path.GetDirectoryName(testBin)!); // Debug/Release
+        var repoRoot = Path.GetFullPath(Path.Combine(testBin, "..", "..", "..", ".."));
+        return Path.Combine(repoRoot, "Excise.App", "bin", config, tfmDir);
+    }
+}

--- a/Excise.App/Excise.App.csproj
+++ b/Excise.App/Excise.App.csproj
@@ -57,26 +57,30 @@
        -r <rid>` (or scripts/run-aot-smoke.sh). Validated: the GUI AOT-compiles and
        passes the packaged GUI smoke on osx-arm64. First-party Excise.* code is
        AOT-clean (source-generated JSON via ExciseJsonContext, no reflection-based
-       ReactiveUI WhenAnyValue). #593 eliminated the third-party warning roll-ups
-       at the source instead of suppressing them wholesale:
-       ReactiveUI.Avalonia dropped (scheduler vendored —
-       Threading/AvaloniaDispatcherScheduler.cs); Avalonia.Controls.DataGrid
-       excluded below (unused transitive of FluentAvaloniaUI — removing it also
-       removes FluentAvalonia's IL2104+IL3053, which lived entirely in its
-       DataGrid integration). The ONE remaining roll-up is CSJ2K's IL2104: its
-       J2kSetup platform probe runs Assembly.DefinedTypes scans from static
-       constructors, unfixable from outside the package. It scans only CSJ2K's
-       own (untrimmed-because-reachable) assembly, and the AOT packaged-GUI
-       smoke confirms JPX decode works; the terminal fix is the native JPX
-       decoder (#403), which removes the package. -->
+       ReactiveUI WhenAnyValue). #593 outcome: ReactiveUI.Avalonia's roll-up is
+       ELIMINATED (package dropped; scheduler vendored at
+       Threading/AvaloniaDispatcherScheduler.cs). The remaining roll-ups are
+       structural and stay suppressed with reasons:
+       - FluentAvalonia + Avalonia.Controls.DataGrid (IL2104/IL3053 each):
+         FluentAvaloniaTheme's compiled XAML hard-references DataGrid control
+         themes in its constructor, so the assembly cannot be excluded — the
+         app crashes at startup without it (see the DataGrid PackageReference
+         note below). Functionality under AOT is covered by the packaged GUI
+         smoke.
+       - CSJ2K (IL2104): its J2kSetup platform probe runs
+         Assembly.DefinedTypes scans from static constructors, unfixable from
+         outside the package. It scans only CSJ2K's own
+         untrimmed-because-reachable assembly; JPX decode is covered by the
+         Core filter tests. Terminal fix: the native JPX decoder (#403),
+         which removes the package. -->
   <PropertyGroup Condition="'$(PublishAot)' == 'true'">
     <!-- ReadyToRun and NativeAOT are mutually exclusive publish modes; the
          Release block above turns R2R on, so it must be turned back off here. -->
     <PublishReadyToRun>false</PublishReadyToRun>
     <!-- PDF text handling needs culture data; do NOT trim globalization. -->
     <InvariantGlobalization>false</InvariantGlobalization>
-    <!-- CSJ2K only — see the #593 note above. IL3053 no longer fires at all. -->
-    <NoWarn>$(NoWarn);IL2104</NoWarn>
+    <!-- FluentAvalonia/DataGrid/CSJ2K only — see the #593 note above. -->
+    <NoWarn>$(NoWarn);IL2104;IL3053</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -94,13 +98,17 @@
     <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.5" />
     <PackageReference Include="Avalonia.Fonts.Inter" Version="12.0.5" />
     <PackageReference Include="FluentAvaloniaUI" Version="3.0.0-preview4" />
-    <!-- Unused transitive of FluentAvaloniaUI, excluded (#593): nothing in
-         the app or in our use of FluentAvalonia touches DataGrid, and its
-         assembly (plus FluentAvalonia's DataGrid integration, the sole
-         source of FluentAvalonia's IL2104/IL3053) carried four of the six
-         AOT warning roll-ups. If a DataGrid is ever wanted, delete this
-         line. -->
-    <PackageReference Include="Avalonia.Controls.DataGrid" Version="12.0.0" ExcludeAssets="all" />
+    <!-- ⚠️ Avalonia.Controls.DataGrid MUST ship even though nothing in the
+         app uses a DataGrid: FluentAvaloniaTheme's compiled XAML
+         (Styling/ControlThemes/Controls.axaml) hard-references DataGrid
+         control themes in its CONSTRUCTOR, so the app dies at startup with
+         FileNotFoundException without the assembly. #593 briefly excluded it
+         (ExcludeAssets="all") to kill its AOT warning roll-ups — every
+         headless test stayed green because the test host's TestApp never
+         loads FluentAvaloniaTheme, and the live launch crash only surfaced
+         afterwards. AppThemeCanaryTests constructs the real theme so this
+         class of exclusion can never pass the suite again. -->
+    <PackageReference Include="Avalonia.Controls.DataGrid" Version="12.0.0" />
     <!-- FluentIcons.Avalonia.Fluent dropped: not referenced anywhere
          in source/axaml. Shell icons use local vector StreamGeometry resources
          instead of the FluentIcons component library. Removing unblocks


### PR DESCRIPTION
**Fixes the app failing to launch on develop** (reported live: every launch dies with `FileNotFoundException: Avalonia.Controls.DataGrid`).

## What happened

PR #708 excluded the DataGrid assembly as an unused transitive to eliminate its AOT warning roll-ups. But `FluentAvaloniaTheme`'s compiled XAML hard-references DataGrid control themes **in its constructor**, so the shipped app crashed at startup. Two blind spots let it through:

1. The headless test host boots a bare `TestApp` that never loads FluentAvaloniaTheme.
2. A test-host canary can't catch it either: the test project's own dependency closure always copies DataGrid.dll into the *test* bin — a first attempt at a canary passed against the exact csproj that crashed the app.

The live-launch validation that would have caught it was blocked at the time by the -6661 display-link condition — which, it turns out, is *still* active (the DataGrid crash fires before the render timer and masked it; a logout/reboot is still needed).

## The fix

- DataGrid restored, with a ⚠️ comment explaining exactly why it must ship despite being "unused".
- `AppThemeCanaryTests` guards both halves: the real theme constructs, and **Excise.App's own build output** ships the DataGrid assembly. Red-green verified against #708's csproj.
- AOT `NoWarn` returns to `IL2104;IL3053`, scoped and documented per assembly. The real #593 win stands: ReactiveUI.Avalonia remains eliminated (unsuppressed publishes report only the three structurally-unavoidable roll-ups).

## Verification

t0 green; canary + mode-switch batteries green; live launch proceeds past theme load (previous crash point) to the known environmental -6661, which reboot clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)