### PR TITLE
fix(redaction): complete search/redaction Unicode-normalization family — NFC, diacritics, invisible separators, fullwidth (#724 #725 #726 #727)

### DIFF
--- a/Excise.App.Tests/Unit/CanonicalAccentSearchTests.cs
+++ b/Excise.App.Tests/Unit/CanonicalAccentSearchTests.cs
@@ -1,0 +1,102 @@
+using AwesomeAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Excise.App.Services;
+using Excise.App.Tests.Utilities;
+using Excise.Core.Document;
+using Xunit;
+
+namespace Excise.App.Tests.Unit;
+
+/// <summary>
+/// Search must treat the two canonically EQUIVALENT Unicode spellings of
+/// accented text as the same (#724): precomposed ("café") and
+/// decomposed ("cafe" + combining acute U+0301). The fixture's /ToUnicode
+/// maps character codes to c,a,f,e,U+0301 so extraction yields the
+/// decomposed spelling, and only canonical (NFC) folding can bridge it to
+/// the typed precomposed needle. Canonical sibling of
+/// LatinLigatureSearchTests (#722) / ArabicPresentationFormSearchTests
+/// (#632).
+/// </summary>
+public class CanonicalAccentSearchTests
+{
+    /// <summary>What a user types: precomposed é (U+00E9).</summary>
+    private const string PrecomposedWord = "caf\u00E9";
+
+    /// <summary>What the page stores/extracts: e + combining acute.</summary>
+    private const string DecomposedWord = "cafe\u0301";
+
+    private static readonly int[] DecomposedScalars = { 'c', 'a', 'f', 'e', 0x0301 };
+
+    private static PdfSearchService NewService() =>
+        new(NullLogger<PdfSearchService>.Instance);
+
+    [Fact]
+    public void SearchInPage_PrecomposedNeedle_FindsDecomposedWord()
+    {
+        using var doc = PdfDocument.Open(ToUnicodePdfFixture.Build(DecomposedScalars));
+        var page = doc.GetPage(1);
+
+        // Anti-vacuity: the page really carries the decomposed spelling.
+        page.Text.Should().Contain(DecomposedWord);
+        page.Text.Should().NotContain(PrecomposedWord);
+
+        var matches = NewService().SearchInPage(page, PrecomposedWord, pageIndex: 0);
+
+        matches.Should().NotBeEmpty(
+            "a precomposed needle must find canonically equivalent decomposed text");
+        var match = matches[0];
+        match.Width.Should().BeGreaterThan(0, "the match must map back to word bounds");
+        match.MatchedText.Should().Be(PrecomposedWord,
+            "matched text is reported in the folded (NFC) space the search ran in");
+    }
+
+    [Fact]
+    public void SearchInPage_WholeWord_PrecomposedNeedle_FindsDecomposedWord()
+    {
+        using var doc = PdfDocument.Open(ToUnicodePdfFixture.Build(DecomposedScalars));
+        var page = doc.GetPage(1);
+
+        var matches = NewService().SearchInPage(page, PrecomposedWord, wholeWordsOnly: true);
+
+        matches.Should().NotBeEmpty(
+            "whole-word comparison must fold both the word and the needle to NFC");
+    }
+
+    [Fact]
+    public void SearchInPage_Regex_PrecomposedPattern_FindsDecomposedWord()
+    {
+        using var doc = PdfDocument.Open(ToUnicodePdfFixture.Build(DecomposedScalars));
+        var page = doc.GetPage(1);
+
+        var matches = NewService().SearchInPage(page, "caf\u00E9?", useRegex: true);
+
+        matches.Should().NotBeEmpty(
+            "the regex path folds the page text so precomposed patterns match decomposed text");
+    }
+
+    [Fact]
+    public void SearchInPage_DecomposedNeedle_AlsoFindsDecomposedWord()
+    {
+        using var doc = PdfDocument.Open(ToUnicodePdfFixture.Build(DecomposedScalars));
+        var page = doc.GetPage(1);
+
+        var matches = NewService().SearchInPage(page, DecomposedWord, pageIndex: 0);
+
+        matches.Should().NotBeEmpty("both sides fold, so a decomposed needle matches too");
+    }
+
+    [Fact]
+    public void SearchInPage_UnaccentedNeedle_DoesNotFindPrecomposedWord()
+    {
+        // Scope guard: canonical folding must not become accent-insensitive
+        // matching — "cafe" is not canonically equivalent to "café".
+        using var doc = PdfDocument.Open(
+            ToUnicodePdfFixture.Build(new[] { 'c', 'a', 'f', 0x00E9 }));
+        var page = doc.GetPage(1);
+
+        var matches = NewService().SearchInPage(page, "cafe", pageIndex: 0);
+
+        matches.Should().BeEmpty(
+            "the accent is canonically meaningful; accent-INSENSITIVE search is out of scope");
+    }
+}

--- a/Excise.App.Tests/Unit/FullwidthFormsSearchTests.cs
+++ b/Excise.App.Tests/Unit/FullwidthFormsSearchTests.cs
@@ -1,0 +1,110 @@
+using System.Linq;
+using AwesomeAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Excise.App.Services;
+using Excise.App.Tests.Utilities;
+using Excise.Core.Document;
+using Xunit;
+
+namespace Excise.App.Tests.Unit;
+
+/// <summary>
+/// Search must find fullwidth ASCII ("ＡＢＣ", "１２３") and halfwidth
+/// katakana ("ｶﾀｶﾅ") from a needle typed on a regular keyboard (#727). The
+/// fixture's /ToUnicode maps character codes to the Halfwidth and Fullwidth
+/// Forms code points so extraction yields them; only the width fold in
+/// MatchingNormalization can bridge that to the typed needle. Scoped to
+/// U+FF00–U+FFEF only — compatibility characters outside the block keep
+/// their identity (pinned). Sibling of CanonicalAccentSearchTests (#724) /
+/// InvisibleSeparatorSearchTests (#726).
+/// </summary>
+public class FullwidthFormsSearchTests
+{
+    private static PdfSearchService NewService() =>
+        new(NullLogger<PdfSearchService>.Instance);
+
+    [Fact]
+    public void SearchInPage_AsciiNeedle_FindsFullwidthText()
+    {
+        var scalars = new[] { 0xFF21, 0xFF22, 0xFF23 }; // fullwidth ABC
+        using var doc = PdfDocument.Open(ToUnicodePdfFixture.Build(scalars));
+        var page = doc.GetPage(1);
+
+        // Anti-vacuity: the page carries fullwidth code points, not ASCII.
+        page.Text.Should().Contain("\uFF21");
+        page.Text.Should().NotContain("ABC");
+
+        var matches = NewService().SearchInPage(page, "ABC", pageIndex: 0);
+
+        matches.Should().NotBeEmpty(
+            "an ASCII needle must find fullwidth text via width folding");
+        matches[0].Width.Should().BeGreaterThan(0, "the match must map back to word bounds");
+    }
+
+    [Fact]
+    public void SearchInPage_AsciiDigits_FindFullwidthDigits()
+    {
+        var scalars = new[] { 0xFF11, 0xFF12, 0xFF13 }; // fullwidth 123
+        using var doc = PdfDocument.Open(ToUnicodePdfFixture.Build(scalars));
+        var page = doc.GetPage(1);
+
+        var matches = NewService().SearchInPage(page, "123", pageIndex: 0);
+
+        matches.Should().NotBeEmpty(
+            "digits are how account numbers hide in fullwidth text");
+    }
+
+    [Fact]
+    public void SearchInPage_KatakanaNeedle_FindsHalfwidthKatakana()
+    {
+        var scalars = new[] { 0xFF76, 0xFF80, 0xFF76, 0xFF85 }; // halfwidth katakana
+        using var doc = PdfDocument.Open(ToUnicodePdfFixture.Build(scalars));
+        var page = doc.GetPage(1);
+
+        var matches = NewService().SearchInPage(
+            page, "\u30AB\u30BF\u30AB\u30CA", pageIndex: 0); // regular katakana
+
+        matches.Should().NotBeEmpty(
+            "a regular-katakana needle must find halfwidth katakana");
+    }
+
+    [Fact]
+    public void SearchInPage_WholeWord_AsciiNeedle_FindsFullwidthWord()
+    {
+        var scalars = new[] { 0xFF21, 0xFF22, 0xFF23 };
+        using var doc = PdfDocument.Open(ToUnicodePdfFixture.Build(scalars));
+        var page = doc.GetPage(1);
+
+        var matches = NewService().SearchInPage(page, "ABC", wholeWordsOnly: true);
+
+        matches.Should().NotBeEmpty(
+            "whole-word comparison must width-fold both the word and the needle");
+    }
+
+    [Fact]
+    public void SearchInPage_FullwidthNeedle_AlsoFindsAsciiText()
+    {
+        var scalars = "ABC".Select(c => (int)c).ToArray();
+        using var doc = PdfDocument.Open(ToUnicodePdfFixture.Build(scalars));
+        var page = doc.GetPage(1);
+
+        var matches = NewService().SearchInPage(
+            page, "\uFF21\uFF22\uFF23", pageIndex: 0);
+
+        matches.Should().NotBeEmpty("both sides fold, so a fullwidth needle matches too");
+    }
+
+    [Fact]
+    public void SearchInPage_CompatibilityCharsOutsideTheBlock_AreNotFolded()
+    {
+        // Scope guard: no whole-string NFKC creep — "2" must not find
+        // superscript two (U+00B2).
+        using var doc = PdfDocument.Open(ToUnicodePdfFixture.Build(new[] { 0x00B2 }));
+        var page = doc.GetPage(1);
+
+        var matches = NewService().SearchInPage(page, "2", pageIndex: 0);
+
+        matches.Should().BeEmpty(
+            "the width fold is scoped to U+FF00-U+FFEF; other compatibility characters keep their identity");
+    }
+}

--- a/Excise.App.Tests/Unit/HarakatNiqqudSearchTests.cs
+++ b/Excise.App.Tests/Unit/HarakatNiqqudSearchTests.cs
@@ -1,0 +1,115 @@
+using AwesomeAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Excise.App.Services;
+using Excise.App.Tests.Utilities;
+using Excise.Core.Document;
+using Xunit;
+
+namespace Excise.App.Tests.Unit;
+
+/// <summary>
+/// Search must find vocalized Arabic (harakat) and pointed Hebrew (niqqud)
+/// text from a bare-letter needle (#725): the marks are optional
+/// vocalization, not different letters. The fixture's /ToUnicode maps
+/// character codes to the vocalized code points so extraction yields the
+/// marks; only the Arabic/Hebrew mark strip in MatchingNormalization can
+/// bridge that to a bare typed needle. Sibling of
+/// ArabicPresentationFormSearchTests (#632) / CanonicalAccentSearchTests
+/// (#724).
+/// </summary>
+public class HarakatNiqqudSearchTests
+{
+    /// <summary>Bare Arabic "kataba": kaf, ta, ba.</summary>
+    private const string BareArabic = "\u0643\u062A\u0628";
+
+    /// <summary>Vocalized: each letter followed by fatha (U+064E).</summary>
+    private const string VocalizedArabic = "\u0643\u064E\u062A\u064E\u0628\u064E";
+
+    /// <summary>
+    /// Stored scalars in VISUAL order (the common producer encoding):
+    /// logical kaf+fatha, ta+fatha, ba+fatha reversed wholesale. Extraction
+    /// reorders the RTL run back to logical, raw marks intact.
+    /// </summary>
+    private static readonly int[] VocalizedArabicScalars =
+        { 0x064E, 0x0628, 0x064E, 0x062A, 0x064E, 0x0643 };
+
+    /// <summary>Bare Hebrew "shalom".</summary>
+    private const string BareHebrew = "\u05E9\u05DC\u05D5\u05DD";
+
+    /// <summary>Pointed "shalom" scalars, stored in visual order.</summary>
+    private static readonly int[] PointedHebrewScalars =
+        { 0x05DD, 0x05B9, 0x05D5, 0x05DC, 0x05B8, 0x05C1, 0x05E9 };
+
+    private static PdfSearchService NewService() =>
+        new(NullLogger<PdfSearchService>.Instance);
+
+    [Fact]
+    public void SearchInPage_BareArabicNeedle_FindsVocalizedWord()
+    {
+        using var doc = PdfDocument.Open(ToUnicodePdfFixture.Build(VocalizedArabicScalars));
+        var page = doc.GetPage(1);
+
+        // Anti-vacuity: the page carries the marks, not the bare spelling.
+        page.Text.Should().Contain("\u064E");
+        page.Text.Should().NotContain(BareArabic);
+
+        var matches = NewService().SearchInPage(page, BareArabic, pageIndex: 0);
+
+        matches.Should().NotBeEmpty(
+            "a bare needle must find vocalized text — harakat are optional vocalization");
+        matches[0].Width.Should().BeGreaterThan(0, "the match must map back to word bounds");
+    }
+
+    [Fact]
+    public void SearchInPage_BareHebrewNeedle_FindsPointedWord()
+    {
+        using var doc = PdfDocument.Open(ToUnicodePdfFixture.Build(PointedHebrewScalars));
+        var page = doc.GetPage(1);
+
+        page.Text.Should().Contain("\u05B8");
+        page.Text.Should().NotContain(BareHebrew);
+
+        var matches = NewService().SearchInPage(page, BareHebrew, pageIndex: 0);
+
+        matches.Should().NotBeEmpty(
+            "a bare needle must find pointed (niqqud) text");
+    }
+
+    [Fact]
+    public void SearchInPage_WholeWord_BareArabicNeedle_FindsVocalizedWord()
+    {
+        using var doc = PdfDocument.Open(ToUnicodePdfFixture.Build(VocalizedArabicScalars));
+        var page = doc.GetPage(1);
+
+        var matches = NewService().SearchInPage(page, BareArabic, wholeWordsOnly: true);
+
+        matches.Should().NotBeEmpty(
+            "whole-word comparison must strip the marks from both the word and the needle");
+    }
+
+    [Fact]
+    public void SearchInPage_VocalizedNeedle_AlsoFindsVocalizedWord()
+    {
+        using var doc = PdfDocument.Open(ToUnicodePdfFixture.Build(VocalizedArabicScalars));
+        var page = doc.GetPage(1);
+
+        var matches = NewService().SearchInPage(page, VocalizedArabic, pageIndex: 0);
+
+        matches.Should().NotBeEmpty("both sides fold, so a vocalized needle matches too");
+    }
+
+    [Fact]
+    public void SearchInPage_LatinAccents_AreNotStripped()
+    {
+        // Scope guard: the strip covers Arabic/Hebrew marks only — searching
+        // "cafe" must not find precomposed "café".
+        using var doc = PdfDocument.Open(
+            ToUnicodePdfFixture.Build(new[] { 'c', 'a', 'f', 0x00E9 }));
+        var page = doc.GetPage(1);
+
+        var matches = NewService().SearchInPage(page, "cafe", pageIndex: 0);
+
+        matches.Should().BeEmpty(
+            "Latin combining accents are canonically meaningful and must not be stripped");
+    }
+}

--- a/Excise.App.Tests/Unit/InvisibleSeparatorSearchTests.cs
+++ b/Excise.App.Tests/Unit/InvisibleSeparatorSearchTests.cs
@@ -1,0 +1,93 @@
+using System.Linq;
+using AwesomeAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Excise.App.Services;
+using Excise.App.Tests.Utilities;
+using Excise.Core.Document;
+using Xunit;
+
+namespace Excise.App.Tests.Unit;
+
+/// <summary>
+/// Search must find words split by invisible/optional separators (#726):
+/// soft hyphen U+00AD (justified text), zero-width space/non-joiner/joiner
+/// U+200B–U+200D, zero-width no-break space U+FEFF, and text using
+/// non-breaking space U+00A0 where the user types a plain space. The
+/// fixture's /ToUnicode maps character codes to the split spelling so
+/// extraction yields the invisible code point; only separator folding in
+/// MatchingNormalization can bridge it to the typed needle. Sibling of
+/// CanonicalAccentSearchTests (#724) / HarakatNiqqudSearchTests (#725).
+/// </summary>
+public class InvisibleSeparatorSearchTests
+{
+    private static PdfSearchService NewService() =>
+        new(NullLogger<PdfSearchService>.Instance);
+
+    private static int[] SplitSecret(int separator) =>
+        new[] { (int)'s', (int)'e', separator, (int)'c', (int)'r', (int)'e', (int)'t' };
+
+    [Theory]
+    [InlineData(0x00AD)]
+    [InlineData(0x200B)]
+    [InlineData(0x200C)]
+    [InlineData(0x200D)]
+    [InlineData(0xFEFF)]
+    public void SearchInPage_PlainNeedle_FindsWordSplitByInvisibleChar(int separator)
+    {
+        using var doc = PdfDocument.Open(ToUnicodePdfFixture.Build(SplitSecret(separator)));
+        var page = doc.GetPage(1);
+
+        // Anti-vacuity: the page carries the split spelling, not the plain one.
+        page.Text.Should().Contain(char.ConvertFromUtf32(separator));
+        page.Text.Should().NotContain("secret");
+
+        var matches = NewService().SearchInPage(page, "secret", pageIndex: 0);
+
+        matches.Should().NotBeEmpty(
+            $"a plain needle must find a word split by U+{separator:X4}");
+        matches[0].Width.Should().BeGreaterThan(0, "the match must map back to word bounds");
+    }
+
+    [Fact]
+    public void SearchInPage_PlainSpaceNeedle_FindsNonBreakingSpaceText()
+    {
+        var scalars = "top".Select(c => (int)c)
+            .Append(0x00A0)
+            .Concat("secret".Select(c => (int)c)).ToArray();
+        using var doc = PdfDocument.Open(ToUnicodePdfFixture.Build(scalars));
+        var page = doc.GetPage(1);
+
+        page.Text.Should().Contain("\u00A0");
+
+        var matches = NewService().SearchInPage(page, "top secret", pageIndex: 0);
+
+        matches.Should().NotBeEmpty(
+            "a needle typed with a plain space must find text stored with U+00A0");
+    }
+
+    [Fact]
+    public void SearchInPage_WholeWord_PlainNeedle_FindsSoftHyphenatedWord()
+    {
+        using var doc = PdfDocument.Open(ToUnicodePdfFixture.Build(SplitSecret(0x00AD)));
+        var page = doc.GetPage(1);
+
+        var matches = NewService().SearchInPage(page, "secret", wholeWordsOnly: true);
+
+        matches.Should().NotBeEmpty(
+            "whole-word comparison must fold the separator out of both the word and the needle");
+    }
+
+    [Fact]
+    public void SearchInPage_RealHyphen_IsNotFolded()
+    {
+        // Scope guard: "secret" must not find "se-cret" — a real hyphen is
+        // visible content.
+        using var doc = PdfDocument.Open(ToUnicodePdfFixture.Build(SplitSecret('-')));
+        var page = doc.GetPage(1);
+
+        var matches = NewService().SearchInPage(page, "secret", pageIndex: 0);
+
+        matches.Should().BeEmpty(
+            "only the soft hyphen is an optional separator; U+002D keeps its identity");
+    }
+}

--- a/Excise.App.Tests/Utilities/ToUnicodePdfFixture.cs
+++ b/Excise.App.Tests/Utilities/ToUnicodePdfFixture.cs
@@ -1,0 +1,93 @@
+using System.IO;
+using System.Text;
+
+namespace Excise.App.Tests.Utilities;
+
+/// <summary>
+/// Minimal single-page PDF whose text is one Tj of character codes
+/// 0x41.. ('A'..) with a /ToUnicode CMap mapping each code to an arbitrary
+/// Unicode scalar. Lets search tests store EXACT code points — ligatures,
+/// combining marks, harakat, zero-width characters, fullwidth forms — and
+/// prove what extraction yields versus what a typed needle must match.
+/// Same shape as <c>Excise.Core.Tests.Text.RtlPdfFixtures.SingleTj</c>.
+/// </summary>
+internal static class ToUnicodePdfFixture
+{
+    /// <summary>
+    /// Build the PDF bytes for a page storing <paramref name="scalars"/> in
+    /// logical order (codes 'A', 'B', … map to the scalars one-to-one).
+    /// </summary>
+    public static byte[] Build(int[] scalars)
+    {
+        var codes = new char[scalars.Length];
+        for (int i = 0; i < scalars.Length; i++) codes[i] = (char)(0x41 + i);
+        var content = $"BT /F1 24 Tf 100 700 Td ({new string(codes)}) Tj ET";
+
+        var entries = new StringBuilder();
+        for (int i = 0; i < scalars.Length; i++)
+            entries.Append($"<{0x41 + i:X2}> <{scalars[i]:X4}>\n");
+
+        var cmap =
+            "/CIDInit /ProcSet findresource begin\n" +
+            "12 dict begin\n" +
+            "begincmap\n" +
+            "/CIDSystemInfo << /Registry (Adobe) /Ordering (UCS) /Supplement 0 >> def\n" +
+            "/CMapName /Adobe-Identity-UCS def\n" +
+            "/CMapType 2 def\n" +
+            "1 begincodespacerange\n<00> <FF>\nendcodespacerange\n" +
+            $"{scalars.Length} beginbfchar\n{entries}endbfchar\n" +
+            "endcmap\nCMapName currentdict /CMap defineresource pop\nend\nend";
+
+        using var ms = new MemoryStream();
+        using var writer = new StreamWriter(ms, Encoding.Latin1, leaveOpen: true);
+        writer.NewLine = "\n";
+
+        writer.WriteLine("%PDF-1.7");
+        writer.Flush();
+
+        var offsets = new long[7];
+
+        offsets[1] = Flush(writer, ms);
+        writer.WriteLine("1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj");
+
+        offsets[2] = Flush(writer, ms);
+        writer.WriteLine("2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj");
+
+        offsets[3] = Flush(writer, ms);
+        writer.WriteLine("3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] " +
+                         "/Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>\nendobj");
+
+        offsets[4] = Flush(writer, ms);
+        writer.WriteLine($"4 0 obj\n<< /Length {content.Length} >>\nstream");
+        writer.WriteLine(content);
+        writer.WriteLine("endstream\nendobj");
+
+        offsets[5] = Flush(writer, ms);
+        writer.WriteLine("5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica " +
+                         "/FirstChar 32 /LastChar 127 /ToUnicode 6 0 R >>\nendobj");
+
+        offsets[6] = Flush(writer, ms);
+        writer.WriteLine($"6 0 obj\n<< /Length {cmap.Length} >>\nstream");
+        writer.WriteLine(cmap);
+        writer.WriteLine("endstream\nendobj");
+
+        long xrefPos = Flush(writer, ms);
+        writer.WriteLine("xref");
+        writer.WriteLine("0 7");
+        writer.WriteLine("0000000000 65535 f ");
+        for (int i = 1; i <= 6; i++)
+            writer.WriteLine($"{offsets[i]:D10} 00000 n ");
+        writer.WriteLine("trailer\n<< /Root 1 0 R /Size 7 >>\nstartxref");
+        writer.WriteLine(xrefPos.ToString());
+        writer.WriteLine("%%EOF");
+        writer.Flush();
+
+        return ms.ToArray();
+    }
+
+    private static long Flush(StreamWriter writer, MemoryStream ms)
+    {
+        writer.Flush();
+        return ms.Position;
+    }
+}

--- a/Excise.App/Services/PdfSearchService.cs
+++ b/Excise.App/Services/PdfSearchService.cs
@@ -341,11 +341,12 @@ public class PdfSearchService
             ? StringComparison.Ordinal
             : StringComparison.OrdinalIgnoreCase;
 
-        // Fold Arabic presentation forms (#632) and Latin ligatures (#722)
-        // on both sides; identity for other text. Indices below are all
-        // within the folded string.
-        text = PresentationFormFolding.Fold(text);
-        searchTerm = PresentationFormFolding.Fold(searchTerm);
+        // Fold both sides into the canonical matching space — Arabic
+        // presentation forms (#632), Latin ligatures (#722), canonical NFC
+        // composition (#724); identity for other text. Indices below are
+        // all within the folded string.
+        text = MatchingNormalization.Fold(text);
+        searchTerm = MatchingNormalization.Fold(searchTerm);
 
         if (useRegex)
         {
@@ -426,13 +427,14 @@ public class PdfSearchService
     {
         var matches = new List<SearchMatch>();
 
-        // Arabic can be stored as shaped presentation forms (#632) and Latin
-        // text as ligature code points (#722) while the user types plain
-        // letters; fold both sides so matching sees plain letters. All index
-        // arithmetic below (word spans, contexts) is done consistently in
-        // folded space.
-        pageText = PresentationFormFolding.Fold(pageText);
-        pattern = PresentationFormFolding.Fold(pattern);
+        // Arabic can be stored as shaped presentation forms (#632), Latin
+        // text as ligature code points (#722), and accents in either
+        // canonical spelling (#724) while the user types plain/precomposed
+        // letters; fold both sides into the canonical matching space. All
+        // index arithmetic below (word spans, contexts) is done consistently
+        // in folded space.
+        pageText = MatchingNormalization.Fold(pageText);
+        pattern = MatchingNormalization.Fold(pattern);
 
         try
         {
@@ -483,13 +485,13 @@ public class PdfSearchService
         var matches = new List<SearchMatch>();
         var comparison = caseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
 
-        // Fold Arabic presentation forms (#632) and Latin ligatures (#722)
-        // on both sides.
-        searchTerm = PresentationFormFolding.Fold(searchTerm);
+        // Fold both sides into the canonical matching space (#632, #722,
+        // #724).
+        searchTerm = MatchingNormalization.Fold(searchTerm);
 
         foreach (var word in words)
         {
-            if (PresentationFormFolding.Fold(word.Text).Equals(searchTerm, comparison))
+            if (MatchingNormalization.Fold(word.Text).Equals(searchTerm, comparison))
             {
                 matches.Add(new SearchMatch
                 {
@@ -520,13 +522,14 @@ public class PdfSearchService
         var matches = new List<SearchMatch>();
         var comparison = caseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
 
-        // Arabic can be stored as shaped presentation forms (#632) and Latin
-        // text as ligature code points (#722) while the user types plain
-        // letters; fold both sides so matching sees plain letters. Word
+        // Arabic can be stored as shaped presentation forms (#632), Latin
+        // text as ligature code points (#722), and accents in either
+        // canonical spelling (#724) while the user types plain/precomposed
+        // letters; fold both sides into the canonical matching space. Word
         // spans and context are computed in the same folded space, so all
         // index arithmetic stays consistent.
-        pageText = PresentationFormFolding.Fold(pageText);
-        searchTerm = PresentationFormFolding.Fold(searchTerm);
+        pageText = MatchingNormalization.Fold(pageText);
+        searchTerm = MatchingNormalization.Fold(searchTerm);
 
         var wordSpans = BuildWordSpans(words, pageText);
 
@@ -577,9 +580,9 @@ public class PdfSearchService
         foreach (var word in words)
         {
             // Word text is folded the same way callers fold pageText
-            // (#632, #722) — identity for unaffected text — so spans line
-            // up either way.
-            var wordText = PresentationFormFolding.Fold(word.Text);
+            // (#632, #722, #724) — identity for unaffected text — so spans
+            // line up either way.
+            var wordText = MatchingNormalization.Fold(word.Text);
 
             // Find next occurrence of this word's text starting from current position
             // This handles duplicates correctly by advancing position after each match

--- a/Excise.Core.Tests/PublicApi/Excise.Core.approved.txt
+++ b/Excise.Core.Tests/PublicApi/Excise.Core.approved.txt
@@ -1630,6 +1630,12 @@ namespace Excise.Core.Text
         public double Width { get; }
         public override string ToString() { }
     }
+    public static class MatchingNormalization
+    {
+        public static string Fold(string text) { }
+        public static string[] FoldAll(System.Collections.Generic.IReadOnlyList<string> values) { }
+        public static bool IsCombiningMark(char c) { }
+    }
     public static class PresentationFormFolding
     {
         public static bool ContainsFoldable(string? text) { }

--- a/Excise.Core.Tests/PublicApi/Excise.Core.approved.txt
+++ b/Excise.Core.Tests/PublicApi/Excise.Core.approved.txt
@@ -1635,6 +1635,7 @@ namespace Excise.Core.Text
         public static string Fold(string text) { }
         public static string[] FoldAll(System.Collections.Generic.IReadOnlyList<string> values) { }
         public static bool IsCombiningMark(char c) { }
+        public static bool IsSemiticVocalizationMark(char c) { }
     }
     public static class PresentationFormFolding
     {

--- a/Excise.Core.Tests/PublicApi/Excise.Core.approved.txt
+++ b/Excise.Core.Tests/PublicApi/Excise.Core.approved.txt
@@ -1635,6 +1635,7 @@ namespace Excise.Core.Text
         public static string Fold(string text) { }
         public static string[] FoldAll(System.Collections.Generic.IReadOnlyList<string> values) { }
         public static bool IsCombiningMark(char c) { }
+        public static bool IsIgnorableSeparator(char c) { }
         public static bool IsSemiticVocalizationMark(char c) { }
     }
     public static class PresentationFormFolding

--- a/Excise.Core.Tests/PublicApi/Excise.Core.approved.txt
+++ b/Excise.Core.Tests/PublicApi/Excise.Core.approved.txt
@@ -1637,6 +1637,7 @@ namespace Excise.Core.Text
         public static bool IsCombiningMark(char c) { }
         public static bool IsIgnorableSeparator(char c) { }
         public static bool IsSemiticVocalizationMark(char c) { }
+        public static bool IsWidthForm(char c) { }
     }
     public static class PresentationFormFolding
     {

--- a/Excise.Core.Tests/Text/MatchingNormalizationTests.cs
+++ b/Excise.Core.Tests/Text/MatchingNormalizationTests.cs
@@ -1,0 +1,180 @@
+using System;
+using AwesomeAssertions;
+using Excise.Core.Text;
+using Xunit;
+
+namespace Excise.Core.Tests.Text;
+
+/// <summary>
+/// Direct unit coverage of the composite matching fold
+/// (<see cref="MatchingNormalization"/>): stage behavior, composition
+/// order, the per-letter <see cref="MatchingNormalization.FoldAll"/>
+/// cluster contract, identity fast paths, and tolerance of the malformed
+/// sequences PDF /ToUnicode maps can produce. Ground truth throughout is
+/// deterministic Unicode data (canonical/compatibility decompositions and
+/// the code points themselves), not a tool's opinion.
+/// Stages: presentation forms/ligatures (#632/#722) → canonical NFC
+/// (#724) → harakat/niqqud strip (#725) → invisible separators (#726) →
+/// halfwidth/fullwidth forms (#727).
+/// </summary>
+public class MatchingNormalizationTests
+{
+    // ---- Stage 2: canonical NFC (#724) ----
+
+    [Fact]
+    public void Fold_ComposesDecomposedAccents()
+    {
+        MatchingNormalization.Fold("cafe\u0301").Should().Be("caf\u00E9");
+        MatchingNormalization.Fold("caf\u00E9").Should().Be("caf\u00E9");
+    }
+
+    [Fact]
+    public void Fold_IsCanonicalOnly_NoNfkcCreep()
+    {
+        // Compatibility characters outside the explicitly folded blocks
+        // keep their identity: superscript two, circled one, ℡.
+        MatchingNormalization.Fold("\u00B2").Should().Be("\u00B2");
+        MatchingNormalization.Fold("\u2460").Should().Be("\u2460");
+        MatchingNormalization.Fold("\u2121").Should().Be("\u2121");
+    }
+
+    // ---- Stage 3: harakat/niqqud strip (#725) ----
+
+    [Fact]
+    public void Fold_StripsArabicHarakat()
+    {
+        MatchingNormalization.Fold("\u0643\u064E\u062A\u064E\u0628\u064E")
+            .Should().Be("\u0643\u062A\u0628");
+    }
+
+    [Fact]
+    public void Fold_StripsHebrewNiqqud()
+    {
+        MatchingNormalization.Fold("\u05E9\u05C1\u05B8\u05DC\u05D5\u05B9\u05DD")
+            .Should().Be("\u05E9\u05DC\u05D5\u05DD");
+    }
+
+    [Fact]
+    public void Fold_KeepsHebrewPunctuationInTheBlock()
+    {
+        // Maqaf, paseq, sof pasuq, nun hafukha are punctuation, not points.
+        MatchingNormalization.Fold("\u05D0\u05BE\u05D1").Should().Be("\u05D0\u05BE\u05D1");
+        MatchingNormalization.Fold("\u05C0\u05C3\u05C6").Should().Be("\u05C0\u05C3\u05C6");
+    }
+
+    [Fact]
+    public void Fold_NfcRunsBeforeTheStrip_SoComposingHamzaSurvives()
+    {
+        // alef + hamza-above (U+0654, inside the stripped range) composes
+        // to U+0623 under NFC FIRST — the hamza is preserved inside the
+        // composed letter, not stripped away.
+        MatchingNormalization.Fold("\u0627\u0654").Should().Be("\u0623");
+    }
+
+    [Fact]
+    public void Fold_KeepsLatinCombiningAccents()
+    {
+        // The strip is Arabic/Hebrew only; a Latin accent survives (as its
+        // NFC composition).
+        MatchingNormalization.Fold("n\u0303").Should().Be("\u00F1");
+    }
+
+    // ---- Stage 4: invisible separators (#726) ----
+
+    [Theory]
+    [InlineData("\u00AD")]
+    [InlineData("\u200B")]
+    [InlineData("\u200C")]
+    [InlineData("\u200D")]
+    [InlineData("\uFEFF")]
+    public void Fold_RemovesInvisibleSeparators(string separator)
+    {
+        MatchingNormalization.Fold("se" + separator + "cret").Should().Be("secret");
+    }
+
+    [Fact]
+    public void Fold_MapsNonBreakingSpaceToSpace()
+    {
+        MatchingNormalization.Fold("top\u00A0secret").Should().Be("top secret");
+    }
+
+    [Fact]
+    public void Fold_KeepsRealHyphen()
+    {
+        MatchingNormalization.Fold("se-cret").Should().Be("se-cret");
+    }
+
+    // ---- Stage 5: halfwidth/fullwidth (#727) ----
+
+    [Fact]
+    public void Fold_FoldsFullwidthAsciiToAscii()
+    {
+        MatchingNormalization.Fold("\uFF21\uFF22\uFF23").Should().Be("ABC");
+        MatchingNormalization.Fold("\uFF11\uFF12\uFF13").Should().Be("123");
+    }
+
+    [Fact]
+    public void Fold_FoldsHalfwidthKatakana_AndComposesVoicedPairs()
+    {
+        MatchingNormalization.Fold("\uFF76\uFF80").Should().Be("\u30AB\u30BF");
+        // ｶ + halfwidth voiced mark ﾞ → カ + U+3099 → composes to ガ.
+        MatchingNormalization.Fold("\uFF76\uFF9E").Should().Be("\u30AC");
+    }
+
+    // ---- Earlier stages still compose (#632/#722 regression) ----
+
+    [Fact]
+    public void Fold_StillFoldsLigaturesAndArabicPresentationForms()
+    {
+        MatchingNormalization.Fold("o\uFB03ce").Should().Be("office");
+        MatchingNormalization.Fold("\uFEB3").Should().Be("\u0633");
+    }
+
+    // ---- Contracts ----
+
+    [Fact]
+    public void Fold_ReturnsSameInstance_WhenNothingChanges()
+    {
+        var s = "plain ASCII text 123";
+        MatchingNormalization.Fold(s).Should().BeSameAs(s,
+            "the identity fast path keeps unaffected haystacks allocation-free");
+    }
+
+    [Fact]
+    public void Fold_ToleratesUnpairedSurrogates()
+    {
+        // Broken /ToUnicode maps can yield lone surrogates; folding must
+        // not throw, and matching degrades to exact comparison.
+        var broken = "abc" + (char)0xD800 + "def";
+        MatchingNormalization.Fold(broken).Should().Be(broken);
+    }
+
+    [Fact]
+    public void FoldAll_ConcatenationEqualsWholeStringFold()
+    {
+        // The per-letter contract: concat(FoldAll(values)) == Fold(concat).
+        var values = new[] { "c", "a", "f", "e", "\u0301", " ", "\uFF76", "\uFF9E" };
+        var folded = MatchingNormalization.FoldAll(values);
+
+        string.Concat(folded).Should().Be(
+            MatchingNormalization.Fold(string.Concat(values)));
+    }
+
+    [Fact]
+    public void FoldAll_MergesCombiningMarkIntoPrecedingLetter()
+    {
+        var folded = MatchingNormalization.FoldAll(new[] { "e", "\u0301" });
+
+        folded[0].Should().Be("\u00E9", "the accent composes into the base letter's cluster");
+        folded[1].Should().BeEmpty("the mark letter contributes zero folded length");
+    }
+
+    [Fact]
+    public void FoldAll_StrippedMarkLettersFoldToEmpty()
+    {
+        var folded = MatchingNormalization.FoldAll(new[] { "\u0643", "\u064E" });
+
+        folded[0].Should().Be("\u0643");
+        folded[1].Should().BeEmpty("harakat letters vanish in folded space");
+    }
+}

--- a/Excise.Core.Tests/Text/Segmentation/CanonicalAccentRedactionTests.cs
+++ b/Excise.Core.Tests/Text/Segmentation/CanonicalAccentRedactionTests.cs
@@ -1,0 +1,186 @@
+using System;
+using System.Linq;
+using System.Text;
+using AwesomeAssertions;
+using Excise.Core.Document;
+using Excise.Core.Tests.Text;
+using Excise.Core.Text.Segmentation;
+using Xunit;
+
+namespace Excise.Core.Tests.Text.Segmentation;
+
+/// <summary>
+/// Canonical-equivalence (NFC/NFD) folding in redaction matching (#724).
+///
+/// Unicode has two canonically EQUIVALENT spellings of every accented Latin
+/// letter: precomposed ("café", é = U+00E9) and decomposed ("cafe" + combining
+/// acute U+0301). Keyboards type the precomposed form; PDFs produced from
+/// TeX/OpenType pipelines routinely store the decomposed form (base glyph +
+/// combining-mark glyph), and vice versa. Before the fix these tests cover,
+/// <c>RedactText("café")</c> returned 0 on a decomposed fixture and reported
+/// success while the word stayed in the file — CLAUDE.md limitation #1
+/// (silent redaction failure) in everyday European-language text.
+///
+/// The ground truth for the equivalence is Unicode canonical equivalence
+/// (deterministic; not a tool's opinion): NFD("café") = "cafe" + U+0301 and
+/// NFC("cafe" + U+0301) = "café". Matching folds BOTH sides to the canonical
+/// DECOMPOSITION (NFD) — same match set as NFC-on-both-sides, but safe for
+/// the per-letter index arithmetic redaction uses (composition can merge
+/// characters ACROSS letter boundaries; decomposition never does). This is
+/// canonical-only: compatibility characters are untouched (no NFKC creep),
+/// and accent-INSENSITIVE matching ("cafe" finding "café") stays out of
+/// scope — the accent is canonically meaningful.
+///
+/// Saved-bytes assertions follow the redaction test rules: ASCII + UTF-16BE
+/// + UTF-8 views of the written file, checked for the word in both canonical
+/// spellings and for the raw character-code carrier the fixture is known to
+/// use — with anti-vacuity checks that the carrier existed before redaction.
+/// </summary>
+public class CanonicalAccentRedactionTests
+{
+    /// <summary>What a user types: precomposed é (U+00E9).</summary>
+    private const string PrecomposedWord = "caf\u00E9";
+
+    /// <summary>What the fixture stores: e + combining acute (U+0301).</summary>
+    private const string DecomposedWord = "cafe\u0301";
+
+    /// <summary>Per-glyph Unicode scalars of the decomposed word.</summary>
+    private static readonly int[] DecomposedScalars = { 'c', 'a', 'f', 'e', 0x0301 };
+
+    /// <summary>Per-glyph Unicode scalars of the precomposed word.</summary>
+    private static readonly int[] PrecomposedScalars = { 'c', 'a', 'f', 0x00E9 };
+
+    [Fact]
+    public void RedactText_PrecomposedNeedle_RemovesDecomposedWord()
+    {
+        // Codes ABCDE in logical order, /ToUnicode maps to c,a,f,e,U+0301.
+        var pdf = RtlPdfFixtures.SingleTj(DecomposedScalars, visualOrder: false);
+        using var doc = PdfDocument.Open(pdf);
+
+        // Anti-vacuity: before redaction the word must be present — extracted
+        // in its raw decomposed spelling, and carried in the saved bytes as
+        // its raw character codes '(ABCDE)'.
+        doc.GetPage(1).Text.Should().Contain(DecomposedWord,
+            "sanity: the fixture must extract decomposed for this test to prove anything");
+        doc.GetPage(1).Text.Should().NotContain(PrecomposedWord,
+            "sanity: the precomposed spelling must NOT be extractable, or matching would succeed without canonical folding");
+        SearchableTextOf(doc.SaveToBytes()).Should().Contain("(ABCDE)",
+            "sanity: the glyph-code carrier must be present before redaction");
+
+        var removed = doc.RedactText(PrecomposedWord);
+
+        removed.Should().BeGreaterThan(0,
+            "a precomposed needle (U+00E9) must match canonically equivalent " +
+            "decomposed text (e + U+0301); 0 matches is the silent-failure mode " +
+            "this test exists to prevent (#724)");
+
+        var saved = doc.SaveToBytes();
+        var searchable = SearchableTextOf(saved);
+        searchable.Should().NotContain(PrecomposedWord, "the word must not survive precomposed");
+        searchable.Should().NotContain(DecomposedWord, "nor decomposed");
+        searchable.Should().NotContain("(ABCDE)", "nor as its raw character codes");
+
+        using var reopened = PdfDocument.Open(saved);
+        reopened.GetPage(1).Text.Should().NotContainAny(PrecomposedWord, DecomposedWord);
+    }
+
+    [Fact]
+    public void RedactText_DecomposedNeedle_RemovesPrecomposedWord()
+    {
+        // The mirror image: text stored precomposed, needle pasted decomposed
+        // (e.g. copied out of a decomposed-form source).
+        var pdf = RtlPdfFixtures.SingleTj(PrecomposedScalars, visualOrder: false);
+        using var doc = PdfDocument.Open(pdf);
+
+        doc.GetPage(1).Text.Should().Contain(PrecomposedWord,
+            "sanity: the fixture must extract precomposed");
+        doc.GetPage(1).Text.Should().NotContain(DecomposedWord);
+        SearchableTextOf(doc.SaveToBytes()).Should().Contain("(ABCD)",
+            "sanity: the glyph-code carrier must be present before redaction");
+
+        var removed = doc.RedactText(DecomposedWord);
+
+        removed.Should().BeGreaterThan(0,
+            "a decomposed needle must match canonically equivalent precomposed text (#724)");
+
+        var searchable = SearchableTextOf(doc.SaveToBytes());
+        searchable.Should().NotContain(PrecomposedWord);
+        searchable.Should().NotContain(DecomposedWord);
+        searchable.Should().NotContain("(ABCD)");
+    }
+
+    [Theory]
+    [InlineData("Mu\u00F1oz", new[] { 'M', 'u', 'n', 0x0303, 'o', 'z' })]        // ñ = n + combining tilde
+    [InlineData("F\u00FChrer", new[] { 'F', 'u', 0x0308, 'h', 'r', 'e', 'r' })]  // ü = u + combining diaeresis
+    [InlineData("Ha\u010Dek", new[] { 'H', 'a', 'c', 0x030C, 'e', 'k' })]        // č = c + combining caron
+    public void RedactText_PrecomposedNeedle_RemovesOtherCombiningMarks(
+        string precomposedNeedle, int[] decomposedScalars)
+    {
+        var pdf = RtlPdfFixtures.SingleTj(decomposedScalars, visualOrder: false);
+        using var doc = PdfDocument.Open(pdf);
+
+        var storedWord = string.Concat(decomposedScalars.Select(char.ConvertFromUtf32));
+        doc.GetPage(1).Text.Should().Contain(storedWord, "sanity: raw decomposed text must extract");
+
+        var removed = doc.RedactText(precomposedNeedle);
+
+        removed.Should().BeGreaterThan(0,
+            $"needle '{precomposedNeedle}' must match its canonical decomposition");
+
+        var searchable = SearchableTextOf(doc.SaveToBytes());
+        searchable.Should().NotContain(storedWord);
+        searchable.Should().NotContain(precomposedNeedle);
+    }
+
+    [Fact]
+    public void RedactText_PrecomposedNeedle_DoesNotTouchUnrelatedText()
+    {
+        // Scope guard: redacting the decomposed word must leave other text on
+        // the same line intact — "cafe<U+0301> xyz", redact "café", keep "xyz".
+        var scalars = DecomposedScalars.Append(' ').Concat("xyz".Select(c => (int)c)).ToArray();
+        var pdf = RtlPdfFixtures.SingleTj(scalars, visualOrder: false);
+        using var doc = PdfDocument.Open(pdf);
+
+        var removed = doc.RedactText(PrecomposedWord);
+
+        removed.Should().BeGreaterThan(0);
+
+        using var reopened = PdfDocument.Open(doc.SaveToBytes());
+        var text = reopened.GetPage(1).Text;
+        text.Should().Contain("xyz", "unrelated text on the same line must survive");
+        text.Should().NotContainAny(PrecomposedWord, DecomposedWord);
+    }
+
+    [Fact]
+    public void RedactText_UnaccentedNeedle_DoesNotMatchAccentedWord()
+    {
+        // Scope guard: canonical folding must NOT become accent-insensitive
+        // matching. "cafe" (no accent) is NOT canonically equivalent to
+        // "café" and must not redact it. The stored form here is
+        // PRECOMPOSED: with decomposed storage the raw bytes physically
+        // contain the letters c-a-f-e and the raw-substring operator
+        // backstop legitimately (and fail-safely) removes them — that
+        // pre-existing behavior is not what this guard is about.
+        var pdf = RtlPdfFixtures.SingleTj(PrecomposedScalars, visualOrder: false);
+        using var doc = PdfDocument.Open(pdf);
+
+        var removed = doc.RedactText("cafe");
+
+        removed.Should().Be(0,
+            "the accent is canonically meaningful; accent-INSENSITIVE matching is out of scope");
+
+        using var reopened = PdfDocument.Open(doc.SaveToBytes());
+        reopened.GetPage(1).Text.Should().Contain(PrecomposedWord,
+            "the accented word must be untouched by a non-equivalent needle");
+    }
+
+    /// <summary>
+    /// Carrier-agnostic view of the saved file, per the redaction test rules:
+    /// ASCII (raw codes, hex carriers) + UTF-16BE (PDF Unicode text strings)
+    /// + UTF-8 (XMP metadata).
+    /// </summary>
+    private static string SearchableTextOf(byte[] saved) =>
+        Encoding.ASCII.GetString(saved) +
+        Encoding.BigEndianUnicode.GetString(saved) +
+        Encoding.UTF8.GetString(saved);
+}

--- a/Excise.Core.Tests/Text/Segmentation/FullwidthFormsRedactionTests.cs
+++ b/Excise.Core.Tests/Text/Segmentation/FullwidthFormsRedactionTests.cs
@@ -1,0 +1,191 @@
+using System;
+using System.Linq;
+using System.Text;
+using AwesomeAssertions;
+using Excise.Core.Document;
+using Excise.Core.Tests.Text;
+using Excise.Core.Text.Segmentation;
+using Xunit;
+
+namespace Excise.Core.Tests.Text.Segmentation;
+
+/// <summary>
+/// Fullwidth/halfwidth form folding in redaction matching (#727).
+///
+/// CJK documents write embedded Latin letters and digits as FULLWIDTH
+/// forms (U+FF01–U+FF5E: "ＡＢＣ", "１２３") and katakana as HALFWIDTH
+/// forms (U+FF61–U+FF9F: "ｶﾀｶﾅ"). A user's needle is typed with a regular
+/// keyboard: "ABC", "123", "カタカナ". Before the fix these tests cover,
+/// <c>RedactText("ABC")</c> returned 0 against stored "ＡＢＣ" and
+/// reported success while the text stayed in the file — CLAUDE.md
+/// limitation #1 (silent redaction failure) for names, account numbers
+/// and dates in Japanese/Chinese/Korean documents.
+///
+/// The ground truth is the Unicode compatibility decomposition (NFKC) of
+/// the Halfwidth and Fullwidth Forms block U+FF00–U+FFEF (deterministic;
+/// not a tool's opinion): U+FF21 → "A", U+FF76 → "カ", and the halfwidth
+/// voiced pair U+FF76 U+FF9E composes to "ガ". The fold is scoped to THAT
+/// BLOCK ONLY — deliberately not whole-string NFKC, which would also
+/// rewrite superscripts, circled numbers, and other compatibility
+/// characters and loosen matching (pinned by scope guards).
+///
+/// Saved-bytes assertions follow the redaction test rules: ASCII +
+/// UTF-16BE + UTF-8 views of the written file, checked for the text in
+/// both widths and for the raw character-code carrier, with anti-vacuity
+/// checks that the carrier existed before redaction.
+/// </summary>
+public class FullwidthFormsRedactionTests
+{
+    [Theory]
+    [InlineData("ABC", new[] { 0xFF21, 0xFF22, 0xFF23 })]  // ＡＢＣ
+    [InlineData("123", new[] { 0xFF11, 0xFF12, 0xFF13 })]  // １２３
+    [InlineData("abc", new[] { 0xFF41, 0xFF42, 0xFF43 })]  // ａｂｃ
+    public void RedactText_AsciiNeedle_RemovesFullwidthText(
+        string plainNeedle, int[] fullwidthScalars)
+    {
+        var pdf = RtlPdfFixtures.SingleTj(fullwidthScalars, visualOrder: false);
+        using var doc = PdfDocument.Open(pdf);
+
+        var storedText = string.Concat(fullwidthScalars.Select(char.ConvertFromUtf32));
+
+        // Anti-vacuity: the fullwidth text must be present — extracted with
+        // its raw fullwidth code points, carried as raw character codes.
+        doc.GetPage(1).Text.Should().Contain(storedText,
+            "sanity: the fixture must extract fullwidth for this test to prove anything");
+        doc.GetPage(1).Text.Should().NotContain(plainNeedle,
+            "sanity: the ASCII spelling must NOT be extractable, or matching would succeed without width folding");
+        SearchableTextOf(doc.SaveToBytes()).Should().Contain("(ABC)",
+            "sanity: the glyph-code carrier must be present before redaction");
+
+        var removed = doc.RedactText(plainNeedle);
+
+        removed.Should().BeGreaterThan(0,
+            $"an ASCII needle '{plainNeedle}' must match fullwidth '{storedText}'; " +
+            "0 matches is the silent-failure mode this test exists to prevent (#727)");
+
+        var saved = doc.SaveToBytes();
+        var searchable = SearchableTextOf(saved);
+        searchable.Should().NotContain(plainNeedle, "the text must not survive in ASCII");
+        searchable.Should().NotContain(storedText, "nor fullwidth");
+        searchable.Should().NotContain("(ABC)", "nor as its raw character codes");
+
+        using var reopened = PdfDocument.Open(saved);
+        reopened.GetPage(1).Text.Should().NotContainAny(plainNeedle, storedText);
+    }
+
+    [Fact]
+    public void RedactText_KatakanaNeedle_RemovesHalfwidthKatakana()
+    {
+        // Stored halfwidth ｶﾀｶﾅ; typed regular katakana カタカナ.
+        var scalars = new[] { 0xFF76, 0xFF80, 0xFF76, 0xFF85 };
+        var storedText = "\uFF76\uFF80\uFF76\uFF85";  // halfwidth katakana
+        var typedNeedle = "\u30AB\u30BF\u30AB\u30CA";  // regular katakana
+        var pdf = RtlPdfFixtures.SingleTj(scalars, visualOrder: false);
+        using var doc = PdfDocument.Open(pdf);
+
+        doc.GetPage(1).Text.Should().Contain(storedText,
+            "sanity: the fixture must extract halfwidth");
+        doc.GetPage(1).Text.Should().NotContain(typedNeedle);
+
+        var removed = doc.RedactText(typedNeedle);
+
+        removed.Should().BeGreaterThan(0,
+            "a regular-katakana needle must match halfwidth katakana (#727)");
+
+        var searchable = SearchableTextOf(doc.SaveToBytes());
+        searchable.Should().NotContain(storedText);
+        searchable.Should().NotContain(typedNeedle);
+        searchable.Should().NotContain("(ABCD)");
+    }
+
+    [Fact]
+    public void RedactText_VoicedKatakanaNeedle_RemovesHalfwidthPair()
+    {
+        // Halfwidth voiced katakana is TWO code points (ｶ + ﾞ,
+        // U+FF76 U+FF9E); the typed needle is ONE (ガ, U+30AC). The width
+        // fold produces カ + combining U+3099, which must then canonically
+        // compose to match — the width and canonical stages must compose
+        // correctly across letter boundaries.
+        var scalars = new[] { 0xFF76, 0xFF9E };
+        var pdf = RtlPdfFixtures.SingleTj(scalars, visualOrder: false);
+        using var doc = PdfDocument.Open(pdf);
+
+        var removed = doc.RedactText("\u30AC");  // ga (voiced ka)
+
+        removed.Should().BeGreaterThan(0,
+            "the halfwidth base+voiced-mark pair must fold and compose to ガ (#727)");
+
+        var searchable = SearchableTextOf(doc.SaveToBytes());
+        searchable.Should().NotContain("\uFF76\uFF9E");
+        searchable.Should().NotContain("\u30AC");
+        searchable.Should().NotContain("(AB)");
+    }
+
+    [Fact]
+    public void RedactText_FullwidthNeedle_AlsoRemovesAsciiText()
+    {
+        // The mirror image: ASCII stored, fullwidth needle pasted from a
+        // CJK document. Folding applies to BOTH sides.
+        var scalars = "ABC".Select(c => (int)c).ToArray();
+        var pdf = RtlPdfFixtures.SingleTj(scalars, visualOrder: false);
+        using var doc = PdfDocument.Open(pdf);
+
+        var removed = doc.RedactText("\uFF21\uFF22\uFF23");  // fullwidth ABC
+
+        removed.Should().BeGreaterThan(0,
+            "a fullwidth needle must match ASCII text (#727)");
+
+        var searchable = SearchableTextOf(doc.SaveToBytes());
+        searchable.Should().NotContain("\uFF21\uFF22\uFF23");
+    }
+
+    [Fact]
+    public void RedactText_AsciiNeedle_DoesNotTouchUnrelatedText()
+    {
+        // Scope guard: redacting the fullwidth text must leave other text on
+        // the same line intact.
+        var scalars = new[] { 0xFF21, 0xFF22, 0xFF23, (int)' ' }
+            .Concat("xyz".Select(c => (int)c)).ToArray();
+        var pdf = RtlPdfFixtures.SingleTj(scalars, visualOrder: false);
+        using var doc = PdfDocument.Open(pdf);
+
+        var removed = doc.RedactText("ABC");
+
+        removed.Should().BeGreaterThan(0);
+
+        using var reopened = PdfDocument.Open(doc.SaveToBytes());
+        var text = reopened.GetPage(1).Text;
+        text.Should().Contain("xyz", "unrelated text on the same line must survive");
+        text.Should().NotContain("ABC");
+    }
+
+    [Theory]
+    [InlineData("2", new[] { 0x00B2 })]   // superscript two ²
+    [InlineData("1", new[] { 0x2460 })]   // circled digit one ①
+    [InlineData("TEL", new[] { 0x2121 })] // telephone sign ℡
+    public void RedactText_CompatibilityCharsOutsideTheBlock_AreNotFolded(
+        string needle, int[] storedScalars)
+    {
+        // Scope guard: the fold is the U+FF00–U+FFEF block ONLY. Whole-string
+        // NFKC would also fold superscripts, circled numbers and squared
+        // signs — that creep must not happen.
+        var pdf = RtlPdfFixtures.SingleTj(storedScalars, visualOrder: false);
+        using var doc = PdfDocument.Open(pdf);
+
+        var removed = doc.RedactText(needle);
+
+        removed.Should().Be(0,
+            "compatibility characters outside the Halfwidth and Fullwidth Forms " +
+            "block must keep their identity (no whole-string NFKC creep)");
+    }
+
+    /// <summary>
+    /// Carrier-agnostic view of the saved file, per the redaction test rules:
+    /// ASCII (raw codes, hex carriers) + UTF-16BE (PDF Unicode text strings)
+    /// + UTF-8 (XMP metadata).
+    /// </summary>
+    private static string SearchableTextOf(byte[] saved) =>
+        Encoding.ASCII.GetString(saved) +
+        Encoding.BigEndianUnicode.GetString(saved) +
+        Encoding.UTF8.GetString(saved);
+}

--- a/Excise.Core.Tests/Text/Segmentation/HarakatNiqqudRedactionTests.cs
+++ b/Excise.Core.Tests/Text/Segmentation/HarakatNiqqudRedactionTests.cs
@@ -1,0 +1,197 @@
+using System;
+using System.Linq;
+using System.Text;
+using AwesomeAssertions;
+using Excise.Core.Document;
+using Excise.Core.Tests.Text;
+using Excise.Core.Text.Segmentation;
+using Xunit;
+
+namespace Excise.Core.Tests.Text.Segmentation;
+
+/// <summary>
+/// Arabic harakat / Hebrew niqqud folding in redaction matching (#725).
+///
+/// Arabic short vowels and annotation signs (harakat — U+064B–U+065F,
+/// U+0670, and the Koranic marks U+06D6–U+06ED) and Hebrew points and
+/// cantillation (niqqud/teamim — U+0591–U+05C7, combining marks only) are
+/// OPTIONAL in normal writing: vocalized text ("كَتَبَ", "שָׁלוֹם") and bare text
+/// ("كتب", "שלום") are the same words. Users type bare; religious texts,
+/// children's books, dictionaries and legal documents store vocalized.
+/// Before the fix these tests cover, <c>RedactText("كتب")</c> returned 0 on
+/// a vocalized fixture and reported success while the word stayed in the
+/// file — CLAUDE.md limitation #1 (silent redaction failure).
+///
+/// The ground truth is the Unicode code points themselves (deterministic;
+/// not a tool's opinion): the stored form is the bare form with combining
+/// marks of the two scripts interleaved. Matching strips exactly those
+/// marks from BOTH sides. Scope is tight: Arabic/Hebrew combining marks
+/// ONLY — Latin combining accents are canonically meaningful (handled by
+/// NFC composition, #724, and kept), and Hebrew PUNCTUATION sharing the
+/// block (maqaf U+05BE, sof pasuq U+05C3…) is untouched.
+///
+/// Saved-bytes assertions follow the redaction test rules: ASCII + UTF-16BE
+/// + UTF-8 views of the written file, checked for the word in vocalized and
+/// bare form and for the raw character-code carrier, with anti-vacuity
+/// checks that the carrier existed before redaction.
+/// </summary>
+public class HarakatNiqqudRedactionTests
+{
+    /// <summary>Bare Arabic "kataba" (wrote): kaf, ta, ba.</summary>
+    private const string BareArabic = "\u0643\u062A\u0628";
+
+    /// <summary>Vocalized: each letter followed by fatha (U+064E).</summary>
+    private const string VocalizedArabic = "\u0643\u064E\u062A\u064E\u0628\u064E";
+
+    private static readonly int[] VocalizedArabicScalars =
+        { 0x0643, 0x064E, 0x062A, 0x064E, 0x0628, 0x064E };
+
+    /// <summary>Bare Hebrew "shalom": shin, lamed, vav, final mem.</summary>
+    private const string BareHebrew = "\u05E9\u05DC\u05D5\u05DD";
+
+    /// <summary>
+    /// Pointed: shin + shin-dot (U+05C1) + qamats (U+05B8), lamed, vav +
+    /// holam (U+05B9), final mem.
+    /// </summary>
+    private const string PointedHebrew = "\u05E9\u05C1\u05B8\u05DC\u05D5\u05B9\u05DD";
+
+    private static readonly int[] PointedHebrewScalars =
+        { 0x05E9, 0x05C1, 0x05B8, 0x05DC, 0x05D5, 0x05B9, 0x05DD };
+
+    [Fact]
+    public void RedactText_BareArabicNeedle_RemovesVocalizedWord()
+    {
+        // Stored in visual order (the common producer encoding); extraction
+        // reorders RTL runs to logical, keeping the raw harakat code points.
+        var pdf = RtlPdfFixtures.SingleTj(VocalizedArabicScalars, visualOrder: true);
+        using var doc = PdfDocument.Open(pdf);
+
+        // Anti-vacuity: the vocalized word must be present — extracted with
+        // its raw harakat, and carried as raw character codes '(FEDCBA)'.
+        doc.GetPage(1).Text.Should().Contain(VocalizedArabic,
+            "sanity: the fixture must extract vocalized for this test to prove anything");
+        doc.GetPage(1).Text.Should().NotContain(BareArabic,
+            "sanity: the bare spelling must NOT be extractable, or matching would succeed without harakat folding");
+        SearchableTextOf(doc.SaveToBytes()).Should().Contain("(FEDCBA)",
+            "sanity: the glyph-code carrier must be present before redaction");
+
+        var removed = doc.RedactText(BareArabic);
+
+        removed.Should().BeGreaterThan(0,
+            "a bare needle must match vocalized text — harakat are optional " +
+            "vocalization, not different letters; 0 matches is the " +
+            "silent-failure mode this test exists to prevent (#725)");
+
+        var saved = doc.SaveToBytes();
+        var searchable = SearchableTextOf(saved);
+        searchable.Should().NotContain(VocalizedArabic, "the word must not survive vocalized");
+        searchable.Should().NotContain(BareArabic, "nor bare");
+        searchable.Should().NotContain("(FEDCBA)", "nor as its raw character codes");
+
+        using var reopened = PdfDocument.Open(saved);
+        reopened.GetPage(1).Text.Should().NotContainAny(VocalizedArabic, BareArabic);
+    }
+
+    [Fact]
+    public void RedactText_VocalizedArabicNeedle_AlsoRemovesVocalizedWord()
+    {
+        // A user may paste vocalized text copied from a viewer. Folding is
+        // applied to BOTH sides, so a vocalized needle matches too.
+        var pdf = RtlPdfFixtures.SingleTj(VocalizedArabicScalars, visualOrder: true);
+        using var doc = PdfDocument.Open(pdf);
+
+        var removed = doc.RedactText(VocalizedArabic);
+
+        removed.Should().BeGreaterThan(0);
+
+        var searchable = SearchableTextOf(doc.SaveToBytes());
+        searchable.Should().NotContain(VocalizedArabic);
+        searchable.Should().NotContain(BareArabic);
+        searchable.Should().NotContain("(FEDCBA)");
+    }
+
+    [Fact]
+    public void RedactText_BareHebrewNeedle_RemovesPointedWord()
+    {
+        var pdf = RtlPdfFixtures.SingleTj(PointedHebrewScalars, visualOrder: true);
+        using var doc = PdfDocument.Open(pdf);
+
+        doc.GetPage(1).Text.Should().Contain(PointedHebrew,
+            "sanity: the fixture must extract pointed");
+        doc.GetPage(1).Text.Should().NotContain(BareHebrew,
+            "sanity: the bare spelling must NOT be extractable");
+        SearchableTextOf(doc.SaveToBytes()).Should().Contain("(GFEDCBA)",
+            "sanity: the glyph-code carrier must be present before redaction");
+
+        var removed = doc.RedactText(BareHebrew);
+
+        removed.Should().BeGreaterThan(0,
+            "a bare needle must match pointed (niqqud) text (#725)");
+
+        var searchable = SearchableTextOf(doc.SaveToBytes());
+        searchable.Should().NotContain(PointedHebrew);
+        searchable.Should().NotContain(BareHebrew);
+        searchable.Should().NotContain("(GFEDCBA)");
+    }
+
+    [Fact]
+    public void RedactText_BareArabicNeedle_DoesNotTouchUnrelatedText()
+    {
+        // Scope guard: redacting the vocalized word must leave Latin text on
+        // the same line intact. Latin prefix + visual-order RTL word in one
+        // Tj — the common producer encoding.
+        var pdf = RtlPdfFixtures.SingleTjWithLatinPrefix("xyz ", VocalizedArabicScalars);
+        using var doc = PdfDocument.Open(pdf);
+
+        var removed = doc.RedactText(BareArabic);
+
+        removed.Should().BeGreaterThan(0);
+
+        using var reopened = PdfDocument.Open(doc.SaveToBytes());
+        var text = reopened.GetPage(1).Text;
+        text.Should().Contain("xyz", "unrelated text on the same line must survive");
+        text.Should().NotContainAny(VocalizedArabic, BareArabic);
+    }
+
+    [Fact]
+    public void RedactText_LatinCombiningAccents_AreNotStripped()
+    {
+        // Scope guard: the strip is Arabic/Hebrew marks ONLY. A Latin
+        // combining accent is canonically meaningful — "cafe" must still not
+        // match "café" stored decomposed-then-composed (see #724).
+        var pdf = RtlPdfFixtures.SingleTj(
+            new[] { 'c', 'a', 'f', 0x00E9 }, visualOrder: false);
+        using var doc = PdfDocument.Open(pdf);
+
+        var removed = doc.RedactText("cafe");
+
+        removed.Should().Be(0,
+            "stripping must not extend to Latin combining accents (accent-insensitivity is out of scope)");
+    }
+
+    [Fact]
+    public void RedactText_HebrewPunctuationInBlock_IsNotStripped()
+    {
+        // Scope guard: U+05BE (maqaf, the Hebrew hyphen) shares the
+        // U+0591–U+05C7 neighborhood but is PUNCTUATION, not a combining
+        // mark. A needle without it must not match text with it.
+        var withMaqaf = new[] { 0x05D0, 0x05D1, 0x05BE, 0x05D2, 0x05D3 }; // אב־גד
+        var pdf = RtlPdfFixtures.SingleTj(withMaqaf, visualOrder: true);
+        using var doc = PdfDocument.Open(pdf);
+
+        var removed = doc.RedactText("\u05D0\u05D1\u05D2\u05D3"); // alef-bet-gimel-dalet, no maqaf
+
+        removed.Should().Be(0,
+            "maqaf is punctuation carrying real content structure, not optional pointing");
+    }
+
+    /// <summary>
+    /// Carrier-agnostic view of the saved file, per the redaction test rules:
+    /// ASCII (raw codes, hex carriers) + UTF-16BE (PDF Unicode text strings)
+    /// + UTF-8 (XMP metadata).
+    /// </summary>
+    private static string SearchableTextOf(byte[] saved) =>
+        Encoding.ASCII.GetString(saved) +
+        Encoding.BigEndianUnicode.GetString(saved) +
+        Encoding.UTF8.GetString(saved);
+}

--- a/Excise.Core.Tests/Text/Segmentation/InvisibleSeparatorRedactionTests.cs
+++ b/Excise.Core.Tests/Text/Segmentation/InvisibleSeparatorRedactionTests.cs
@@ -1,0 +1,172 @@
+using System;
+using System.Linq;
+using System.Text;
+using AwesomeAssertions;
+using Excise.Core.Document;
+using Excise.Core.Tests.Text;
+using Excise.Core.Text.Segmentation;
+using Xunit;
+
+namespace Excise.Core.Tests.Text.Segmentation;
+
+/// <summary>
+/// Invisible/optional separator folding in redaction matching (#726).
+///
+/// Justified and shaped text routinely carries characters a user cannot
+/// see and will never type: soft hyphens (U+00AD) at line-break
+/// opportunities, zero-width space/non-joiner/joiner (U+200B–U+200D)
+/// between letters, the zero-width no-break space / BOM (U+FEFF), and
+/// non-breaking spaces (U+00A0) where the keyboard produces a plain space.
+/// Extraction faithfully reports these code points, so before the fix
+/// these tests cover, <c>RedactText("secret")</c> returned 0 against
+/// stored "se&#173;cret" and reported success while the word stayed in
+/// the file — CLAUDE.md limitation #1 (silent redaction failure) in
+/// ordinary justified body text.
+///
+/// The ground truth is the Unicode code points themselves (deterministic;
+/// not a tool's opinion). Matching removes exactly {U+00AD, U+200B,
+/// U+200C, U+200D, U+FEFF} and maps U+00A0 to a plain space, on BOTH
+/// sides. Scope is tight: real hyphens (U+002D), spaces, and every other
+/// format/space character keep their identity.
+///
+/// Saved-bytes assertions follow the redaction test rules: ASCII +
+/// UTF-16BE + UTF-8 views of the written file, checked for the word with
+/// and without the separator and for the raw character-code carrier, with
+/// anti-vacuity checks that the carrier existed before redaction.
+/// </summary>
+public class InvisibleSeparatorRedactionTests
+{
+    [Theory]
+    [InlineData(0x00AD, "soft hyphen")]
+    [InlineData(0x200B, "zero-width space")]
+    [InlineData(0x200C, "zero-width non-joiner")]
+    [InlineData(0x200D, "zero-width joiner")]
+    [InlineData(0xFEFF, "zero-width no-break space")]
+    public void RedactText_PlainNeedle_RemovesWordSplitByInvisibleChar(
+        int separator, string name)
+    {
+        // Stored: "se" + separator + "cret"; typed: "secret".
+        var scalars = new[] { (int)'s', (int)'e', separator, (int)'c', (int)'r', (int)'e', (int)'t' };
+        var storedWord = string.Concat(scalars.Select(char.ConvertFromUtf32));
+        var pdf = RtlPdfFixtures.SingleTj(scalars, visualOrder: false);
+        using var doc = PdfDocument.Open(pdf);
+
+        // Anti-vacuity: the split word must be present — extracted with the
+        // raw invisible code point, carried as raw character codes.
+        doc.GetPage(1).Text.Should().Contain(storedWord,
+            $"sanity: the fixture must extract with the raw {name} for this test to prove anything");
+        doc.GetPage(1).Text.Should().NotContain("secret",
+            "sanity: the unbroken spelling must NOT be extractable, or matching would succeed without separator folding");
+        SearchableTextOf(doc.SaveToBytes()).Should().Contain("(ABCDEFG)",
+            "sanity: the glyph-code carrier must be present before redaction");
+
+        var removed = doc.RedactText("secret");
+
+        removed.Should().BeGreaterThan(0,
+            $"a plain needle must match a word split by a {name} " +
+            "(U+" + separator.ToString("X4") + "); 0 matches is the " +
+            "silent-failure mode this test exists to prevent (#726)");
+
+        var saved = doc.SaveToBytes();
+        var searchable = SearchableTextOf(saved);
+        searchable.Should().NotContain("secret", "the word must not survive unbroken");
+        searchable.Should().NotContain(storedWord, "nor with the invisible separator");
+        searchable.Should().NotContain("(ABCDEFG)", "nor as its raw character codes");
+
+        using var reopened = PdfDocument.Open(saved);
+        reopened.GetPage(1).Text.Should().NotContainAny("secret", storedWord);
+    }
+
+    [Fact]
+    public void RedactText_NeedleWithPlainSpace_RemovesNonBreakingSpaceText()
+    {
+        // Stored: "top" + NBSP + "secret"; typed: "top secret" with a plain space.
+        var scalars = "top".Select(c => (int)c)
+            .Append(0x00A0)
+            .Concat("secret".Select(c => (int)c)).ToArray();
+        var storedText = "top\u00A0secret";
+        var pdf = RtlPdfFixtures.SingleTj(scalars, visualOrder: false);
+        using var doc = PdfDocument.Open(pdf);
+
+        doc.GetPage(1).Text.Should().Contain(storedText,
+            "sanity: the fixture must extract with the raw NBSP");
+
+        var removed = doc.RedactText("top secret");
+
+        removed.Should().BeGreaterThan(0,
+            "a needle typed with a plain space must match text stored with U+00A0 (#726)");
+
+        var searchable = SearchableTextOf(doc.SaveToBytes());
+        searchable.Should().NotContain(storedText);
+        searchable.Should().NotContain("top secret");
+        searchable.Should().NotContain("(ABCDEFGHIJ)");
+    }
+
+    [Fact]
+    public void RedactText_SoftHyphenNeedle_AlsoRemovesSplitWord()
+    {
+        // A user may paste text copied from a viewer, soft hyphen included.
+        // Folding applies to BOTH sides.
+        var scalars = new[] { (int)'s', (int)'e', 0x00AD, (int)'c', (int)'r', (int)'e', (int)'t' };
+        var pdf = RtlPdfFixtures.SingleTj(scalars, visualOrder: false);
+        using var doc = PdfDocument.Open(pdf);
+
+        var removed = doc.RedactText("se\u00ADcret");
+
+        removed.Should().BeGreaterThan(0);
+
+        var searchable = SearchableTextOf(doc.SaveToBytes());
+        searchable.Should().NotContain("secret");
+        searchable.Should().NotContain("se\u00ADcret");
+        searchable.Should().NotContain("(ABCDEFG)");
+    }
+
+    [Fact]
+    public void RedactText_PlainNeedle_DoesNotTouchUnrelatedText()
+    {
+        // Scope guard: redacting the split word must leave other text on the
+        // same line intact.
+        var scalars = new[] { (int)'s', (int)'e', 0x00AD, (int)'c', (int)'r', (int)'e', (int)'t' }
+            .Append(' ').Concat("xyz".Select(c => (int)c)).ToArray();
+        var pdf = RtlPdfFixtures.SingleTj(scalars, visualOrder: false);
+        using var doc = PdfDocument.Open(pdf);
+
+        var removed = doc.RedactText("secret");
+
+        removed.Should().BeGreaterThan(0);
+
+        using var reopened = PdfDocument.Open(doc.SaveToBytes());
+        var text = reopened.GetPage(1).Text;
+        text.Should().Contain("xyz", "unrelated text on the same line must survive");
+        text.Should().NotContain("secret");
+    }
+
+    [Fact]
+    public void RedactText_RealHyphen_IsNotFolded()
+    {
+        // Scope guard: a REAL hyphen (U+002D) is visible content, not an
+        // optional separator — "secret" must not match "se-cret".
+        var scalars = new[] { (int)'s', (int)'e', (int)'-', (int)'c', (int)'r', (int)'e', (int)'t' };
+        var pdf = RtlPdfFixtures.SingleTj(scalars, visualOrder: false);
+        using var doc = PdfDocument.Open(pdf);
+
+        var removed = doc.RedactText("secret");
+
+        removed.Should().Be(0,
+            "a real hyphen is visible content; only the soft hyphen is an optional separator");
+
+        using var reopened = PdfDocument.Open(doc.SaveToBytes());
+        reopened.GetPage(1).Text.Should().Contain("se-cret",
+            "the hyphenated word must be untouched");
+    }
+
+    /// <summary>
+    /// Carrier-agnostic view of the saved file, per the redaction test rules:
+    /// ASCII (raw codes, hex carriers) + UTF-16BE (PDF Unicode text strings)
+    /// + UTF-8 (XMP metadata).
+    /// </summary>
+    private static string SearchableTextOf(byte[] saved) =>
+        Encoding.ASCII.GetString(saved) +
+        Encoding.BigEndianUnicode.GetString(saved) +
+        Encoding.UTF8.GetString(saved);
+}

--- a/Excise.Core/Operations/PdfRedaction.cs
+++ b/Excise.Core/Operations/PdfRedaction.cs
@@ -222,14 +222,20 @@ public class PdfRedaction
     {
         var results = new List<List<Letter>>();
 
-        // Fold Arabic presentation forms (#632) and Latin ligatures (#722)
-        // on both sides so a plain-letter needle matches shaped/ligated
-        // text; index arithmetic stays in folded space via the per-letter
-        // folded values (lam-alef folds 1 char → 2, ﬃ folds 1 → 3).
-        var needle = PresentationFormFolding.Fold(searchText);
-        var foldedValues = new string[letters.Count];
+        // Fold BOTH sides into the canonical matching space — presentation
+        // forms/ligatures to plain letters (#632, #722), canonical NFC
+        // composition (#724) — so a plain-letter or precomposed needle
+        // matches shaped, ligated, or decomposed text; index arithmetic
+        // stays in folded space via the per-letter folded values (lam-alef
+        // folds 1 char → 2, ﬃ folds 1 → 3, a combining-accent letter folds
+        // to "" after merging into its base's cluster).
+        var needle = MatchingNormalization.Fold(searchText);
+        if (needle.Length == 0)
+            return results;
+        var rawValues = new string[letters.Count];
         for (int i = 0; i < letters.Count; i++)
-            foldedValues[i] = PresentationFormFolding.Fold(letters[i].Value);
+            rawValues[i] = letters[i].Value;
+        var foldedValues = MatchingNormalization.FoldAll(rawValues);
 
         var fullText = string.Concat(foldedValues);
 
@@ -246,11 +252,23 @@ public class PdfRedaction
                 letterIndex++;
             }
 
+            // Zero-length folded values at the boundary belong to the
+            // previous cluster — skip before, absorb after (see
+            // TextRedactor.FindTextOccurrences).
+            while (letterIndex < letters.Count && foldedValues[letterIndex].Length == 0)
+                letterIndex++;
+
             var matchChars = 0;
             while (matchChars < needle.Length && letterIndex < letters.Count)
             {
                 match.Add(letters[letterIndex]);
                 matchChars += foldedValues[letterIndex].Length;
+                letterIndex++;
+            }
+
+            while (letterIndex < letters.Count && foldedValues[letterIndex].Length == 0)
+            {
+                match.Add(letters[letterIndex]);
                 letterIndex++;
             }
 

--- a/Excise.Core/Operations/TextRedactor.cs
+++ b/Excise.Core/Operations/TextRedactor.cs
@@ -155,16 +155,22 @@ public class TextRedactor
     {
         var results = new List<List<Letter>>();
 
-        // Fold Arabic presentation forms (#632) and Latin ligatures (#722) to
-        // plain letters on BOTH sides so a plain-letter needle matches
-        // shaped/ligated text. All index arithmetic below is done
-        // consistently in folded space: the per-letter folded values (a
-        // lam-alef ligature folds 1 char → 2, ﬃ folds 1 → 3) drive the
-        // mapping from folded string positions back to letters.
-        var needle = PresentationFormFolding.Fold(searchText);
-        var foldedValues = new string[letters.Count];
+        // Fold BOTH sides into the canonical matching space — presentation
+        // forms/ligatures to plain letters (#632, #722) and canonical NFC
+        // composition (#724) — so a plain-letter or precomposed needle
+        // matches shaped, ligated, or decomposed text. All index arithmetic
+        // below is done consistently in folded space: the per-letter folded
+        // values (a lam-alef ligature folds 1 char → 2, ﬃ folds 1 → 3, a
+        // combining-accent letter folds to "" after merging into its base's
+        // cluster) drive the mapping from folded string positions back to
+        // letters.
+        var needle = MatchingNormalization.Fold(searchText);
+        if (needle.Length == 0)
+            return results;
+        var rawValues = new string[letters.Count];
         for (int i = 0; i < letters.Count; i++)
-            foldedValues[i] = PresentationFormFolding.Fold(letters[i].Value);
+            rawValues[i] = letters[i].Value;
+        var foldedValues = MatchingNormalization.FoldAll(rawValues);
 
         // Build a string from all letters for searching
         var fullText = string.Concat(foldedValues);
@@ -185,12 +191,27 @@ public class TextRedactor
                 letterIndex++;
             }
 
+            // Letters at the boundary with zero-length folded values belong
+            // to the PREVIOUS cluster (e.g. a combining accent merged into
+            // the base letter before the match) — skip them.
+            while (letterIndex < letters.Count && foldedValues[letterIndex].Length == 0)
+                letterIndex++;
+
             // Collect letters that make up the match
             var matchChars = 0;
             while (matchChars < needle.Length && letterIndex < letters.Count)
             {
                 match.Add(letters[letterIndex]);
                 matchChars += foldedValues[letterIndex].Length;
+                letterIndex++;
+            }
+
+            // Absorb trailing letters whose folded values are empty — they
+            // are part of the last matched cluster (its combining marks) and
+            // must be removed with it.
+            while (letterIndex < letters.Count && foldedValues[letterIndex].Length == 0)
+            {
+                match.Add(letters[letterIndex]);
                 letterIndex++;
             }
 

--- a/Excise.Core/Text/MatchingNormalization.cs
+++ b/Excise.Core/Text/MatchingNormalization.cs
@@ -19,6 +19,14 @@ namespace Excise.Core.Text;
 /// ("cafe" + combining acute U+0301) and vice versa. Canonical ONLY — this
 /// is deliberately not NFKC, which would rewrite unrelated compatibility
 /// characters and loosen matching.</item>
+/// <item>Arabic harakat / Hebrew niqqud stripping (#725) — the optional
+/// vocalization marks of the two scripts (Arabic U+064B–U+065F, U+0670,
+/// Koranic U+06D6–U+06ED; Hebrew combining points/cantillation in
+/// U+0591–U+05C7) are removed, so a bare needle ("كتب", "שלום") matches
+/// vocalized storage ("كَتَبَ", "שָׁלוֹם"). Scoped to those scripts' combining
+/// marks ONLY: Latin combining accents are canonically meaningful and kept,
+/// and the Hebrew PUNCTUATION sharing the block (maqaf U+05BE, paseq
+/// U+05C0, sof pasuq U+05C3, nun hafukha U+05C6) is untouched.</item>
 /// </list>
 /// </summary>
 /// <remarks>
@@ -45,16 +53,18 @@ public static class MatchingNormalization
 {
     /// <summary>
     /// Fold <paramref name="text"/> into the canonical matching space:
-    /// presentation forms/ligatures decomposed to plain letters, then the
-    /// whole string composed to Unicode NFC. Returns the original string
-    /// instance when nothing changes.
+    /// presentation forms/ligatures decomposed to plain letters, the whole
+    /// string composed to Unicode NFC, then optional Arabic/Hebrew
+    /// vocalization marks stripped. Returns the original string instance
+    /// when nothing changes.
     /// </summary>
     public static string Fold(string text)
     {
         if (string.IsNullOrEmpty(text)) return text;
 
         var folded = PresentationFormFolding.Fold(text);
-        return CanonicalCompose(folded);
+        folded = CanonicalCompose(folded);
+        return StripSemiticVocalization(folded);
     }
 
     /// <summary>
@@ -106,6 +116,73 @@ public static class MatchingNormalization
         return category is UnicodeCategory.NonSpacingMark
             or UnicodeCategory.SpacingCombiningMark
             or UnicodeCategory.EnclosingMark;
+    }
+
+    /// <summary>
+    /// True when <paramref name="c"/> is an optional Arabic or Hebrew
+    /// vocalization mark stripped for matching (#725): Arabic harakat and
+    /// annotation signs — U+064B–U+065F (incl. shadda/sukun), U+0670
+    /// (superscript alef), U+06D6–U+06DC, U+06DF–U+06E4, U+06E7–U+06E8,
+    /// U+06EA–U+06ED (Koranic marks) — and the Hebrew combining marks of
+    /// U+0591–U+05C7: U+0591–U+05BD (cantillation + points), U+05BF (rafe),
+    /// U+05C1–U+05C2 (shin/sin dots), U+05C4–U+05C5, U+05C7. The
+    /// non-combining PUNCTUATION interleaved in that Hebrew range — maqaf
+    /// U+05BE, paseq U+05C0, sof pasuq U+05C3, nun hafukha U+05C6 — is
+    /// deliberately NOT included. Runs AFTER canonical composition, so
+    /// marks that canonically compose into a distinct letter (alef + madda
+    /// U+0653 → U+0622, alef + hamza U+0654 → U+0623) are preserved inside
+    /// the composed letter and only truly optional marks are stripped.
+    /// </summary>
+    public static bool IsSemiticVocalizationMark(char c)
+    {
+        if (c < '\u0591' || c > '\u06ED') return false;
+
+        return c switch
+        {
+            // Hebrew: combining marks only, skipping the block's punctuation.
+            >= '\u0591' and <= '\u05BD' => true,
+            '\u05BF' => true,
+            '\u05C1' or '\u05C2' => true,
+            '\u05C4' or '\u05C5' => true,
+            '\u05C7' => true,
+
+            // Arabic: harakat, tanween, shadda, sukun; superscript alef.
+            >= '\u064B' and <= '\u065F' => true,
+            '\u0670' => true,
+
+            // Arabic: Koranic annotation signs (the combining subranges).
+            >= '\u06D6' and <= '\u06DC' => true,
+            >= '\u06DF' and <= '\u06E4' => true,
+            '\u06E7' or '\u06E8' => true,
+            >= '\u06EA' and <= '\u06ED' => true,
+
+            _ => false,
+        };
+    }
+
+    /// <summary>
+    /// Remove every character matched by
+    /// <see cref="IsSemiticVocalizationMark"/>; returns the original string
+    /// instance when none is present.
+    /// </summary>
+    private static string StripSemiticVocalization(string text)
+    {
+        int first = -1;
+        for (int i = 0; i < text.Length; i++)
+        {
+            if (IsSemiticVocalizationMark(text[i])) { first = i; break; }
+        }
+
+        if (first < 0) return text;
+
+        var sb = new StringBuilder(text.Length);
+        sb.Append(text, 0, first);
+        for (int i = first; i < text.Length; i++)
+        {
+            if (!IsSemiticVocalizationMark(text[i])) sb.Append(text[i]);
+        }
+
+        return sb.ToString();
     }
 
     /// <summary>

--- a/Excise.Core/Text/MatchingNormalization.cs
+++ b/Excise.Core/Text/MatchingNormalization.cs
@@ -1,0 +1,132 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+
+namespace Excise.Core.Text;
+
+/// <summary>
+/// The single normalization pipeline used by every MATCHING path — redaction
+/// text search (<c>PdfDocument.RedactText</c>, <c>TextRedactor</c>,
+/// <c>PdfRedaction</c>, the operator-text backstop) and the GUI search
+/// service. It composes, in order:
+/// <list type="number">
+/// <item>Presentation-form folding (<see cref="PresentationFormFolding"/>) —
+/// Arabic presentation blocks (#632) and Latin ligatures (#722) to their
+/// plain-letter compatibility decompositions.</item>
+/// <item>Canonical composition (NFC, #724) — so precomposed needles
+/// ("café", U+00E9) match canonically equivalent decomposed storage
+/// ("cafe" + combining acute U+0301) and vice versa. Canonical ONLY — this
+/// is deliberately not NFKC, which would rewrite unrelated compatibility
+/// characters and loosen matching.</item>
+/// </list>
+/// </summary>
+/// <remarks>
+/// <para>
+/// Folding is for MATCHING only: callers fold both the needle and the
+/// haystack view they search, never the stored text — extraction
+/// (<c>page.Text</c>, letters, operator text) keeps raw code points so
+/// glyph-level removal still pairs char↔glyph on raw values. The fold can
+/// change length in both directions (ﬃ 1→3 expands; e + U+0301 → é 2→1
+/// shrinks), so index arithmetic must stay consistently in raw or folded
+/// space, never across the two.
+/// </para>
+/// <para>
+/// Canonical composition is NOT per-character: a base letter and its
+/// combining mark may arrive as two separate letters/glyphs. Per-letter
+/// callers must use <see cref="FoldAll"/>, which folds letter values
+/// cluster-wise (a letter whose folded value begins with a combining mark is
+/// merged into the preceding letter's folded value, which then re-composes),
+/// so that concatenating the per-letter folds equals folding the
+/// concatenation.
+/// </para>
+/// </remarks>
+public static class MatchingNormalization
+{
+    /// <summary>
+    /// Fold <paramref name="text"/> into the canonical matching space:
+    /// presentation forms/ligatures decomposed to plain letters, then the
+    /// whole string composed to Unicode NFC. Returns the original string
+    /// instance when nothing changes.
+    /// </summary>
+    public static string Fold(string text)
+    {
+        if (string.IsNullOrEmpty(text)) return text;
+
+        var folded = PresentationFormFolding.Fold(text);
+        return CanonicalCompose(folded);
+    }
+
+    /// <summary>
+    /// Fold a sequence of per-letter text values so that
+    /// <c>string.Concat(result)</c> equals <see cref="Fold"/> of the
+    /// concatenated values (modulo unmatched cluster boundaries). A letter
+    /// whose folded value begins with a combining mark contributes the empty
+    /// string, and its mark is composed into the preceding letter's folded
+    /// value — callers doing folded-space index arithmetic must treat
+    /// zero-length values as part of the preceding letter's cluster.
+    /// </summary>
+    public static string[] FoldAll(IReadOnlyList<string> values)
+    {
+        if (values == null) throw new ArgumentNullException(nameof(values));
+
+        var folded = new string[values.Count];
+        int lastNonEmpty = -1;
+        for (int i = 0; i < values.Count; i++)
+        {
+            folded[i] = Fold(values[i] ?? string.Empty);
+
+            // A folded value that STARTS with a combining mark continues the
+            // preceding letter's canonical cluster (decomposed accents stored
+            // as their own glyphs, or width-folded voiced marks). Merge it
+            // left and re-fold so the cluster composes; the merged letter
+            // keeps a zero-length folded value.
+            if (folded[i].Length > 0 && lastNonEmpty >= 0 &&
+                IsCombiningMark(folded[i][0]))
+            {
+                folded[lastNonEmpty] = Fold(folded[lastNonEmpty] + folded[i]);
+                folded[i] = string.Empty;
+                continue;
+            }
+
+            if (folded[i].Length > 0) lastNonEmpty = i;
+        }
+
+        return folded;
+    }
+
+    /// <summary>
+    /// True when <paramref name="c"/> is a combining mark that attaches to
+    /// the preceding base character (Unicode nonspacing/spacing-combining/
+    /// enclosing mark).
+    /// </summary>
+    public static bool IsCombiningMark(char c)
+    {
+        var category = CharUnicodeInfo.GetUnicodeCategory(c);
+        return category is UnicodeCategory.NonSpacingMark
+            or UnicodeCategory.SpacingCombiningMark
+            or UnicodeCategory.EnclosingMark;
+    }
+
+    /// <summary>
+    /// Unicode canonical composition (NFC), tolerant of the malformed
+    /// sequences PDF /ToUnicode maps can produce: strings that are already
+    /// NFC are returned as the same instance, and strings .NET cannot
+    /// normalize (unpaired surrogates, noncharacters) are returned raw
+    /// rather than throwing — matching then degrades to exact comparison
+    /// for that string instead of failing the whole operation.
+    /// </summary>
+    private static string CanonicalCompose(string text)
+    {
+        try
+        {
+            return text.IsNormalized(NormalizationForm.FormC)
+                ? text
+                : text.Normalize(NormalizationForm.FormC);
+        }
+        catch (ArgumentException)
+        {
+            return text;
+        }
+    }
+}

--- a/Excise.Core/Text/MatchingNormalization.cs
+++ b/Excise.Core/Text/MatchingNormalization.cs
@@ -27,6 +27,12 @@ namespace Excise.Core.Text;
 /// marks ONLY: Latin combining accents are canonically meaningful and kept,
 /// and the Hebrew PUNCTUATION sharing the block (maqaf U+05BE, paseq
 /// U+05C0, sof pasuq U+05C3, nun hafukha U+05C6) is untouched.</item>
+/// <item>Invisible/optional separator folding (#726) — soft hyphen U+00AD
+/// and the zero-width characters U+200B–U+200D and U+FEFF are removed, and
+/// non-breaking space U+00A0 becomes a plain space, so "secret" matches
+/// "se&#173;cret" in justified text and "top secret" matches
+/// "top&#160;secret". Exactly those five-plus-one code points — real
+/// hyphens, spaces, and other format characters keep their identity.</item>
 /// </list>
 /// </summary>
 /// <remarks>
@@ -64,7 +70,8 @@ public static class MatchingNormalization
 
         var folded = PresentationFormFolding.Fold(text);
         folded = CanonicalCompose(folded);
-        return StripSemiticVocalization(folded);
+        folded = StripSemiticVocalization(folded);
+        return FoldSeparators(folded);
     }
 
     /// <summary>
@@ -180,6 +187,47 @@ public static class MatchingNormalization
         for (int i = first; i < text.Length; i++)
         {
             if (!IsSemiticVocalizationMark(text[i])) sb.Append(text[i]);
+        }
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// True when <paramref name="c"/> is an invisible/optional separator
+    /// removed for matching (#726): soft hyphen U+00AD (a line-break
+    /// OPPORTUNITY the layout engine may or may not render), zero-width
+    /// space/non-joiner/joiner U+200B–U+200D, and zero-width no-break
+    /// space / BOM U+FEFF. Exactly these code points — a real hyphen
+    /// (U+002D) is visible content and keeps its identity, as do all other
+    /// format characters (bidi marks are handled by
+    /// <see cref="BidiReorderer"/>, not stripped here).
+    /// </summary>
+    public static bool IsIgnorableSeparator(char c) =>
+        c is '\u00AD' or '\u200B' or '\u200C' or '\u200D' or '\uFEFF';
+
+    /// <summary>
+    /// Remove every <see cref="IsIgnorableSeparator"/> character and map
+    /// non-breaking space U+00A0 to a plain space; returns the original
+    /// string instance when neither occurs.
+    /// </summary>
+    private static string FoldSeparators(string text)
+    {
+        int first = -1;
+        for (int i = 0; i < text.Length; i++)
+        {
+            var c = text[i];
+            if (IsIgnorableSeparator(c) || c == '\u00A0') { first = i; break; }
+        }
+
+        if (first < 0) return text;
+
+        var sb = new StringBuilder(text.Length);
+        sb.Append(text, 0, first);
+        for (int i = first; i < text.Length; i++)
+        {
+            var c = text[i];
+            if (IsIgnorableSeparator(c)) continue;
+            sb.Append(c == '\u00A0' ? ' ' : c);
         }
 
         return sb.ToString();

--- a/Excise.Core/Text/MatchingNormalization.cs
+++ b/Excise.Core/Text/MatchingNormalization.cs
@@ -33,6 +33,16 @@ namespace Excise.Core.Text;
 /// "se&#173;cret" in justified text and "top secret" matches
 /// "top&#160;secret". Exactly those five-plus-one code points — real
 /// hyphens, spaces, and other format characters keep their identity.</item>
+/// <item>Halfwidth/fullwidth form folding (#727) — every character of the
+/// Halfwidth and Fullwidth Forms block U+FF00–U+FFEF folds to its
+/// compatibility decomposition, so an ASCII needle ("ABC", "123") matches
+/// fullwidth storage ("ＡＢＣ", "１２３") and a regular-katakana needle
+/// matches halfwidth katakana ("ｶﾀｶﾅ"). Scoped to THAT BLOCK only —
+/// deliberately not whole-string NFKC, which would also rewrite
+/// superscripts, circled numbers and other compatibility characters. A
+/// width fold can surface combining marks (halfwidth voiced ﾞ → U+3099),
+/// so the result is canonically re-composed to keep the NFC invariant
+/// (ｶ + ﾞ ends as ガ).</item>
 /// </list>
 /// </summary>
 /// <remarks>
@@ -60,9 +70,10 @@ public static class MatchingNormalization
     /// <summary>
     /// Fold <paramref name="text"/> into the canonical matching space:
     /// presentation forms/ligatures decomposed to plain letters, the whole
-    /// string composed to Unicode NFC, then optional Arabic/Hebrew
-    /// vocalization marks stripped. Returns the original string instance
-    /// when nothing changes.
+    /// string composed to Unicode NFC, optional Arabic/Hebrew vocalization
+    /// marks stripped, invisible separators removed (NBSP → space), and
+    /// halfwidth/fullwidth forms folded. Returns the original string
+    /// instance when nothing changes.
     /// </summary>
     public static string Fold(string text)
     {
@@ -71,7 +82,8 @@ public static class MatchingNormalization
         var folded = PresentationFormFolding.Fold(text);
         folded = CanonicalCompose(folded);
         folded = StripSemiticVocalization(folded);
-        return FoldSeparators(folded);
+        folded = FoldSeparators(folded);
+        return FoldWidthForms(folded);
     }
 
     /// <summary>
@@ -231,6 +243,82 @@ public static class MatchingNormalization
         }
 
         return sb.ToString();
+    }
+
+    private const char WidthBlockStart = '\uFF00';
+    private const char WidthBlockEnd = '\uFFEF';
+
+    /// <summary>
+    /// Per-character fold cache for the Halfwidth and Fullwidth Forms
+    /// block. Index 0 corresponds to U+FF00.
+    /// </summary>
+    private static readonly string?[] WidthFoldCache =
+        new string?[WidthBlockEnd - WidthBlockStart + 1];
+
+    /// <summary>
+    /// True when <paramref name="c"/> is in the Halfwidth and Fullwidth
+    /// Forms block (U+FF00–U+FFEF) folded for matching (#727). U+FEFF is
+    /// just below the block and is handled by
+    /// <see cref="IsIgnorableSeparator"/> instead.
+    /// </summary>
+    public static bool IsWidthForm(char c) =>
+        c >= WidthBlockStart && c <= WidthBlockEnd;
+
+    /// <summary>
+    /// Replace every Halfwidth and Fullwidth Forms character with its
+    /// compatibility decomposition (U+FF21 → "A", U+FF76 → "カ", U+FF9E →
+    /// combining U+3099) and canonically re-compose the result so surfaced
+    /// combining marks join their base (ｶ + ﾞ → ガ), keeping the pipeline's
+    /// NFC invariant. Returns the original string instance when the block
+    /// does not occur.
+    /// </summary>
+    private static string FoldWidthForms(string text)
+    {
+        int first = -1;
+        for (int i = 0; i < text.Length; i++)
+        {
+            if (IsWidthForm(text[i])) { first = i; break; }
+        }
+
+        if (first < 0) return text;
+
+        var sb = new StringBuilder(text.Length + 8);
+        sb.Append(text, 0, first);
+        for (int i = first; i < text.Length; i++)
+        {
+            var c = text[i];
+            if (IsWidthForm(c)) sb.Append(FoldWidthChar(c));
+            else sb.Append(c);
+        }
+
+        return CanonicalCompose(sb.ToString());
+    }
+
+    /// <summary>
+    /// The NFKC decomposition of a single character in U+FF00–U+FFEF —
+    /// per-character, so nothing outside the block is ever rewritten.
+    /// Unassigned code points inside the block have no decomposition and
+    /// can make Normalize throw; they fold to themselves (same guard as
+    /// <see cref="ArabicPresentationForms"/>).
+    /// </summary>
+    private static string FoldWidthChar(char c)
+    {
+        int index = c - WidthBlockStart;
+        var cached = WidthFoldCache[index];
+        if (cached != null) return cached;
+
+        string folded;
+        try
+        {
+            folded = c.ToString().Normalize(NormalizationForm.FormKC);
+        }
+        catch (ArgumentException)
+        {
+            folded = c.ToString();
+        }
+
+        WidthFoldCache[index] = folded;
+        return folded;
     }
 
     /// <summary>

--- a/Excise.Core/Text/Segmentation/PdfDocumentRedactionExtensions.cs
+++ b/Excise.Core/Text/Segmentation/PdfDocumentRedactionExtensions.cs
@@ -173,13 +173,14 @@ public static class PdfDocumentRedactionExtensions
             : null;
 
         // The stream may also carry Arabic as shaped presentation forms
-        // (#632) or Latin ligature code points like ﬃ (#722) while the
-        // needle is plain/base letters. Fold the needle once; each
-        // operator's text is checked folded — both as stored and with its RTL
-        // runs reversed to logical order FIRST (reversing must happen on the
-        // raw shaped chars: a lam-alef ligature is one char before folding
-        // but two after, and reversing the folded string would scramble it).
-        var foldedNeedle = PresentationFormFolding.Fold(searchText);
+        // (#632), Latin ligature code points like ﬃ (#722), or decomposed
+        // accents (e + U+0301 for é, #724) while the needle is typed in
+        // plain/precomposed letters. Fold the needle once; each operator's
+        // text is checked folded — both as stored and with its RTL runs
+        // reversed to logical order FIRST (reversing must happen on the raw
+        // shaped chars: a lam-alef ligature is one char before folding but
+        // two after, and reversing the folded string would scramble it).
+        var foldedNeedle = MatchingNormalization.Fold(searchText);
 
         foreach (var op in content.Operators)
         {
@@ -205,26 +206,27 @@ public static class PdfDocumentRedactionExtensions
     }
 
     /// <summary>
-    /// True when <paramref name="opText"/>, folded from Arabic presentation
-    /// forms / Latin ligatures to plain letters, contains
-    /// <paramref name="foldedNeedle"/> — checked in stored order and, for
-    /// strong-RTL content, with its RTL runs reversed to logical order
-    /// before folding (visual-order streams).
+    /// True when <paramref name="opText"/>, folded into the canonical
+    /// matching space (presentation forms / ligatures to plain letters,
+    /// canonical NFC composition), contains <paramref name="foldedNeedle"/>
+    /// — checked in stored order and, for strong-RTL content, with its RTL
+    /// runs reversed to logical order before folding (visual-order streams).
     /// </summary>
     private static bool ContainsFolded(
         string opText, string foldedNeedle, StringComparison comparison)
     {
-        if (foldedNeedle.Length == 0 ||
-            !PresentationFormFolding.ContainsFoldable(opText))
-        {
+        if (foldedNeedle.Length == 0)
             return false;
-        }
 
-        if (PresentationFormFolding.Fold(opText).IndexOf(foldedNeedle, comparison) >= 0)
+        // Fold is identity (same instance) for unaffected text, so this is
+        // cheap; no pre-gate on "contains foldable chars" — the needle side
+        // alone can differ from its raw form (a decomposed needle against
+        // precomposed operator text), which a haystack-only gate would miss.
+        if (MatchingNormalization.Fold(opText).IndexOf(foldedNeedle, comparison) >= 0)
             return true;
 
         return BidiReorderer.ContainsStrongRtl(opText) &&
-               PresentationFormFolding.Fold(BidiReorderer.ReverseRtlRunsInString(opText))
+               MatchingNormalization.Fold(BidiReorderer.ReverseRtlRunsInString(opText))
                    .IndexOf(foldedNeedle, comparison) >= 0;
     }
 
@@ -320,10 +322,11 @@ public static class PdfDocumentRedactionExtensions
         int i = 0;
         while (i < fullText.Length)
         {
-            // Normalize may collapse whitespace, so a window of 2× needle
-            // length is a safe upper bound on "does the text here start with
-            // needle?"
-            var windowLen = Math.Min(needle.Length * 2, fullText.Length - i);
+            // Normalize may collapse whitespace and SHRINK raw text
+            // (decomposed accents compose: e + U+0301 → é, up to several raw
+            // marks per folded char), so a window of 4× needle length is the
+            // safe upper bound on "does the text here start with needle?"
+            var windowLen = Math.Min(needle.Length * 4, fullText.Length - i);
             var normWindow = NormalizeText(fullText.Substring(i, windowLen));
 
             if (normWindow.StartsWith(needle, comparison))
@@ -337,6 +340,18 @@ public static class PdfDocumentRedactionExtensions
                     var cur = NormalizeText(fullText.Substring(i, endIndex - i + 1));
                     if (cur.Equals(needle, comparison)) break;
                     if (cur.Length >= needle.Length) break;
+                    endIndex++;
+                }
+
+                // Absorb trailing raw combining marks: the last matched
+                // letter's canonical cluster may continue past the minimal
+                // span (needle "café" against raw "cafe" + U+0301 — the
+                // expansion stops at the 'e' when the raw length reaches the
+                // needle length, but the accent belongs to the matched
+                // cluster and must be removed with it).
+                while (endIndex + 1 < fullText.Length &&
+                       MatchingNormalization.IsCombiningMark(fullText[endIndex + 1]))
+                {
                     endIndex++;
                 }
 
@@ -369,13 +384,16 @@ public static class PdfDocumentRedactionExtensions
         if (string.IsNullOrEmpty(text)) return text;
 
         // Arabic can be stored as shaped presentation forms (U+FB50–U+FDFF,
-        // U+FE70–U+FEFF — #632) and Latin text as ligature code points
-        // (U+FB00–U+FB06, e.g. "oﬃce" — #722) while the user types plain
-        // letters; fold both sides of the comparison to the plain-letter
-        // decomposition. Note the fold EXPANDS (lam-alef 1 char → 2,
-        // ﬃ 1 → 3), so normalized length may exceed raw length —
-        // FindTextMatches accounts for that.
-        var normalized = PresentationFormFolding.Fold(text)
+        // U+FE70–U+FEFF — #632), Latin text as ligature code points
+        // (U+FB00–U+FB06, e.g. "oﬃce" — #722), and accented text in either
+        // canonical spelling ("café" vs "cafe" + U+0301 — #724) while the
+        // user types plain/precomposed letters; fold both sides of the
+        // comparison into the canonical matching space. Note the fold can
+        // change length in BOTH directions (lam-alef 1 char → 2, ﬃ 1 → 3
+        // expand; e + U+0301 → é shrinks 2 → 1), so normalized length may
+        // differ from raw length either way — FindTextMatches accounts for
+        // that.
+        var normalized = MatchingNormalization.Fold(text)
             .Replace('’', '\'')  // right single quote
             .Replace('‘', '\'')  // left single quote
             .Replace('ʼ', '\'')  // modifier letter apostrophe


### PR DESCRIPTION
Completes the search/redaction matching-normalization family (Fable-implemented, independently re-verified). Each class is a silent redaction failure — `RedactText`/search miss a word because the stored Unicode form differs from what the user types (CLAUDE.md limitation #1). Builds on the merged RTL/Arabic-presentation-form/Latin-ligature folds.

New `Excise.Core/Text/MatchingNormalization.cs` — the single matching fold used by every path (`PdfDocumentRedactionExtensions` incl. operator backstop, `TextRedactor`, `PdfRedaction`, `PdfSearchService`). **Order:** presentation forms/ligatures → **NFC** → harakat/niqqud strip → invisible separators → fullwidth/halfwidth (+ re-compose). Matching-only — extraction/letters/operator text stay raw; `FoldAll` does cluster-wise per-letter folding so combining-mark glyphs are removed with their base (folded-space index arithmetic).

## Classes (each its own commit + tests + security bug)
- **#724 NFC canonical accents** — `café` (precomposed) vs `cafe`+U+0301 now match. Canonical only (no NFKC — ²/①/℡ untouched); accent-*insensitivity* explicitly out of scope.
- **#725 Arabic harakat / Hebrew niqqud** — bare-letter needle matches vocalized/pointed text. Scoped to the two scripts' combining marks (Hebrew punctuation maqaf pinned excluded; Latin accents untouched); runs after NFC so alef+hamza→U+0623 survives.
- **#726 invisible separators** — soft hyphen U+00AD, zero-width U+200B–200D/FEFF removed, NBSP→space. Real hyphen pinned ("secret" ≠ "se-cret").
- **#727 fullwidth/halfwidth** — U+FF00–FFEF folds to ASCII/composed katakana (incl. cross-letter halfwidth voiced pairs カ+゛→ガ). NFKC-creep pinned.

## Verification (no self-oracle)
Ground truth = deterministic Unicode code points (explicit `\uXXXX`), not a reference tool. Per class: red→green fixtures, saved bytes clean in ASCII+UTF-16BE+UTF-8 with anti-vacuity carriers, unrelated-text scope guards. Plus `MatchingNormalizationTests` (22: stage order, FoldAll contract, identity fast-path, surrogate tolerance).

Gates (re-run on clean develop): **redaction+normalization suite 166 tests × 3 runs stable** (the agent's post-rebuild transient did not reproduce); extraction-parity #645 PASS (332 pages ≥ floor — extraction byte-identical, matching-only); full Core 3521/0; App search 104/0; t0 all 9 PASS; 0 warnings.

Closes #724, #725, #726, #727.

🤖 Generated with [Claude Code](https://claude.com/claude-code)