### PR TITLE
feat(a11y): expose page text to the accessibility tree via an AutomationPeer (#631)

### DIFF
--- a/Excise.App.Tests/Controls/PdfViewerContentAccessibilityTests.cs
+++ b/Excise.App.Tests/Controls/PdfViewerContentAccessibilityTests.cs
@@ -1,0 +1,147 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Avalonia.Automation.Peers;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using AwesomeAssertions;
+using Excise.Avalonia.Controls;
+using Excise.Core.Document;
+using Excise.Core.Graphics;
+using Excise.App.Tests.UI;
+using Xunit;
+using PdfCoreDocument = Excise.Core.Document.PdfDocument;
+
+namespace Excise.App.Tests.Controls;
+
+/// <summary>
+/// Issue #631 — document content must be visible to screen readers.
+///
+/// <para>
+/// These tests assert that the current page's text is REACHABLE through the
+/// automation peer tree (not merely that a peer exists): they walk
+/// <see cref="AutomationPeer.GetChildren"/> from the viewer's peer, find the
+/// synthetic page-text node, and verify its Name carries the page text in
+/// reading order, follows page navigation, and goes empty when no document
+/// is loaded.
+/// </para>
+/// </summary>
+[Collection("AvaloniaTests")]
+public class PdfViewerContentAccessibilityTests
+{
+    private const string PageTextAutomationId = "PdfPageTextContent";
+
+    [FixedAvaloniaFact]
+    public async Task PageText_IsReachableThroughAutomationPeerTree_InReadingOrder()
+    {
+        using var doc = CreateDocument(page =>
+        {
+            // PDF space is Y-up: larger Y = higher on the page, i.e. read first.
+            Draw(page, "Alpha heading line", y: 700);
+            Draw(page, "Beta body line", y: 650);
+        });
+
+        var viewer = await ShowViewerAsync(doc);
+
+        var textPeer = FindPageTextPeer(ControlAutomationPeer.CreatePeerForElement(viewer));
+
+        textPeer.Should().NotBeNull("the viewer's automation peer must expose a page-text child (issue #631)");
+        textPeer!.GetAutomationControlType().Should().Be(AutomationControlType.Text);
+        textPeer.IsContentElement().Should().BeTrue("screen readers only surface content elements");
+        textPeer.IsControlElement().Should().BeTrue();
+
+        var name = textPeer.GetName();
+        name.Should().Contain("Alpha heading line");
+        name.Should().Contain("Beta body line");
+        name!.IndexOf("Alpha heading line", System.StringComparison.Ordinal)
+            .Should().BeLessThan(
+                name.IndexOf("Beta body line", System.StringComparison.Ordinal),
+                "page text must be exposed in reading order (top line first)");
+    }
+
+    [FixedAvaloniaFact]
+    public async Task PageText_FollowsPageNavigation()
+    {
+        using var doc = CreateDocument(
+            page => Draw(page, "Content of the first page", y: 700),
+            page => Draw(page, "Content of the second page", y: 700));
+
+        var viewer = await ShowViewerAsync(doc);
+        var textPeer = FindPageTextPeer(ControlAutomationPeer.CreatePeerForElement(viewer));
+        textPeer.Should().NotBeNull();
+
+        textPeer!.GetName().Should().Contain("Content of the first page");
+
+        viewer.CurrentPage = 2;
+        await KeyboardTestHelpers.FlushDispatcherAsync();
+
+        var name = textPeer.GetName();
+        name.Should().Contain("Content of the second page");
+        name.Should().NotContain("Content of the first page",
+            "the accessible text must track the displayed page");
+    }
+
+    [FixedAvaloniaFact]
+    public async Task PageText_IsEmptyWithoutDocument()
+    {
+        var viewer = new PdfViewerControl();
+        var window = new Window { Content = viewer, Width = 800, Height = 600 };
+        window.Show();
+        window.UpdateLayout();
+        await KeyboardTestHelpers.FlushDispatcherAsync();
+
+        var textPeer = FindPageTextPeer(ControlAutomationPeer.CreatePeerForElement(viewer));
+
+        textPeer.Should().NotBeNull();
+        (textPeer!.GetName() ?? string.Empty).Should().BeEmpty(
+            "no document means no page text to announce");
+
+        window.Close();
+    }
+
+    private static PdfCoreDocument CreateDocument(params System.Action<PdfPage>[] pages)
+    {
+        using var builder = PdfCoreDocument.CreateNew();
+        foreach (var drawPage in pages)
+        {
+            var page = builder.Pages.AddBlank();
+            drawPage(page);
+        }
+
+        return PdfCoreDocument.Open(builder.SaveToBytes());
+    }
+
+    private static void Draw(PdfPage page, string text, double y)
+    {
+        using var g = page.GetGraphics();
+        g.DrawString(text, PdfFont.Helvetica(12), PdfBrush.Black, 100, y);
+        g.Flush();
+    }
+
+    private static async Task<PdfViewerControl> ShowViewerAsync(PdfCoreDocument doc)
+    {
+        var viewer = new PdfViewerControl();
+        var window = new Window { Content = viewer, Width = 800, Height = 600 };
+        window.Show();
+        viewer.Document = doc;
+        window.UpdateLayout();
+        await KeyboardTestHelpers.FlushDispatcherAsync();
+        return viewer;
+    }
+
+    /// <summary>Depth-first search of the automation tree for the synthetic page-text peer.</summary>
+    private static AutomationPeer? FindPageTextPeer(AutomationPeer root)
+    {
+        var stack = new Stack<AutomationPeer>();
+        stack.Push(root);
+        while (stack.Count > 0)
+        {
+            var peer = stack.Pop();
+            if (peer.GetAutomationId() == PageTextAutomationId)
+                return peer;
+            foreach (var child in peer.GetChildren())
+                stack.Push(child);
+        }
+
+        return null;
+    }
+}

--- a/Excise.Avalonia.Tests/PublicApi/Excise.Avalonia.approved.txt
+++ b/Excise.Avalonia.Tests/PublicApi/Excise.Avalonia.approved.txt
@@ -139,6 +139,7 @@ namespace Excise.Avalonia.Controls
         public void InitializeComponent(bool loadXaml = true) { }
         public void InvalidatePageCache() { }
         public void NextPage() { }
+        protected override Avalonia.Automation.Peers.AutomationPeer OnCreateAutomationPeer() { }
         public void PreviousPage() { }
         public void ZoomIn() { }
         public void ZoomOut() { }

--- a/Excise.Avalonia/Automation/PdfViewerAutomationPeer.cs
+++ b/Excise.Avalonia/Automation/PdfViewerAutomationPeer.cs
@@ -1,0 +1,119 @@
+using Avalonia.Automation;
+using Avalonia.Automation.Peers;
+using Excise.Avalonia.Controls;
+using System.Collections.Generic;
+
+namespace Excise.Avalonia.Automation;
+
+/// <summary>
+/// Automation peer for <see cref="PdfViewerControl"/> (issue #631).
+///
+/// <para>
+/// The rendered PDF page is an opaque bitmap to assistive technology: the
+/// viewer's visual children are an <c>Image</c> and overlay <c>Canvas</c>es,
+/// none of which carry the document's text. This peer inserts a synthetic
+/// <see cref="PdfPageTextAutomationPeer"/> child — first in the children list,
+/// so it is the first thing a screen reader reaches when entering the viewer —
+/// that exposes the current page's extractable text in reading order.
+/// </para>
+/// </summary>
+internal sealed class PdfViewerAutomationPeer : ControlAutomationPeer
+{
+    private readonly PdfViewerControl _viewer;
+    private PdfPageTextAutomationPeer? _textPeer;
+
+    public PdfViewerAutomationPeer(PdfViewerControl viewer)
+        : base(viewer)
+    {
+        _viewer = viewer;
+    }
+
+    protected override AutomationControlType GetAutomationControlTypeCore() =>
+        AutomationControlType.Document;
+
+    protected override IReadOnlyList<AutomationPeer>? GetChildrenCore()
+    {
+        _textPeer ??= new PdfPageTextAutomationPeer(_viewer);
+
+        var result = new List<AutomationPeer> { _textPeer };
+        var baseChildren = base.GetChildrenCore();
+        if (baseChildren != null)
+            result.AddRange(baseChildren);
+        return result;
+    }
+
+    /// <summary>
+    /// Called by the viewer when the current page's text content changed
+    /// (page navigation, document swap, or a content rewrite such as
+    /// redaction). Raises a Name property change on the synthetic text
+    /// child so screen readers pick up the new content.
+    /// </summary>
+    internal void NotifyPageTextChanged() => _textPeer?.NotifyTextChanged();
+}
+
+/// <summary>
+/// Synthetic (control-less) peer that carries the current page's extractable
+/// text so screen readers can read the document content (issue #631).
+///
+/// <para>
+/// The text is produced by the same pipeline text-selection copy uses —
+/// <c>Excise.Core</c> letter extraction sorted into geometric reading order
+/// (top-to-bottom lines, left-to-right within a line) and joined with
+/// word/line breaks. Struct-tree (tagged PDF) reading order is a follow-up
+/// slice of #631: the parsed structure tree does not yet map elements to
+/// pages or MCIDs to letters, so geometric order is used for all documents.
+/// </para>
+///
+/// <para>
+/// Avalonia has no TextPattern provider, so the content is exposed through
+/// the peer's Name — the property every platform backend (UIA, AX,
+/// AT-SPI) surfaces to screen readers.
+/// </para>
+/// </summary>
+internal sealed class PdfPageTextAutomationPeer : UnrealizedElementAutomationPeer
+{
+    private readonly PdfViewerControl _viewer;
+    private AutomationPeer? _parent;
+
+    public PdfPageTextAutomationPeer(PdfViewerControl viewer)
+    {
+        _viewer = viewer;
+    }
+
+    protected override string? GetNameCore() => _viewer.GetAccessiblePageText();
+
+    protected override AutomationControlType GetAutomationControlTypeCore() =>
+        AutomationControlType.Text;
+
+    protected override string GetClassNameCore() => "PdfPageText";
+
+    protected override string GetAutomationIdCore() => "PdfPageTextContent";
+
+    protected override string GetLocalizedControlTypeCore() => "page text";
+
+    protected override string? GetAcceleratorKeyCore() => null;
+
+    protected override string? GetAccessKeyCore() => null;
+
+    protected override AutomationPeer? GetLabeledByCore() => null;
+
+    protected override AutomationPeer? GetParentCore() => _parent;
+
+    // The base UnrealizedElementAutomationPeer refuses parents (returns
+    // false), which orphans the peer. ControlAutomationPeer's child
+    // wiring calls TrySetParent on every child it returns, so accepting
+    // here is what links this synthetic node into the tree.
+    protected override bool TrySetParent(AutomationPeer? parent)
+    {
+        _parent = parent;
+        return true;
+    }
+
+    // Unrealized peers default to invisible-to-AT (content/control element
+    // both false). This node exists solely for assistive technology.
+    protected override bool IsContentElementCore() => true;
+    protected override bool IsControlElementCore() => true;
+
+    internal void NotifyTextChanged() =>
+        RaisePropertyChangedEvent(AutomationElementIdentifiers.NameProperty, null, GetName());
+}

--- a/Excise.Avalonia/Controls/PdfViewerControl.axaml.cs
+++ b/Excise.Avalonia/Controls/PdfViewerControl.axaml.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Automation;
+using Avalonia.Automation.Peers;
 using Avalonia.Collections;
 using Avalonia.Reactive;
 using Avalonia.Controls;
@@ -999,6 +1000,74 @@ public partial class PdfViewerControl : UserControl
         AutomationProperties.SetItemStatus(this, status);
 
         AutomationProperties.SetHelpText(this, BuildViewerAutomationHelpText());
+
+        NotifyAutomationPageTextChangedIfNeeded();
+    }
+
+    /// <summary>
+    /// Expose the document content to the platform accessibility tree via a
+    /// custom peer that carries the current page's text (issue #631). The
+    /// rendered page is otherwise an opaque bitmap to screen readers.
+    /// </summary>
+    protected override AutomationPeer OnCreateAutomationPeer() =>
+        new Excise.Avalonia.Automation.PdfViewerAutomationPeer(this);
+
+    // Content identity last announced to the automation tree; used to raise a
+    // Name change on the synthetic page-text peer only when the page's text
+    // could actually have changed (page/document/content-rewrite), not on
+    // zoom or view-mode churn that also refreshes automation properties.
+    private object? _announcedTextDocument;
+    private int _announcedTextPage = -1;
+    private long _announcedTextRenderVersion = -1;
+
+    private void NotifyAutomationPageTextChangedIfNeeded()
+    {
+        if (ReferenceEquals(_announcedTextDocument, Document)
+            && _announcedTextPage == CurrentPage
+            && _announcedTextRenderVersion == RenderVersion)
+            return;
+
+        _announcedTextDocument = Document;
+        _announcedTextPage = CurrentPage;
+        _announcedTextRenderVersion = RenderVersion;
+
+        // FromElement returns null until some automation client materialized
+        // the peer — no screen reader, no cost.
+        (ControlAutomationPeer.FromElement(this) as Excise.Avalonia.Automation.PdfViewerAutomationPeer)
+            ?.NotifyPageTextChanged();
+    }
+
+    // Cache for the joined accessible page text. Keyed by reference identity
+    // of the reading-ordered letter list: every invalidation path (page
+    // change, document change, content rewrite via RenderVersion) replaces
+    // _readingOrderedLetters, so a stale join can never be returned.
+    private List<Letter>? _accessibleTextSource;
+    private string? _accessibleTextCache;
+
+    /// <summary>
+    /// The current page's extractable text in reading order, for the
+    /// accessibility tree (issue #631). Uses the same letter pipeline as
+    /// text-selection copy: geometric reading order (top-to-bottom lines,
+    /// left-to-right in a line) joined with word/line breaks. Empty when no
+    /// document is loaded or the page has no extractable text.
+    /// </summary>
+    internal string GetAccessiblePageText()
+    {
+        if (Document == null || CurrentPage < 1 || CurrentPage > Document.PageCount)
+            return string.Empty;
+
+        EnsurePageLettersLoaded();
+        var source = _readingOrderedLetters;
+        if (source == null || source.Count == 0)
+            return string.Empty;
+
+        if (!ReferenceEquals(source, _accessibleTextSource) || _accessibleTextCache == null)
+        {
+            _accessibleTextCache = TextSelectionEngine.JoinText(source);
+            _accessibleTextSource = source;
+        }
+
+        return _accessibleTextCache;
     }
 
     private string BuildViewerAutomationHelpText()
@@ -1225,6 +1294,11 @@ public partial class PdfViewerControl : UserControl
         {
             _ = RenderCurrentPageAsync();
         }
+
+        // A RenderVersion bump means the page content was rewritten (e.g. a
+        // redaction was applied) — the accessible page text must follow
+        // (issue #631).
+        NotifyAutomationPageTextChangedIfNeeded();
     }
 
     private void RefreshPageAnnotations()


### PR DESCRIPTION
First slice of #631 (investigated + implemented with the Fable model). PDF page content was an opaque bitmap to assistive technology — the struct tree is parsed but never exposed and the viewer had no AutomationPeer over page content.

## What this does
A screen reader entering the PDF viewer now reaches the current page's text. New `PdfViewerAutomationPeer` (control type Document) inserts a synthetic `PdfPageTextAutomationPeer` (control type Text) as its first automation child, whose Name is the current page's extractable text in reading order — produced by the same Excise.Core letter-extraction + geometric-reading-order pipeline text-selection copy uses. Name-changed events fire on page navigation, document swap, and content rewrites (redaction). Correctly handles the `UnrealizedElementAutomationPeer` parent/content-element wiring so the node is actually AT-visible (UIA/AX/AT-SPI surface `Name`).

## Scope
Geometric reading order (struct-tree/tagged-PDF order needs `/StructParents` reverse lookup + MCID→letter mapping — a follow-up slice). No PDF/UA or PDF/A validators yet.

## Verification
New `PdfViewerContentAccessibilityTests` (3 tests) assert the page text is **reachable by walking the automation tree** (not just that a peer exists) — reading order, page-navigation tracking, empty without a document. `scripts/run-accessibility-smoke.sh` PASS; 13 accessibility tests green; existing `PdfViewerControlTests` + `Excise.Avalonia.Tests` green; t0 all green; 0 warnings.

## Remaining slices (on #631)
struct-tree reading order · per-element peers (headings/lists/tables/figures) · keyboard structure navigation + live announcements · PDF/UA + PDF/A validators · live VoiceOver/NVDA verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)