### PR TITLE
fix(text): embedded-cmap GID→Unicode for embedded Identity-H CID fonts with no /ToUnicode (#515 slice 3)

### DIFF
--- a/Excise.Core.Tests/Fixtures/TestFontFixtures.cs
+++ b/Excise.Core.Tests/Fixtures/TestFontFixtures.cs
@@ -19,6 +19,9 @@ internal static class TestFontFixtures
     /// <summary>A CFF-flavored OpenType ('OTTO') fixture — Libertinus Serif, SIL OFL 1.1.</summary>
     public static byte[] LoadLibertinusSerifCffBytes() => LoadEmbedded("LibertinusSerif-Regular.otf");
 
+    /// <summary>A raw (unwrapped, name-keyed) CFF fixture — Inconsolata, SIL OFL 1.1.</summary>
+    public static byte[] LoadInconsolataCffBytes() => LoadEmbedded("Inconsolata.cff");
+
     private static byte[] LoadEmbedded(string fileName)
     {
         var asm = Assembly.GetExecutingAssembly();

--- a/Excise.Core.Tests/Text/EmbeddedCidReverseCmapTests.cs
+++ b/Excise.Core.Tests/Text/EmbeddedCidReverseCmapTests.cs
@@ -1,0 +1,253 @@
+using System.IO;
+using System.Linq;
+using System.Text;
+using AwesomeAssertions;
+using Excise.Core.Document;
+using Excise.Core.Fonts;
+using Excise.Core.Text;
+using Excise.Core.Tests.Fixtures;
+using Xunit;
+
+namespace Excise.Core.Tests.Text;
+
+/// <summary>
+/// #515 slice 3 — GID→Unicode via the EMBEDDED font program's own character
+/// map, read in reverse, for Type0 + Identity-H/V fonts with NO /ToUnicode.
+///
+/// This class of font previously extracted as garbage: #532's
+/// standard-Mac-glyph-order fallback is deliberately scoped to NON-embedded
+/// fonts (embedded subset glyph orders are arbitrary, so a Mac-order guess
+/// would corrupt them), so embedded Identity-H no-ToUnicode text fell through
+/// to DecodeWinAnsi(rawGID). Garbled extraction is a silent redaction failure
+/// (CLAUDE.md limitation #1: excise cannot redact what it cannot read).
+///
+/// Every fixture here is GENERATED at test time around a real, checked-in
+/// font program (DejaVu Sans TTF / Inconsolata CFF / Libertinus OTTO), with
+/// the content-stream codes computed FROM the font's own tables — no
+/// hard-coded GIDs, and a genuine red→green: pre-fix, each positive test's
+/// extraction is raw-GID garbage.
+/// </summary>
+public class EmbeddedCidReverseCmapTests
+{
+    private const string Word = "Redact";
+
+    // ---------- /FontFile2 (CIDFontType2, TrueType) ----------
+
+    [Fact] // pre-fix: extracts raw GIDs as Latin-1 garbage
+    public void EmbeddedTrueType_IdentityH_NoToUnicode_ExtractsViaReverseCmap()
+    {
+        var font = TestFontFixtures.LoadDejaVuSansBytes();
+        var gids = GidsFor(font, Word);
+
+        var pdf = BuildEmbeddedType0Pdf(font, fontFileKey: "FontFile2",
+            codes: gids, toUnicode: null, cidToGidMap: null);
+
+        Extract(pdf).Should().Contain(Word,
+            "an embedded Identity-H CIDFontType2 with no /ToUnicode must decode via the " +
+            "embedded TrueType cmap read in reverse (GID→Unicode), not raw-GID WinAnsi");
+    }
+
+    [Fact] // /CIDToGIDMap stream: code→CID→GID must be applied before the reverse cmap
+    public void EmbeddedTrueType_CidToGidMapStream_IsAppliedBeforeReverseCmap()
+    {
+        var font = TestFontFixtures.LoadDejaVuSansBytes();
+        var gids = GidsFor(font, Word);
+
+        // CIDs 1..N remap to the word's GIDs via a CIDToGIDMap stream. The
+        // content stream uses the low CIDs — decoding them correctly requires
+        // honoring the stream (identity CID==GID would hit unrelated glyphs).
+        var cidToGid = new byte[(gids.Length + 1) * 2];
+        for (int i = 0; i < gids.Length; i++)
+        {
+            cidToGid[(i + 1) * 2] = (byte)(gids[i] >> 8);
+            cidToGid[(i + 1) * 2 + 1] = (byte)(gids[i] & 0xFF);
+        }
+        var codes = Enumerable.Range(1, gids.Length).ToArray();
+
+        var pdf = BuildEmbeddedType0Pdf(font, fontFileKey: "FontFile2",
+            codes: codes, toUnicode: null, cidToGidMap: cidToGid);
+
+        Extract(pdf).Should().Contain(Word,
+            "a /CIDToGIDMap stream maps code→CID→GID; the reverse-cmap lookup must key on the GID");
+    }
+
+    [Fact] // guard: a /ToUnicode stream always outranks the embedded reverse cmap
+    public void ToUnicodeStream_IsNotOverriddenByEmbeddedReverseCmap()
+    {
+        var font = TestFontFixtures.LoadDejaVuSansBytes();
+        var gids = GidsFor(font, "R");
+
+        // ToUnicode says this code is "Z" — the producer's declared map wins
+        // even though the embedded cmap says the GID is "R".
+        var toUnicode = "/CIDInit /ProcSet findresource begin\n12 dict begin\nbegincmap\n" +
+            "1 begincodespacerange\n<0000> <FFFF>\nendcodespacerange\n" +
+            $"1 beginbfchar\n<{gids[0]:X4}> <005A>\nendbfchar\nendcmap\nend end";
+
+        var pdf = BuildEmbeddedType0Pdf(font, fontFileKey: "FontFile2",
+            codes: gids, toUnicode: toUnicode, cidToGidMap: null);
+
+        var text = Extract(pdf);
+        text.Should().Contain("Z", "/ToUnicode is the producer's declared map and has priority");
+        text.Should().NotContain("R", "the embedded reverse cmap must not override /ToUnicode");
+    }
+
+    [Fact] // codes the embedded cmap can't resolve keep the pre-existing fallback (don't invent)
+    public void UnmappedGid_FallsThroughToExistingBehavior()
+    {
+        var font = TestFontFixtures.LoadDejaVuSansBytes();
+        var known = GidsFor(font, "A");
+        var unmapped = 0xFFFE; // far beyond any real DejaVu GID
+
+        var pdf = BuildEmbeddedType0Pdf(font, fontFileKey: "FontFile2",
+            codes: new[] { known[0], unmapped }, toUnicode: null, cidToGidMap: null);
+
+        // Must not throw, and the mapped code must still decode.
+        Extract(pdf).Should().Contain("A");
+    }
+
+    // ---------- /FontFile3 (CIDFontType0, CFF) ----------
+
+    [Fact] // raw name-keyed CFF: GID→glyph-name→Unicode via the AGL
+    public void EmbeddedRawCff_IdentityH_NoToUnicode_ExtractsViaGlyphNames()
+    {
+        var cff = TestFontFixtures.LoadInconsolataCffBytes();
+        var info = CffParser.Parse(cff);
+        Assert.NotNull(info);
+        info!.IsCidKeyed.Should().BeFalse("Inconsolata.cff is a name-keyed CFF");
+
+        // Per §9.7.4.2, a non-CID-keyed CFF descendant uses the CID directly
+        // as glyph index — compute the glyph indices from the charset.
+        //
+        // Deliberately NOT plain ASCII letters: this fixture's glyph order
+        // mirrors Latin-1 for those (GID('R') == 0x52), so the raw-GID WinAnsi
+        // fallback would pass by coincidence and the test would prove nothing.
+        // These glyphs sit at indices with no Latin-1 relationship at all.
+        var glyphs = new[] { "OE", "ellipsis", "bullet", "dagger" };
+        var codes = glyphs.Select(n => info.GlyphNameToIndex[n]).ToArray();
+
+        var pdf = BuildEmbeddedType0Pdf(cff, fontFileKey: "FontFile3",
+            codes: codes, toUnicode: null, cidToGidMap: null,
+            descendantSubtype: "CIDFontType0", fontFileSubtype: "Type1C");
+
+        Extract(pdf).Should().Contain("Œ…•†",
+            "an embedded name-keyed CFF resolves GID→glyph-name→Unicode via the Adobe Glyph List");
+    }
+
+    [Fact] // OpenType-wrapped CFF ('OTTO'): the sfnt cmap is the Unicode source
+    public void EmbeddedOpenTypeCff_IdentityH_NoToUnicode_ExtractsViaSfntCmap()
+    {
+        var otf = TestFontFixtures.LoadLibertinusSerifCffBytes();
+        var gids = GidsFor(otf, Word);
+
+        var pdf = BuildEmbeddedType0Pdf(otf, fontFileKey: "FontFile3",
+            codes: gids, toUnicode: null, cidToGidMap: null,
+            descendantSubtype: "CIDFontType0", fontFileSubtype: "OpenType");
+
+        Extract(pdf).Should().Contain(Word,
+            "an OpenType-wrapped CFF exposes its sfnt cmap; reversed, it is the GID→Unicode source");
+    }
+
+    // ---------- helpers ----------
+
+    private static int[] GidsFor(byte[] sfntFont, string word)
+    {
+        var ttf = TrueTypeFontFile.Parse(sfntFont);
+        return word.Select(c =>
+        {
+            var gid = ttf.GidForCodepoint(c);
+            gid.Should().BeGreaterThan(0, $"fixture font must map '{c}'");
+            return gid;
+        }).ToArray();
+    }
+
+    private static string Extract(byte[] pdf)
+    {
+        using var doc = PdfDocument.Open(new MemoryStream(pdf));
+        return new TextExtractor(doc.GetPage(1)).ExtractText();
+    }
+
+    /// <summary>
+    /// Builds a single-page PDF with a Type0 / Identity-H font whose descendant
+    /// embeds <paramref name="fontFile"/> and (deliberately) has NO /ToUnicode
+    /// unless one is passed. The content stream shows the 2-byte
+    /// <paramref name="codes"/> as one hex string. Binary-safe (the font bytes
+    /// are written raw), unlike the ASCII-only builders in
+    /// <see cref="TextExtractorType0Tests"/>.
+    /// </summary>
+    private static byte[] BuildEmbeddedType0Pdf(
+        byte[] fontFile, string fontFileKey, int[] codes, string? toUnicode,
+        byte[]? cidToGidMap, string descendantSubtype = "CIDFontType2",
+        string? fontFileSubtype = null)
+    {
+        var ms = new MemoryStream();
+        var offsets = new long[11];
+        void Ascii(string s)
+        {
+            var b = Encoding.ASCII.GetBytes(s);
+            ms.Write(b, 0, b.Length);
+        }
+        void Obj(int n) => offsets[n] = ms.Length;
+
+        var hex = string.Concat(codes.Select(c => c.ToString("X4")));
+        var content = $"BT /F0 24 Tf 72 700 Td <{hex}> Tj ET";
+
+        Ascii("%PDF-1.7\n");
+        Obj(1); Ascii("1 0 obj <</Type/Catalog/Pages 2 0 R>> endobj\n");
+        Obj(2); Ascii("2 0 obj <</Type/Pages/Count 1/Kids[3 0 R]>> endobj\n");
+        Obj(3); Ascii("3 0 obj <</Type/Page/Parent 2 0 R/MediaBox[0 0 612 792]" +
+                      "/Resources<</Font<</F0 4 0 R>>>>/Contents 9 0 R>> endobj\n");
+
+        Obj(4);
+        Ascii("4 0 obj <</Type/Font/Subtype/Type0/BaseFont/Test" +
+              "/Encoding/Identity-H/DescendantFonts[5 0 R]" +
+              (toUnicode != null ? "/ToUnicode 10 0 R" : "") + ">> endobj\n");
+
+        Obj(5);
+        Ascii($"5 0 obj <</Type/Font/Subtype/{descendantSubtype}/BaseFont/Test" +
+              "/CIDSystemInfo<</Registry(Adobe)/Ordering(Identity)/Supplement 0>>" +
+              "/FontDescriptor 6 0 R/DW 1000" +
+              (cidToGidMap != null ? "/CIDToGIDMap 8 0 R" : "") + ">> endobj\n");
+
+        Obj(6);
+        Ascii("6 0 obj <</Type/FontDescriptor/FontName/Test/Flags 4" +
+              "/FontBBox[0 0 1000 1000]/ItalicAngle 0/Ascent 800/Descent -200" +
+              $"/CapHeight 700/StemV 80/{fontFileKey} 7 0 R>> endobj\n");
+
+        Obj(7);
+        Ascii($"7 0 obj <</Length {fontFile.Length}" +
+              (fontFileKey == "FontFile2" ? $"/Length1 {fontFile.Length}" : "") +
+              (fontFileSubtype != null ? $"/Subtype/{fontFileSubtype}" : "") +
+              ">>\nstream\n");
+        ms.Write(fontFile, 0, fontFile.Length);
+        Ascii("\nendstream endobj\n");
+
+        if (cidToGidMap != null)
+        {
+            Obj(8);
+            Ascii($"8 0 obj <</Length {cidToGidMap.Length}>>\nstream\n");
+            ms.Write(cidToGidMap, 0, cidToGidMap.Length);
+            Ascii("\nendstream endobj\n");
+        }
+
+        Obj(9);
+        Ascii($"9 0 obj <</Length {content.Length}>>\nstream\n{content}\nendstream endobj\n");
+
+        if (toUnicode != null)
+        {
+            Obj(10);
+            Ascii($"10 0 obj <</Length {toUnicode.Length}>>\nstream\n{toUnicode}\nendstream endobj\n");
+        }
+
+        var xref = ms.Length;
+        Ascii("xref\n0 11\n0000000000 65535 f \n");
+        for (int i = 1; i <= 10; i++)
+        {
+            if (offsets[i] == 0)
+                Ascii("0000000000 65535 f \n");
+            else
+                Ascii(offsets[i].ToString("D10") + " 00000 n \n");
+        }
+        Ascii($"trailer <</Size 11/Root 1 0 R>>\nstartxref\n{xref}\n%%EOF\n");
+        return ms.ToArray();
+    }
+}

--- a/Excise.Core.Tests/Text/EncodingResidualClassificationTests.cs
+++ b/Excise.Core.Tests/Text/EncodingResidualClassificationTests.cs
@@ -92,6 +92,12 @@ public class EncodingResidualClassificationTests
         // reference to match against. This test documents the classification
         // (not a correctness assertion) — full CMap/CID coverage is tracked in
         // #515. It must at least not crash or return empty.
+        //
+        // #515 slice 3 (embedded-cmap reverse lookup) verified this fixture
+        // contains ZERO embedded font programs (no /FontFile* anywhere), so it
+        // is permanently outside that fix's scope: with neither a /ToUnicode
+        // nor an embedded program, the GID→Unicode bridge simply does not
+        // exist in the file. Extraction is byte-identical before/after slice 3.
         Extract("issue13916.pdf").Should().NotBeNullOrEmpty(
             "extraction must still produce output (routing to #515 for correct decoding)");
     }

--- a/Excise.Core/Text/TextExtractor.cs
+++ b/Excise.Core/Text/TextExtractor.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using System.Text;
 using Excise.Core.Document;
+using Excise.Core.Fonts;
 using Excise.Core.Primitives;
 
 namespace Excise.Core.Text;
@@ -29,6 +30,18 @@ public class TextExtractor
     // program the only GID→Unicode bridge is the standard Macintosh glyph order
     // (#532; see DecodeCharacter). Recomputed on each /Tf.
     private bool _useStandardMacGlyphOrder;
+    // For an EMBEDDED Type0 font with Identity-H/V encoding and no /ToUnicode
+    // (#515 slice 3): code (CID) → Unicode recovered by reading the embedded
+    // font program's own character map in REVERSE (Unicode→GID becomes
+    // GID→Unicode; CIDToGIDMap applied first when present). Embedded subset
+    // glyph orders are arbitrary, so #532's standard-Mac-order guess is
+    // deliberately scoped to NON-embedded fonts — without this map, embedded
+    // Identity-H text fell through to DecodeWinAnsi(rawGID) = garbage, which
+    // is a silent redaction failure (excise cannot redact what it cannot
+    // read). Null when the current font is out of scope or the embedded
+    // program yields nothing. Recomputed on each /Tf (cached per font dict).
+    private Dictionary<int, string>? _embeddedCidToUnicode;
+    private readonly Dictionary<PdfDictionary, Dictionary<int, string>?> _embeddedCidToUnicodeCache = new(ReferenceEqualityComparer.Instance);
     // True when /ToUnicode is the predefined-CMap NAME /Identity-H or /Identity-V
     // (not a stream): the 2-byte code IS the UTF-16BE Unicode scalar, so it must
     // be decoded directly rather than left to the WinAnsi fallback (which is only
@@ -858,6 +871,7 @@ public class TextExtractor
                     (_differencesGlyphNames, _differencesBaseEncoding) = LoadDifferencesEncoding(_currentFont);
                     _toUnicodeIdentity = _toUnicodeMap == null && ToUnicodeIsIdentity(_currentFont);
                     _useStandardMacGlyphOrder = _toUnicodeMap == null && UsesStandardMacGlyphOrderFallback(_currentFont);
+                    _embeddedCidToUnicode = _toUnicodeMap == null ? LoadEmbeddedCidToUnicodeMap(_currentFont) : null;
                     LoadFontGeometry();
                 }
                 break;
@@ -1490,6 +1504,18 @@ public class TextExtractor
             return ((char)charCode).ToString();
         }
 
+        // Embedded Type0 + Identity-H/V + no /ToUnicode (#515 slice 3): the
+        // 2-byte code is a CID whose GID lives in the EMBEDDED font program,
+        // so the program's own cmap/charset — read in reverse — is the
+        // authoritative GID→Unicode source (higher priority than any
+        // glyph-order guess; #532's Mac-order fallback stays scoped to
+        // non-embedded fonts). Codes the embedded map doesn't cover fall
+        // through to the existing behavior rather than inventing a mapping.
+        if (_embeddedCidToUnicode != null && _embeddedCidToUnicode.TryGetValue(charCode, out var embeddedUnicode))
+        {
+            return embeddedUnicode;
+        }
+
         // /Encoding << /Differences [...] >> (#662): a Differences entry for
         // this exact code overrides everything below it — the glyph name it
         // assigns takes priority over both /BaseEncoding and the bare-name
@@ -1606,6 +1632,256 @@ public class TextExtractor
             || fd.GetOptional("FontFile") != null;
         return !embedded;
     }
+
+    /// <summary>
+    /// For an EMBEDDED Type0 font with Identity-H/V encoding and no
+    /// <c>/ToUnicode</c> (#515 slice 3), builds a code (CID) → Unicode map by
+    /// reading the embedded font program's own character map in REVERSE:
+    /// <list type="bullet">
+    /// <item><c>/FontFile2</c> (CIDFontType2 TrueType): the font's cmap table is
+    /// Unicode→GID; reversed it is GID→Unicode. <c>/CIDToGIDMap</c> is honored —
+    /// for a stream, code→CID→GID first; for <c>/Identity</c> (or absent),
+    /// CID == GID.</item>
+    /// <item><c>/FontFile3</c> (CIDFontType0 CFF): a non-CID-keyed CFF names its
+    /// glyphs, so GID→name→Unicode via the Adobe Glyph List (per §9.7.4.2 the CID
+    /// is the glyph index directly); a CID-keyed CFF has no glyph names, so
+    /// Unicode is only recoverable from an OpenType wrapper's sfnt cmap
+    /// (charset gives CID→GID).</item>
+    /// </list>
+    /// Returns null when the font is out of scope (non-Type0, has /ToUnicode,
+    /// non-Identity encoding, not embedded) or the embedded program yields no
+    /// mappings — callers then fall through to the pre-existing behavior.
+    /// Scope mirrors #532's guards exactly, on the opposite (embedded) side.
+    /// </summary>
+    private Dictionary<int, string>? LoadEmbeddedCidToUnicodeMap(PdfDictionary? font)
+    {
+        if (font == null || font.GetNameOrNull("Subtype") != "Type0")
+            return null;
+
+        // A present /ToUnicode (stream or predefined name) is the producer's
+        // declared map and wins; this path is only for fonts with none at all.
+        if (font.GetOptional("ToUnicode") != null)
+            return null;
+
+        var enc = _page.Document.Resolve(font.GetOptional("Encoding") ?? PdfNull.Instance);
+        if (enc is not PdfName encName || (encName.Value != "Identity-H" && encName.Value != "Identity-V"))
+            return null;
+
+        if (_embeddedCidToUnicodeCache.TryGetValue(font, out var cached))
+            return cached;
+
+        Dictionary<int, string>? map = null;
+        try
+        {
+            var descObj = _page.Document.Resolve(font.GetOptional("DescendantFonts") ?? PdfNull.Instance);
+            var descendant = descObj switch
+            {
+                PdfArray arr when arr.Count > 0 => _page.Document.Resolve(arr[0]) as PdfDictionary,
+                PdfDictionary d => d,
+                _ => null,
+            };
+            if (descendant != null
+                && _page.Document.Resolve(descendant.GetOptional("FontDescriptor") ?? PdfNull.Instance)
+                    is PdfDictionary fd)
+            {
+                if (_page.Document.Resolve(fd.GetOptional("FontFile2") ?? PdfNull.Instance) is PdfStream ff2)
+                    map = BuildCidToUnicodeFromTrueType(ff2.DecodedData, descendant);
+                else if (_page.Document.Resolve(fd.GetOptional("FontFile3") ?? PdfNull.Instance) is PdfStream ff3)
+                    map = BuildCidToUnicodeFromCff(ff3.DecodedData);
+            }
+        }
+        catch (Exception ex) when (ex is not OutOfMemoryException)
+        {
+            // Malformed/truncated embedded program — fall back to existing
+            // behavior rather than failing extraction.
+            map = null;
+        }
+
+        if (map is { Count: 0 })
+            map = null;
+        _embeddedCidToUnicodeCache[font] = map;
+        return map;
+    }
+
+    /// <summary>
+    /// GID→Unicode for an embedded TrueType program (reverse of its cmap),
+    /// re-keyed by CID through <c>/CIDToGIDMap</c> when that is a stream.
+    /// Returns null when the program has no usable cmap (common for subsets
+    /// that drop it — exactly the case where no mapping should be invented).
+    /// </summary>
+    private Dictionary<int, string>? BuildCidToUnicodeFromTrueType(byte[] fontData, PdfDictionary descendant)
+    {
+        TrueTypeFontFile ttf;
+        try
+        {
+            ttf = TrueTypeFontFile.Parse(fontData);
+        }
+        catch (NotSupportedException)
+        {
+            return null; // no cmap table / unsupported flavor
+        }
+
+        var gidToCodepoint = ReverseCmap(ttf.Cmap);
+        if (gidToCodepoint.Count == 0)
+            return null;
+
+        // /CIDToGIDMap stream: 2 bytes per CID, big-endian GID. Map
+        // code→CID→GID before the reverse-cmap lookup. /Identity or absent
+        // means CID == GID.
+        var cidToGidObj = descendant.GetOptional("CIDToGIDMap");
+        if (cidToGidObj != null && _page.Document.Resolve(cidToGidObj) is PdfStream cidToGidStream)
+        {
+            var data = cidToGidStream.DecodedData;
+            var byCid = new Dictionary<int, string>();
+            int count = data.Length / 2;
+            for (int cid = 0; cid < count; cid++)
+            {
+                int gid = (data[cid * 2] << 8) | data[cid * 2 + 1];
+                if (gid != 0 && gidToCodepoint.TryGetValue(gid, out var cp))
+                    byCid[cid] = char.ConvertFromUtf32(cp);
+            }
+            return byCid;
+        }
+
+        var byGid = new Dictionary<int, string>(gidToCodepoint.Count);
+        foreach (var (gid, cp) in gidToCodepoint)
+            byGid[gid] = char.ConvertFromUtf32(cp);
+        return byGid;
+    }
+
+    /// <summary>
+    /// CID→Unicode for an embedded /FontFile3 program: raw CFF (Subtype
+    /// /Type1C or /CIDFontType0C) or OpenType-wrapped CFF (Subtype /OpenType).
+    /// </summary>
+    private static Dictionary<int, string>? BuildCidToUnicodeFromCff(byte[] fontData)
+    {
+        // OpenType wrapper: its sfnt cmap is a direct Unicode→GID map (reverse
+        // it), and the raw CFF table inside carries the charset/CID data.
+        Dictionary<int, int>? gidToCodepoint = null;
+        byte[]? cff = fontData;
+        if (fontData.Length >= 4 && IsSfnt(ReadU32(fontData, 0)))
+        {
+            try
+            {
+                gidToCodepoint = ReverseCmap(TrueTypeFontFile.Parse(fontData).Cmap);
+            }
+            catch (NotSupportedException)
+            {
+                gidToCodepoint = null;
+            }
+            cff = ExtractSfntTable(fontData, "CFF ");
+        }
+
+        var info = cff != null ? CffParser.Parse(cff) : null;
+        var result = new Dictionary<int, string>();
+
+        if (info is { IsCidKeyed: true })
+        {
+            // CID-keyed CFF: charset gives CID→GID, but glyphs have no names —
+            // Unicode is only recoverable via an sfnt cmap (OpenType wrapper).
+            if (gidToCodepoint == null || info.CidToGlyph == null)
+                return null;
+            foreach (var (cid, gid) in info.CidToGlyph)
+            {
+                if (gid != 0 && gidToCodepoint.TryGetValue(gid, out var cp))
+                    result[cid] = char.ConvertFromUtf32(cp);
+            }
+            return result;
+        }
+
+        if (info != null && info.GlyphNames.Length > 0)
+        {
+            // Non-CID-keyed CFF as a CIDFontType0 descendant: per §9.7.4.2 the
+            // CID is used directly as the glyph index. GID→name→Unicode via
+            // the AGL / uniXXXX convention; sfnt cmap as a secondary source.
+            for (int gid = 1; gid < info.GlyphNames.Length; gid++)
+            {
+                var name = info.GlyphNames[gid];
+                if (!string.IsNullOrEmpty(name))
+                {
+                    var unicode = GlyphNameToUnicode(name);
+                    if (unicode != null)
+                    {
+                        result[gid] = unicode;
+                        continue;
+                    }
+                }
+                if (gidToCodepoint != null && gidToCodepoint.TryGetValue(gid, out var cp))
+                    result[gid] = char.ConvertFromUtf32(cp);
+            }
+            return result;
+        }
+
+        // No usable CFF info; fall back to the sfnt cmap alone (CID == GID).
+        if (gidToCodepoint != null)
+        {
+            foreach (var (gid, cp) in gidToCodepoint)
+                result[gid] = char.ConvertFromUtf32(cp);
+            return result;
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Reverses a font cmap (Unicode codepoint → GID) into GID → codepoint.
+    /// When several codepoints share a GID, a non-Private-Use codepoint beats a
+    /// Private-Use one, then the smaller codepoint wins — deterministic, and
+    /// avoids emitting PUA garbage when a subset also maps a real character.
+    /// </summary>
+    private static Dictionary<int, int> ReverseCmap(IReadOnlyDictionary<int, int> unicodeToGid)
+    {
+        var gidToCodepoint = new Dictionary<int, int>();
+        foreach (var (cp, gid) in unicodeToGid)
+        {
+            if (gid == 0 || cp <= 0 || cp > 0x10FFFF || (cp >= 0xD800 && cp <= 0xDFFF))
+                continue;
+            if (!gidToCodepoint.TryGetValue(gid, out var existing) || PreferCodepoint(cp, existing))
+                gidToCodepoint[gid] = cp;
+        }
+        return gidToCodepoint;
+    }
+
+    private static bool PreferCodepoint(int candidate, int existing)
+    {
+        bool candidatePua = IsPrivateUse(candidate);
+        bool existingPua = IsPrivateUse(existing);
+        if (candidatePua != existingPua)
+            return existingPua; // prefer the non-PUA codepoint
+        return candidate < existing;
+    }
+
+    private static bool IsPrivateUse(int cp) =>
+        (cp >= 0xE000 && cp <= 0xF8FF) || cp >= 0xF0000;
+
+    private static bool IsSfnt(int sfntVersion) =>
+        sfntVersion == 0x4F54544F   // 'OTTO' (CFF-based OpenType)
+        || sfntVersion == 0x00010000
+        || sfntVersion == 0x74727565; // 'true'
+
+    /// <summary>Extracts a table's bytes from an sfnt (OpenType) container, or null.</summary>
+    private static byte[]? ExtractSfntTable(byte[] data, string tag)
+    {
+        if (data.Length < 12 || tag.Length != 4)
+            return null;
+        int numTables = (data[4] << 8) | data[5];
+        for (int i = 0, p = 12; i < numTables && p + 16 <= data.Length; i++, p += 16)
+        {
+            if (data[p] == tag[0] && data[p + 1] == tag[1] && data[p + 2] == tag[2] && data[p + 3] == tag[3])
+            {
+                int offset = ReadU32(data, p + 8);
+                int length = ReadU32(data, p + 12);
+                if (offset < 0 || length <= 0 || (long)offset + length > data.Length)
+                    return null;
+                var table = new byte[length];
+                Array.Copy(data, offset, table, 0, length);
+                return table;
+            }
+        }
+        return null;
+    }
+
+    private static int ReadU32(byte[] data, int offset) =>
+        (data[offset] << 24) | (data[offset + 1] << 16) | (data[offset + 2] << 8) | data[offset + 3];
 
     /// <summary>
     /// Loads a simple font's <c>/Encoding &lt;&lt; /BaseEncoding ... /Differences [...] &gt;&gt;</c>


### PR DESCRIPTION
Slice 3 of #515 (Fable-implemented, independently re-verified). Redaction-security: for an EMBEDDED Type0 font (CIDFontType2/CIDFontType0) with Identity-H/V and no /ToUnicode, extraction had no GID→Unicode source and garbled — a silent redaction risk (CLAUDE.md limitation #1). #532's Mac-glyph-order fallback is scoped to NON-embedded only.

## Fix
`DecodeCharacter` now builds a code→Unicode map by reading the **embedded program's cmap in reverse**:
- **/FontFile2 (TrueType):** reverse `TrueTypeFontFile.Cmap` (Unicode→GID), non-PUA-preferring/deterministic; honors a `/CIDToGIDMap` stream (code→CID→GID first).
- **/FontFile3 (CFF):** name-keyed via `CffParser` charset → AGL/uniXXXX; OTTO-wrapped CFF via the sfnt cmap (incl. CID-keyed charset CID→GID).
- Guards mirror #532 exactly (embedded + Identity + no /ToUnicode only); a present /ToUnicode always wins; unmapped codes fall through unchanged; per-font cache; malformed/cmap-less subsets degrade to prior behavior.

## Verification (no self-oracle)
- New `EmbeddedCidReverseCmapTests` (6): fixtures generated around real checked-in fonts with codes computed from the font's own tables (ground truth by construction). **5/6 fail pre-fix, 6/6 pass post-fix** (6th is the /ToUnicode-priority guard). A self-deceiving test (Inconsolata's ASCII order mirrors Latin-1) was caught and replaced with discriminating glyphs (Œ/…/•/†). Cross-check: mutool emits U+FFFD on the DejaVu fixture — excise now decodes a class mutool can't.
- **issue13916 honest verdict:** it contains **zero embedded font programs** — with neither /ToUnicode nor a FontFile there is no GID→Unicode bridge in the file; extraction is byte-identical before/after and it stays "no reliable ground truth" (not fixable by data the file doesn't carry). Not forced.
- Gates: #645 parity PASS (332 pages ≥ floor, 98.7% held); 319 Core extraction/redaction tests green; t0 all green; 0 warnings.

## Remaining #515
Registered CJK CMaps as /Encoding and /ToUnicode (needs Adobe predefined-CMap resources — re-scoped effort:large under #715); CMap parser edge cases; /W2//DW2 vertical metrics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)