### PR TITLE
test(render): run Excise.Rendering.Tests 4-way parallel — 243s→~165s, identical coverage (#731)

### DIFF
--- a/Excise.Rendering.Tests/AssemblyInfo.cs
+++ b/Excise.Rendering.Tests/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+// Excise.Rendering.Tests runs with 4-way xUnit collection parallelism
+// (xunit.runner.json: parallelizeTestCollections=true, maxParallelThreads=4).
+//
+// This is DELIBERATE and empirically validated — do not silently revert to
+// serial. See #731.
+//
+// Why it is safe here but NOT in Excise.App.Tests (which is serialized for the
+// #363 native-font-manager crash): SkiaSharp's font subsystem reaches a
+// *process-wide* native font manager that corrupts/crashes the host under
+// concurrent typeface creation. In Excise.Rendering that hazard is fully
+// contained — every typeface-acquisition path (SKTypeface.FromData,
+// FromFamilyName, and the SKTypeface.Default fallbacks) is serialized behind the
+// process-wide `_typefaceLoadLock` in SkiaRenderer (see SkiaRenderer.cs:259 and
+// SkiaRenderer.Text.cs:431/1310/1321). These tests drive SkiaRenderer directly
+// and never touch Avalonia's headless font stack, so — unlike App.Tests, whose
+// crash comes from Avalonia's *own* native font paths that the renderer lock
+// does not cover — there is no unguarded concurrent native-font access.
+//
+// Empirical proof (#731, 10-core dev box, external reference tools present so the
+// text-measurement-heavy differential suites actually run): full suite serial =
+// 243s, 4-way = 162s (33% faster), identical outcomes (3553 passed / 2 skipped,
+// zero failures, zero native crash/OOM), across the same 4-way concurrency that
+// reliably killed App.Tests at ~640 tests. CI runs this suite with those tools
+// ABSENT (differential tests skip), i.e. strictly lower font-op density than the
+// validated local run, so local-with-tools is the stress case.
+//
+// >>> If this suite ever dies with a native "Test host process crashed" (blank
+// >>> blame, abrupt native death), REVERT this file + the xunit.runner.json
+// >>> parallelism FIRST — that is the #363 signature and the most likely cause.
+//
+// The ±1 discovery wobble seen between runs is unrelated: it is pre-existing
+// nondeterminism in external-tool/fixture-gated [Fact(Timeout=...)] tests
+// (e.g. Type3_PopplerFixture_MatchesLivePdftocairo,
+// RenderPage_PdfjsS2_JpxSoftMasksClearImageBackgrounds) whose skip/run decision
+// depends on external availability, not a parallelism coverage loss — serial
+// runs drop cases too. Tracked as a note on #731.

--- a/Excise.Rendering.Tests/xunit.runner.json
+++ b/Excise.Rendering.Tests/xunit.runner.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
-  "parallelizeTestCollections": false,
-  "maxParallelThreads": 1
+  "parallelizeTestCollections": true,
+  "maxParallelThreads": 4
 }


### PR DESCRIPTION
## What
Enable 4-way xUnit collection parallelism for `Excise.Rendering.Tests` (`xunit.runner.json`: `parallelizeTestCollections:true`, `maxParallelThreads:4`), plus a documenting `AssemblyInfo.cs`.

## Why it was serial (and why that was wrong)
The suite was pinned to `maxParallelThreads:1` — a config **carried through the pdfe→Excise rename** (`efddbcc`) with no #363-style justification. It is **subprocess-dominated** (threads block on mutool/ghostscript/poppler reference renders) yet ran single-threaded on a 10-core box.

## Result (measured, #731 experiment — 10-core, external reference tools present so the differential suites actually run, not skip)
| Config | Wall | Passed | Skipped | Failures | Crash/OOM |
|---|---|---|---|---|---|
| serial (1 thread) | 243s | 3553 | 2 | 0 | none |
| **4 threads (this PR)** | **162–169s** | 3553/3554* | 2 | 0 | none |

\*±1 is pre-existing discovery nondeterminism in external-tool-gated `[Fact(Timeout=...)]` tests (serial itself drops `Type3_PopplerFixture_MatchesLivePdftocairo`), **not** a parallelism coverage loss. Noted on #731.

**~30% faster, identical outcomes.**

## Why this is safe here but NOT in `Excise.App.Tests` (the #363 native-crash guard)
The #363 crash is a **process-wide SkiaSharp native font-manager race** under concurrent typeface creation. In `Excise.Rendering` that hazard is **fully contained**: every typeface-acquisition path — `SKTypeface.FromData`, `FromFamilyName`, and the `.Default` fallbacks — is serialized behind the process-wide `_typefaceLoadLock` (`SkiaRenderer.cs:259`, `SkiaRenderer.Text.cs:431/1310/1321`; the lock comment itself says it exists *because* visual tests failed under xUnit parallelism). These tests drive `SkiaRenderer` directly and **never touch Avalonia's headless font stack** — unlike App.Tests, whose crash comes from Avalonia's *own* native font paths the renderer lock doesn't cover. Empirically validated at the same 4-way concurrency that killed App.Tests at ~640 tests; this suite cleared 3553.

CI runs this suite with those external tools **absent** (differential tests skip) → strictly lower font-op density than the validated local run, so local-with-tools is the stress case.

## Chose 4, not 8
8 threads bought only +15s for double the native-memory pressure and moves away from the concurrency that directly refutes the #363 mechanism.

## Guardrail
`AssemblyInfo.cs` documents the rationale + a **revert-first** instruction, so a future native 'test host crashed' in this suite is instantly attributable and one-line revertible (no repeat of the blank-blame #363 hunt).

Refs #731

🤖 Generated with [Claude Code](https://claude.com/claude-code)