### PR TITLE
fix(text): decode /ToUnicode /Identity-H|V by identity, not WinAnsi (#715, #515)

### DIFF
--- a/Excise.Core.Tests/Text/PredefinedToUnicodeCMapTests.cs
+++ b/Excise.Core.Tests/Text/PredefinedToUnicodeCMapTests.cs
@@ -1,0 +1,59 @@
+using System.Text;
+using AwesomeAssertions;
+using Excise.Core.Document;
+using Excise.Core.Text;
+using Xunit;
+
+namespace Excise.Core.Tests.Text;
+
+/// <summary>
+/// #715 / #515 — a <c>/ToUnicode</c> that is the predefined-CMap NAME
+/// <c>/Identity-H</c> (or <c>/Identity-V</c>) declares code == UTF-16BE Unicode.
+/// It must be decoded directly, not left to the WinAnsi fallback (which is only
+/// identity by coincidence and mis-maps 2-byte codes whose value is 128–159).
+/// </summary>
+public class PredefinedToUnicodeCMapTests
+{
+    [Fact]
+    public void IdentityHToUnicode_DecodesTwoByteCodesAsUtf16BeUnicode()
+    {
+        // Codes: 0x0041 'A', 0x0091 (a value in the 128–159 band), 0x0042 'B'.
+        var pdf = BuildType0IdentityToUnicodePdf("BT /F0 12 Tf 100 700 Td <004100910042> Tj ET");
+        using var doc = PdfDocument.Open(pdf);
+        var text = new TextExtractor(doc.GetPage(1)).ExtractText();
+
+        // With /ToUnicode /Identity-H the middle code is U+0091, NOT the WinAnsi
+        // CP1252 remap U+2019 (’) the old fallback produced.
+        text.Should().Be("AB");
+        text.Should().NotContain("’", "code 0x91 must decode as U+0091 (Identity), not the WinAnsi ’");
+    }
+
+    private static byte[] BuildType0IdentityToUnicodePdf(string content)
+    {
+        var sb = new StringBuilder();
+        var off = new long[8];
+        void Mark(int n) => off[n] = Encoding.ASCII.GetByteCount(sb.ToString());
+
+        sb.Append("%PDF-1.7\n");
+        Mark(1); sb.Append("1 0 obj <</Type/Catalog/Pages 2 0 R>> endobj\n");
+        Mark(2); sb.Append("2 0 obj <</Type/Pages/Count 1/Kids[3 0 R]>> endobj\n");
+        Mark(3); sb.Append("3 0 obj <</Type/Page/Parent 2 0 R/MediaBox[0 0 612 792]"
+                         + "/Resources<</Font<</F0 4 0 R>>>>/Contents 7 0 R>> endobj\n");
+        // Type0 with predefined-NAME /ToUnicode /Identity-H (not a stream).
+        Mark(4); sb.Append("4 0 obj <</Type/Font/Subtype/Type0/BaseFont/Test"
+                         + "/Encoding/Identity-H/ToUnicode/Identity-H/DescendantFonts[5 0 R]>> endobj\n");
+        Mark(5); sb.Append("5 0 obj <</Type/Font/Subtype/CIDFontType2/BaseFont/Test"
+                         + "/CIDSystemInfo<</Registry(Adobe)/Ordering(Identity)/Supplement 0>>"
+                         + "/FontDescriptor 6 0 R/CIDToGIDMap/Identity/DW 1000>> endobj\n");
+        Mark(6); sb.Append("6 0 obj <</Type/FontDescriptor/FontName/Test/Flags 4"
+                         + "/FontBBox[0 0 1000 1000]/ItalicAngle 0/Ascent 900/Descent -200"
+                         + "/CapHeight 700/StemV 80>> endobj\n");
+        Mark(7); sb.Append($"7 0 obj <</Length {content.Length}>> stream\n{content}\nendstream endobj\n");
+
+        long xref = Encoding.ASCII.GetByteCount(sb.ToString());
+        sb.Append("xref\n0 8\n0000000000 65535 f \n");
+        for (int i = 1; i <= 7; i++) sb.Append($"{off[i]:D10} 00000 n \n");
+        sb.Append($"trailer <</Root 1 0 R/Size 8>>\nstartxref\n{xref}\n%%EOF");
+        return Encoding.ASCII.GetBytes(sb.ToString());
+    }
+}

--- a/Excise.Core/Text/TextExtractor.cs
+++ b/Excise.Core/Text/TextExtractor.cs
@@ -29,6 +29,11 @@ public class TextExtractor
     // program the only GID→Unicode bridge is the standard Macintosh glyph order
     // (#532; see DecodeCharacter). Recomputed on each /Tf.
     private bool _useStandardMacGlyphOrder;
+    // True when /ToUnicode is the predefined-CMap NAME /Identity-H or /Identity-V
+    // (not a stream): the 2-byte code IS the UTF-16BE Unicode scalar, so it must
+    // be decoded directly rather than left to the WinAnsi fallback (which is only
+    // correct by coincidence and mis-maps codes 128–159). #715 / #515.
+    private bool _toUnicodeIdentity;
     private double _textLeading = 0;
     private double _charSpacing = 0;
     private double _wordSpacing = 0;
@@ -844,6 +849,7 @@ public class TextExtractor
                     _currentFont = ResolveFontFromActiveResources(_fontName);
                     _toUnicodeMap = LoadToUnicodeMap(_currentFont);
                     (_differencesGlyphNames, _differencesBaseEncoding) = LoadDifferencesEncoding(_currentFont);
+                    _toUnicodeIdentity = _toUnicodeMap == null && ToUnicodeIsIdentity(_currentFont);
                     _useStandardMacGlyphOrder = _toUnicodeMap == null && UsesStandardMacGlyphOrderFallback(_currentFont);
                     LoadFontGeometry();
                 }
@@ -1468,6 +1474,15 @@ public class TextExtractor
             return unicode;
         }
 
+        // Predefined /ToUnicode /Identity-H|/Identity-V (a CMap NAME, so no map
+        // was built above): the 2-byte code IS the UTF-16BE Unicode scalar.
+        // Decode it directly — the WinAnsi default below is only identity by
+        // coincidence and mis-maps codes 128–159 (#715 / #515).
+        if (_toUnicodeIdentity && charCode is >= 0 and <= 0xFFFF && !char.IsSurrogate((char)charCode))
+        {
+            return ((char)charCode).ToString();
+        }
+
         // /Encoding << /Differences [...] >> (#662): a Differences entry for
         // this exact code overrides everything below it — the glyph name it
         // assigns takes priority over both /BaseEncoding and the bare-name
@@ -1533,6 +1548,20 @@ public class TextExtractor
     /// because their (often subset-reordered) glyph order is authoritative and a
     /// standard-order guess would corrupt correct output. #532.
     /// </summary>
+    /// <summary>
+    /// True when the font's <c>/ToUnicode</c> is the predefined-CMap name
+    /// <c>/Identity-H</c> or <c>/Identity-V</c> (as opposed to a stream). Such a
+    /// ToUnicode declares code == Unicode (UTF-16BE); see <see cref="DecodeCharacter"/>.
+    /// #715 / #515.
+    /// </summary>
+    private bool ToUnicodeIsIdentity(PdfDictionary? font)
+    {
+        if (font == null)
+            return false;
+        var toUnicode = _page.Document.Resolve(font.GetOptional("ToUnicode") ?? PdfNull.Instance);
+        return toUnicode is PdfName name && (name.Value == "Identity-H" || name.Value == "Identity-V");
+    }
+
     private bool UsesStandardMacGlyphOrderFallback(PdfDictionary? font)
     {
         if (font == null || font.GetNameOrNull("Subtype") != "Type0")


### PR DESCRIPTION
First slice of the CMap/CID coverage epic **#515**, and closes the Identity part of **#715**.

## Problem
When `/ToUnicode` is the predefined-CMap **name** `/Identity-H` or `/Identity-V` (not a stream), the 2-byte content code IS the UTF-16BE Unicode scalar. `LoadToUnicodeMap` only parses streams, so these fonts built no map and `DecodeCharacter` fell through to `DecodeWinAnsi(charCode)` — identity only by coincidence, and it mis-maps codes **128–159** (CP1252 remap, e.g. `0x91` → U+2019 instead of U+0091). Found in #532: `issue12418_reduced.pdf` extracts correctly today only because its codes miss that band.

## Fix
A Type0 font whose `/ToUnicode` resolves to the name Identity-H/V now decodes each 2-byte code directly as a Unicode code unit (BMP, non-surrogate). Scoped so it never overrides a stream `/ToUnicode` or the #532 Mac-glyph-order fallback.

## Verification
- New `PredefinedToUnicodeCMapTests` (in-memory Type0 `/ToUnicode /Identity-H`); **negative control confirmed** it fails on the pre-fix WinAnsi path (`A’B` vs `AB`).
- `issue12418_reduced.pdf` still extracts "Uvolnění vinkulace" (now explicit, not coincidence).
- 248 Core extraction tests green; extraction-parity gate **#645 PASS** (332 pages ≥ baseline); t0 green; 0 warnings.

## Remaining under #515/#715
Registered CJK CMap names as `/ToUnicode` (`/UniGB-UCS2-H` etc.) need the predefined-CMap set — still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)