### PR TITLE
fix(render): keep DrawText mask fill for embedded raw Type 1 faces — #710 regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,17 @@ now extracts *and* renders, and page content is exposed to screen readers.
   outline — with a DrawText fallback for bitmap-only faces (color emoji).
   Gated by `TextRasterInkParityTests` against mutool on an embedded-CFF
   fixture.
+- **Raw Type 1 (`/FontFile`) text keeps the platform glyph-mask fill**
+  (#710 regression fix) — the outline-path fill above made embedded raw
+  Type 1 faces render *worse* against the references (highlights.pdf p5,
+  URW Nimbus Roman: DifferingPixelFraction vs mutool 0.00067 → 0.0152),
+  because the platform's raw-Type1 raster path never applied the CFF
+  stem darkening the outline fill was fixing — DrawText already matched
+  mutool almost exactly there. Outline fill is now scoped to embedded
+  CFF/Type1C, TrueType, OpenType, and system-substituted faces
+  (`ResolvedRenderFont.HasRawType1Program` gate in
+  `FillTextUsingGlyphPath`); both directions are test-gated
+  (`PdfJsFontFallbackDifferentialTests` + `TextRasterInkParityTests`).
 - **Type 3 uncolored-glyph (d1) colour semantics** (#514) — a d1 CharProc's
   own colour operators are now ignored so the glyph paints in the text
   object's fill colour, per ISO 32000-1 §9.6.5.

--- a/Excise.Rendering.Tests/Fonts/ResolvedRenderFontTests.cs
+++ b/Excise.Rendering.Tests/Fonts/ResolvedRenderFontTests.cs
@@ -56,6 +56,7 @@ public class ResolvedRenderFontTests
             Typeface: null,
             ByteToGlyph: null,
             HasEmbeddedProgram: false,
+            HasRawType1Program: false,
             CidWidths: null,
             CidDefaultWidth: 1000f,
             CidUseUnicodeCmap: false,
@@ -77,10 +78,10 @@ public class ResolvedRenderFontTests
     public void ForwardingProperties_ReflectType0AndType3Subtypes()
     {
         var type0 = new ResolvedRenderFont(
-            MakePdfFont(subtype: "Type0"), null, null, null, null, null, false,
+            MakePdfFont(subtype: "Type0"), null, null, null, null, null, false, false,
             null, 1000f, false, null, null, null, Array.Empty<string>());
         var type3 = new ResolvedRenderFont(
-            MakePdfFont(subtype: "Type3"), null, null, null, null, null, false,
+            MakePdfFont(subtype: "Type3"), null, null, null, null, null, false, false,
             null, 1000f, false, null, null, null, Array.Empty<string>());
 
         type0.IsType0.Should().BeTrue();
@@ -98,7 +99,7 @@ public class ResolvedRenderFontTests
         };
 
         var resolved = new ResolvedRenderFont(
-            MakePdfFont(), null, null, null, null, null, false,
+            MakePdfFont(), null, null, null, null, null, false, false,
             null, 1000f, false, null, null, null, diagnostics);
 
         resolved.Diagnostics.Should().ContainSingle()
@@ -109,7 +110,7 @@ public class ResolvedRenderFontTests
     public void Diagnostics_DefaultsToEmpty_NotNull_WhenFontResolvesCleanly()
     {
         var resolved = new ResolvedRenderFont(
-            MakePdfFont(), null, null, null, null, null, false,
+            MakePdfFont(), null, null, null, null, null, false, false,
             null, 1000f, false, null, null, null, Array.Empty<string>());
 
         resolved.Diagnostics.Should().NotBeNull();
@@ -129,7 +130,7 @@ public class ResolvedRenderFontTests
     public void With_ProducesANewInstance_OriginalIsUnaffected()
     {
         var original = new ResolvedRenderFont(
-            MakePdfFont(), null, null, null, null, null, HasEmbeddedProgram: false,
+            MakePdfFont(), null, null, null, null, null, HasEmbeddedProgram: false, HasRawType1Program: false,
             null, 1000f, false, null, null, null, Array.Empty<string>());
 
         var modified = original with { HasEmbeddedProgram = true };

--- a/Excise.Rendering/Fonts/ResolvedRenderFont.cs
+++ b/Excise.Rendering/Fonts/ResolvedRenderFont.cs
@@ -38,6 +38,7 @@ internal sealed record ResolvedRenderFont(
     SKTypeface? Typeface,
     ushort[]? ByteToGlyph,
     bool HasEmbeddedProgram,
+    bool HasRawType1Program,
     Dictionary<int, float>? CidWidths,
     float CidDefaultWidth,
     bool CidUseUnicodeCmap,

--- a/Excise.Rendering/SkiaRenderer.Text.cs
+++ b/Excise.Rendering/SkiaRenderer.Text.cs
@@ -102,6 +102,8 @@ internal partial class RenderContext
             fontDict, toUnicodeMap, codeToGlyphName, codeToUnicode, encodingName,
             fontWidths, firstChar, diagnostics);
         var hasEmbeddedProgram = embedded != null;
+        var hasRawType1Program = embedded != null && fontDict != null
+            && _embeddedRawType1FontDicts.Contains(fontDict);
         var typeface = embedded ?? GetTypeface(
             resolvedFont.BaseFont,
             suppressSyntheticStyleForMissingType0: resolvedFont.IsType0);
@@ -177,6 +179,7 @@ internal partial class RenderContext
             typeface,
             byteToGlyph,
             hasEmbeddedProgram,
+            hasRawType1Program,
             cidWidths,
             cidDefaultWidth,
             cidUseUnicodeCmap,
@@ -451,6 +454,8 @@ internal partial class RenderContext
         }
 
         _embeddedTypefaces[fontDict] = typeface;
+        if (isType1)
+            _embeddedRawType1FontDicts.Add(fontDict);
         _embeddedTypefaceByteToGlyph[fontDict] = cffByteToGlyph
             ?? type1ByteToGlyph
             ?? ResolveByteCodeCmap(typeface, fontDict, toUnicodeMap);
@@ -1851,9 +1856,33 @@ internal partial class RenderContext
     /// geometry: bitmap-only faces (e.g. color emoji) have no outlines but
     /// do render via DrawText, and an all-whitespace run is a harmless
     /// no-op either way. See issue #710.
+    ///
+    /// <b>Scope (#710 regression fix):</b> the outline-path fill applies to
+    /// the font programs where it measurably closes the gap to the
+    /// references — embedded CFF/Type1C, TrueType, OpenType, and
+    /// system-substituted faces. Embedded <b>raw Type 1 (/FontFile)</b>
+    /// faces keep the DrawText glyph-mask path: for those faces the
+    /// platform masks already match mutool almost exactly
+    /// (highlights.pdf p5 @72dpi: DrawText diffFraction 0.00067 vs
+    /// DrawPath 0.0152 against mutool, with pdftocairo agreeing), while
+    /// the analytic outline fill of the very same outlines lands
+    /// symmetrically darker AND lighter on nearly every small-size glyph
+    /// edge — a per-edge coverage disagreement, not a weight or geometry
+    /// error (glyph paths are scale-invariant and identical at 9.5pt and
+    /// 100pt). The #710 CFF stem-darkening mismatch that motivated the
+    /// outline fill does not occur on the platform's raw-Type1 raster
+    /// path, so switching those faces to DrawPath only ADDED error.
+    /// Verified both ways: PdfJsFontFallbackDifferentialTests (raw Type 1
+    /// vs mutool) and TextRasterInkParityTests (embedded CFF ink parity).
     /// </summary>
     private void FillTextUsingGlyphPath(SKPath? glyphRunPath, SKPaint fillPaint, Action fallbackDraw)
     {
+        if (_currentFont?.HasRawType1Program == true)
+        {
+            RenderWithCurrentSoftMask(fallbackDraw, fillPaint);
+            return;
+        }
+
         if (glyphRunPath != null && !glyphRunPath.IsEmpty)
         {
             RenderWithCurrentSoftMask(() => _canvas.DrawPath(glyphRunPath, fillPaint), fillPaint);

--- a/Excise.Rendering/SkiaRenderer.cs
+++ b/Excise.Rendering/SkiaRenderer.cs
@@ -384,6 +384,13 @@ internal partial class RenderContext
     // independent byte-cmap probes.
     private readonly Dictionary<Excise.Core.Primitives.PdfDictionary, ushort[]?> _embeddedTypefaceByteToGlyph = new();
 
+    // Font dicts whose embedded program is a raw Type 1 /FontFile (PFA/PFB),
+    // as opposed to /FontFile2 TrueType or /FontFile3 CFF/OpenType. Fill-mode
+    // text for these faces must keep the pre-#710 DrawText (glyph mask) path:
+    // scoping check for FillTextUsingGlyphPath — see the comment there.
+    // Keyed by the same fontDict reference as _embeddedTypefaces.
+    private readonly HashSet<Excise.Core.Primitives.PdfDictionary> _embeddedRawType1FontDicts = new();
+
     // Stack of /Resources dictionaries currently active. The page's own
     // /Resources is the bottom; entering a Form XObject pushes its own
     // /Resources (or null when absent — we still push so push/pop pair).


### PR DESCRIPTION
Fixes a rendering regression from #710 that blocked the v3.2.1 release-smoke (only surfaces at t2 — the test is skip-allowlisted so CI never ran it).

## Root cause (bisected to #710)
#710 rasterizes fill text from glyph OUTLINE PATHS (`DrawPath`) instead of platform glyph masks (`DrawText`) — correct for embedded CFF (closes a stem-darkening gap to the references). But for embedded **raw Type 1 (`/FontFile`)** faces it made text render heavier than mutool AND pdftocairo (highlights.pdf p5 @72dpi: DrawText diffFraction 0.00067 vs DrawPath **0.0152** vs mutool; pdftocairo agrees). The analytic outline fill of the raw-Type1 outlines lands symmetrically darker/lighter on small-size glyph edges — a per-edge coverage disagreement — and the CFF stem-darkening problem #710 solved doesn't occur on the platform's raw-Type1 raster path, so DrawPath only added error there.

## Fix
Scope the outline-path fill to the faces where it helps (embedded CFF/Type1C, TrueType, OpenType, substituted system faces); **embedded raw Type 1 `/FontFile` faces keep the `DrawText` mask path** (tracked via a `HasRawType1Program` flag). Minimal, targeted.

## Verification (both directions)
- `PdfJsFontFallbackDifferentialTests.HighlightsPage5_LoadsEmbeddedUrwType1FontFile` **and** `Issue16316_LoadsEmbeddedRawType1FontFile` now PASS (raw Type 1 matches mutool < 0.005).
- `TextRasterInkParityTests.EmbeddedCffSmallText_InkMatchesMutool` STILL passes — #710's embedded-CFF gain is preserved.
- `run-visual-regression-local.sh` all 3 groups PASS (48 baselines hold, no churn); t0 all pass; 0 warnings.

Note: these differential tests are skip-allowlisted (external mutool + gitignored corpus), so they run at t1/t2, not CI — which is why #710's regression wasn't caught at merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)