### PR TITLE
fix(text): byte-wise CMap codespace-range matching (§9.7.6.2) — #515 slice 4

### DIFF
--- a/Excise.Core.Tests/Text/CMapCodespaceEdgeCaseTests.cs
+++ b/Excise.Core.Tests/Text/CMapCodespaceEdgeCaseTests.cs
@@ -1,0 +1,262 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using AwesomeAssertions;
+using Excise.Core.Document;
+using Excise.Core.Text;
+using Excise.Core.Text.Segmentation;
+using Xunit;
+
+namespace Excise.Core.Tests.Text;
+
+/// <summary>
+/// #515 slice 4 — CMap codespace edge cases, end-to-end.
+///
+/// Codespace-range matching must be BYTE-WISE (PDF 32000 §9.7.6.2), not
+/// scalar: a codespace &lt;8140&gt; &lt;FEFE&gt; accepts a 2-byte code only when
+/// byte 0 ∈ [0x81,0xFE] AND byte 1 ∈ [0x40,0xFE]. The historical scalar
+/// compare accepted byte-wise-invalid codes like &lt;81FF&gt; (inside
+/// [0x8140,0xFEFE] as a number), stealing bytes that per spec belong to a
+/// 1-byte codespace — which mis-segments every following code, garbles
+/// extraction, and therefore silently breaks RedactText (CLAUDE.md
+/// limitation #1: excise cannot redact what excise cannot read).
+///
+/// These fixtures use an EMBEDDED /Encoding CMap stream (§9.7.6.2), which as
+/// of this slice drives segmentation through the same parsed CMap the
+/// renderer already used — extraction, the redaction content-stream parser,
+/// and rendering must all segment identically.
+///
+/// Expected sequences are computed from the spec by hand, not from excise.
+/// </summary>
+public class CMapCodespaceEdgeCaseTests
+{
+    // Mixed-width codespaces: every byte is a valid 1-byte code, AND
+    // [81..FE][40..FE] pairs are valid 2-byte codes. Per spec the 2-byte
+    // space wins where it matches byte-wise; anything else is 1-byte.
+    private const string MixedWidthEncodingCMap = @"
+/CIDInit /ProcSet findresource begin
+12 dict begin
+begincmap
+2 begincodespacerange
+<00> <FF>
+<8140> <FEFE>
+endcodespacerange
+1 begincidrange
+<00> <FF> 0
+endcidrange
+1 begincidchar
+<8141> 500
+endcidchar
+endcmap
+CMapName currentdict /CMap defineresource pop
+end
+end
+";
+
+    // Code-keyed ToUnicode: the secret "SECRET" is spelled by 1-byte codes
+    // 41 81 FF 42 43 44 — the 81/FF pair is the scalar-vs-byte-wise
+    // discriminator: scalar matching folds them into one bogus 2-byte code
+    // 0x81FF ("S?RET", secret unfindable); byte-wise matching resolves both
+    // through the 1-byte codespace ("SECRET").
+    private const string SecretToUnicode = @"
+/CIDInit /ProcSet findresource begin
+12 dict begin
+begincmap
+1 begincodespacerange
+<00> <FF>
+endcodespacerange
+9 beginbfchar
+<41> <0053>
+<81> <0045>
+<FF> <0043>
+<42> <0052>
+<43> <0045>
+<44> <0054>
+<58> <0058>
+<59> <0059>
+<5A> <005A>
+endbfchar
+1 beginbfrange
+<20> <20> <0020>
+endbfrange
+endcmap
+end
+end
+";
+
+    // 41 81 FF 42 43 44 → "SECRET", 20 → " ", 58 59 5A → "XYZ".
+    private const string ContentCodesHex = "4181FF4243442058595A";
+
+    [Fact]
+    public void Extract_EmbeddedMixedWidthCMap_SegmentsByteWise()
+    {
+        var pdf = BuildPdf(ContentCodesHex + "8141");
+
+        using var doc = PdfDocument.Open(new MemoryStream(pdf));
+        var letters = new TextExtractor(doc.GetPage(1)).ExtractLetters();
+
+        // 6 secret letters + space + XYZ + the 2-byte code = 11 glyphs.
+        letters.Should().HaveCount(11);
+        string.Concat(letters.Take(10).Select(l => l.Value)).Should().Be("SECRET XYZ");
+
+        // Source char-code preservation (redaction re-encodes kept glyphs
+        // byte-exactly): the original codes and their byte lengths survive.
+        letters.Select(l => l.CharacterCode).Should().Equal(
+            0x41, 0x81, 0xFF, 0x42, 0x43, 0x44, 0x20, 0x58, 0x59, 0x5A, 0x8141);
+        letters.Select(l => l.CodeByteLength).Should().Equal(
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2);
+
+        // The one byte-wise VALID 2-byte code went through its cidchar
+        // mapping, proving the 2-byte codespace still claims what is its own.
+        letters[10].IsCidFont.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ContentStreamParser_EmbeddedMixedWidthCMap_StaysInLockstepWithExtractor()
+    {
+        // The redaction content-stream parser must segment the same bytes
+        // the same way the extractor does — otherwise redaction bounds
+        // drift from the letters RedactText matched.
+        var pdf = BuildPdf(ContentCodesHex);
+
+        using var doc = PdfDocument.Open(new MemoryStream(pdf), false);
+        var page = doc.GetPage(1);
+
+        var extracted = new TextExtractor(page).ExtractText();
+        var tjOp = page.GetContentStream().Operators.FirstOrDefault(o => o.Name == "Tj");
+
+        tjOp.Should().NotBeNull();
+        extracted.Should().Contain("SECRET XYZ");
+        tjOp!.TextContent.Should().Be("SECRET XYZ",
+            "parser and extractor must decode identical text from identical bytes");
+    }
+
+    [Fact]
+    public void RedactText_EmbeddedMixedWidthCMap_RemovesSecretThatScalarMatchingCouldNotFind()
+    {
+        // End-to-end redaction-security proof for the byte-wise fix: under
+        // scalar matching the 81/FF pair collapsed into one bogus 2-byte
+        // code, extraction read "S?RET", RedactText("SECRET") matched
+        // NOTHING and reported success — the definition of a silent leak.
+        var pdf = BuildPdf(ContentCodesHex);
+        var input = Path.Combine(Path.GetTempPath(), $"cmap-edge-{Guid.NewGuid():N}.pdf");
+        var output = Path.Combine(Path.GetTempPath(), $"cmap-edge-red-{Guid.NewGuid():N}.pdf");
+        try
+        {
+            File.WriteAllBytes(input, pdf);
+            using (var doc = PdfDocument.Open(input))
+            {
+                doc.RedactText("SECRET").Should().Be(1,
+                    "byte-wise codespace matching must make the mixed-width-encoded secret findable");
+                doc.Save(output);
+            }
+
+            using var redacted = PdfDocument.Open(output);
+            var text = new TextExtractor(redacted.GetPage(1)).ExtractText();
+            text.Should().NotContain("SECRET", "the redacted glyphs must be gone");
+            text.Should().Contain("XYZ",
+                "adjacent kept glyphs must survive, re-encoded with their original code bytes");
+
+            // Carrier-agnostic saved-bytes check (CLAUDE.md): the secret must
+            // not appear in ANY uncompressed carrier, in any of the encodings
+            // a PDF can restate text in.
+            var saved = File.ReadAllBytes(output);
+            var haystack = Encoding.ASCII.GetString(saved)
+                + Encoding.BigEndianUnicode.GetString(saved)
+                + Encoding.UTF8.GetString(saved);
+            haystack.Should().NotContain("SECRET");
+        }
+        finally
+        {
+            File.Delete(input);
+            File.Delete(output);
+        }
+    }
+
+    [Fact]
+    public void Extract_EmbeddedCMapWithUsecmap_InheritsRegisteredBase()
+    {
+        // An embedded CMap stream may pull in a registered base via
+        // `usecmap` — its codespaces and mappings must be honored so the
+        // extractor (and redaction) segment exactly like the renderer.
+        var embedded = @"
+/CIDInit /ProcSet findresource begin
+12 dict begin
+begincmap
+/90ms-RKSJ-H usecmap
+endcmap
+end
+end
+";
+        // Shift-JIS: 41='A' (1-byte, CID 264), 93FA='日' (2-byte, CID 3284).
+        var pdf = BuildPdf("4193FA", encodingCMap: embedded, toUnicode: null, ordering: "Japan1");
+
+        using var doc = PdfDocument.Open(new MemoryStream(pdf));
+        var letters = new TextExtractor(doc.GetPage(1)).ExtractLetters();
+
+        letters.Select(l => l.Value).Should().Equal("A", "日");
+        letters.Select(l => l.CodeByteLength).Should().Equal(1, 2);
+    }
+
+    [Fact]
+    public void Extract_JunkEmbeddedCMap_FallsBackGracefully()
+    {
+        // A garbage /Encoding stream must not crash or hang — the font
+        // keeps the safe 2-byte identity default.
+        var pdf = BuildPdf("00410042", encodingCMap: "%% not a cmap at all\n<<<<[[[ (((", toUnicode: null);
+
+        using var doc = PdfDocument.Open(new MemoryStream(pdf));
+        var letters = new TextExtractor(doc.GetPage(1)).ExtractLetters();
+
+        letters.Should().HaveCount(2, "4 bytes decode as two 2-byte identity codes");
+        letters.Select(l => l.CharacterCode).Should().Equal(0x41, 0x42);
+    }
+
+    // ─── PDF builder ─────────────────────────────────────────────────────────
+
+    private static byte[] BuildPdf(
+        string codesHex,
+        string? encodingCMap = null,
+        string? toUnicode = SecretToUnicode,
+        string ordering = "Identity")
+    {
+        encodingCMap ??= MixedWidthEncodingCMap;
+
+        var sb = new StringBuilder();
+        var offsets = new long[8];
+        void Obj(int n) => offsets[n] = sb.Length;
+
+        var content = $"BT /F0 24 Tf 72 700 Td <{codesHex}> Tj ET";
+        var toUnicodeEntry = toUnicode != null ? "/ToUnicode 7 0 R" : "";
+
+        sb.Append("%PDF-1.7\n");
+        Obj(1); sb.Append("1 0 obj <</Type/Catalog/Pages 2 0 R>> endobj\n");
+        Obj(2); sb.Append("2 0 obj <</Type/Pages/Count 1/Kids[3 0 R]>> endobj\n");
+        Obj(3); sb.Append("3 0 obj <</Type/Page/Parent 2 0 R/MediaBox[0 0 612 792]" +
+                          "/Resources<</Font<</F0 4 0 R>>>>/Contents 5 0 R>> endobj\n");
+        Obj(4); sb.Append("4 0 obj <</Type/Font/Subtype/Type0/BaseFont/Test" +
+                          $"/Encoding 6 0 R{toUnicodeEntry}" +
+                          "/DescendantFonts[<</Type/Font/Subtype/CIDFontType2/BaseFont/Test" +
+                          $"/CIDSystemInfo<</Registry(Adobe)/Ordering({ordering})/Supplement 0>>" +
+                          "/DW 1000>>]>> endobj\n");
+        Obj(5); sb.Append($"5 0 obj <</Length {content.Length}>>\nstream\n{content}\nendstream endobj\n");
+        Obj(6); sb.Append($"6 0 obj <</Length {encodingCMap.Length}>>\nstream\n{encodingCMap}\nendstream endobj\n");
+        if (toUnicode != null)
+        {
+            Obj(7);
+            sb.Append($"7 0 obj <</Length {toUnicode.Length}>>\nstream\n{toUnicode}\nendstream endobj\n");
+        }
+
+        var xref = sb.Length;
+        sb.Append("xref\n0 8\n0000000000 65535 f \n");
+        for (int i = 1; i <= 7; i++)
+        {
+            sb.Append(offsets[i] == 0
+                ? "0000000000 65535 f \n"
+                : offsets[i].ToString("D10") + " 00000 n \n");
+        }
+        sb.Append($"trailer <</Size 8/Root 1 0 R>>\nstartxref\n{xref}\n%%EOF\n");
+        return Encoding.ASCII.GetBytes(sb.ToString());
+    }
+}

--- a/Excise.Core.Tests/Text/CidCMapParserTests.cs
+++ b/Excise.Core.Tests/Text/CidCMapParserTests.cs
@@ -113,16 +113,18 @@ public class CidCMapParserTests
     [Fact]
     public void Decode_ByteOutsideEveryCodespace_FallsBackWithoutLosingData()
     {
-        // 0xFF is outside the declared 1-byte <00> <7f> codespace; the
-        // decoder's fallback must still consume input (2 bytes when
-        // available) instead of looping or dropping bytes.
+        // 0xFF is outside the declared 1-byte <00> <7f> codespace AND no
+        // codespace's lead-byte range claims it, so the invalid code
+        // consumes exactly ONE byte (Adobe TN #5014 undefined-code
+        // handling, matching mutool/pdf.js) — the decoder must not pair it
+        // with the following valid byte, and must not loop or drop input.
         var cmap = CidCMap.Parse("""
             1 begincodespacerange
             <00> <7f>
             endcodespacerange
             """);
 
-        cmap.Decode([0x41, 0xFF, 0x41]).Should().Equal(0x41, 0xFF41);
+        cmap.Decode([0x41, 0xFF, 0x41]).Should().Equal(0x41, 0xFF, 0x41);
         // Trailing single out-of-space byte: 1-byte fallback.
         cmap.Decode([0xFF]).Should().Equal(0xFF);
     }
@@ -232,5 +234,165 @@ public class CidCMapParserTests
 
         var truncatedCodespace = CidCMap.Parse("1 begincodespacerange <00>");
         truncatedCodespace.CodespaceRanges.Should().BeEmpty();
+    }
+
+    // ── #515 slice 4: per-byte-range codespace matching (§9.7.6.2) ──────────
+    //
+    // Expected sequences below are computed from the CMap spec by hand, not
+    // from excise: a codespace <lo> <hi> contains a code only when EVERY byte
+    // lies within the corresponding byte range of the bounds — NOT when the
+    // code's scalar value lies within [lo, hi].
+
+    [Fact]
+    public void Decode_CodespaceMatchIsByteWise_NotScalar()
+    {
+        // GBK-EUC-H-shaped mixed-width codespaces, plus a crafted 1-byte
+        // space wide enough to catch what the 2-byte space rejects.
+        var cmap = CidCMap.Parse("""
+            2 begincodespacerange
+            <00> <FF>
+            <8140> <FEFE>
+            endcodespacerange
+            2 begincidchar
+            <81> 900
+            <FF> 901
+            endcidchar
+            1 begincidrange
+            <8141> <8149> 100
+            endcidrange
+            """);
+
+        // <8141>: byte 0 ∈ [81,FE], byte 1 ∈ [40,FE] → one 2-byte code.
+        cmap.DecodeDetailed([0x81, 0x41]).Should().Equal((0x8141, 100, 2));
+
+        // <81FF>: scalar-wise inside [0x8140, 0xFEFE] — the historical bug —
+        // but byte 1 (0xFF) is OUTSIDE [0x40, 0xFE], so the 2-byte space
+        // must NOT claim it. Both bytes fall to the 1-byte codespace and hit
+        // their cidchar mappings.
+        cmap.DecodeDetailed([0x81, 0xFF]).Should().Equal((0x81, 900, 1), (0xFF, 901, 1));
+
+        // Mixed stream around the invalid pair keeps byte-exact segmentation.
+        cmap.DecodeDetailed([0x81, 0x41, 0x81, 0xFF, 0x81, 0x49])
+            .Should().Equal((0x8141, 100, 2), (0x81, 900, 1), (0xFF, 901, 1), (0x8149, 108, 2));
+    }
+
+    [Fact]
+    public void Decode_ByteWiseInvalidCode_ConsumesLeadByteCodespaceWidth()
+    {
+        // Only a 2-byte codespace: an invalid code whose LEAD byte the
+        // codespace claims consumes the codespace's full width (Adobe TN
+        // #5014 undefined-code handling); a lead byte nothing claims
+        // consumes exactly one byte.
+        var cmap = CidCMap.Parse("""
+            1 begincodespacerange
+            <8140> <FEFE>
+            endcodespacerange
+            """);
+
+        // 0x81 ∈ [81,FE] → the invalid pair <81FF> is consumed as 2 bytes.
+        cmap.DecodeDetailed([0x81, 0xFF, 0x81, 0x41])
+            .Should().Equal((0x81FF, 0x81FF, 2), (0x8141, 0x8141, 2));
+
+        // 0xFF ∉ [81,FE] → single-byte consumption, and the following byte
+        // is re-examined on its own instead of being swallowed.
+        cmap.DecodeDetailed([0xFF, 0x41])
+            .Should().Equal((0xFF, 0xFF, 1), (0x41, 0x41, 1));
+    }
+
+    [Fact]
+    public void Decode_TruncatedTrailingCode_ConsumesRemainingByte()
+    {
+        var cmap = CidCMap.Parse("""
+            1 begincodespacerange
+            <8140> <FEFE>
+            endcodespacerange
+            """);
+
+        // A dangling lead byte at end-of-input cannot form a 2-byte code;
+        // it must be consumed as a 1-byte fallback, not dropped.
+        cmap.DecodeDetailed([0x81, 0x41, 0x81])
+            .Should().Equal((0x8141, 0x8141, 2), (0x81, 0x81, 1));
+    }
+
+    [Fact]
+    public void Decode_RealRksjCMap_RejectsByteWiseInvalidTrailByte()
+    {
+        // The shipped 90ms-RKSJ-H declares <8140> <9FFC> / <E040> <FCFC>
+        // 2-byte spaces. <81FF> is scalar-inside [0x8140, 0x9FFC] but its
+        // trail byte 0xFF exceeds 0xFC — per-byte matching must treat it as
+        // an invalid code (2 bytes via the lead), NOT as a valid member
+        // eligible for cidrange mapping.
+        var cmap = PredefinedCMapProvider.TryGetEncodingCMap("90ms-RKSJ-H");
+        cmap.Should().NotBeNull();
+
+        var decoded = cmap!.DecodeDetailed([0x81, 0xFF, 0x41]);
+        decoded.Should().HaveCount(2);
+        decoded[0].ByteLength.Should().Be(2, "the lead byte 0x81 claims the 2-byte width");
+        decoded[0].Code.Should().Be(0x81FF);
+        decoded[1].Should().Be((0x41, 264, 1), "the following ASCII byte decodes normally");
+    }
+
+    // ── #515 slice 4: malformed-CMap resilience ─────────────────────────────
+
+    [Fact(Timeout = 30000)]
+    public void Parse_HugeCidRange_IsCappedWithoutHangingOrExhaustingMemory()
+    {
+        // A hostile range spanning the whole positive int space: a naive
+        // scalar expansion would insert 2^31 entries (OOM) — and with
+        // <FFFFFFFF> as the bound an int loop counter would wrap and never
+        // terminate. The parser must cap the expansion and keep working.
+        var cmap = CidCMap.Parse("""
+            1 begincodespacerange
+            <00000000> <FFFFFFFF>
+            endcodespacerange
+            1 begincidrange
+            <00000000> <7FFFFFFF> 5
+            endcidrange
+            """);
+
+        cmap.Mapping.Count.Should().BeLessThanOrEqualTo(65536);
+        cmap.Mapping[0].Should().Be(5);
+        cmap.Mapping[0xFFFF].Should().Be(5 + 0xFFFF, "the cap keeps a full 64K prefix intact");
+    }
+
+    [Fact(Timeout = 30000)]
+    public void Parse_FullTwoByteRange_SurvivesTheCapIntact()
+    {
+        // The largest legitimate incrementing range must not be truncated.
+        var cmap = CidCMap.Parse("""
+            1 begincodespacerange
+            <0000> <FFFF>
+            endcodespacerange
+            1 begincidrange
+            <0000> <FFFF> 0
+            endcidrange
+            """);
+
+        cmap.Mapping.Count.Should().Be(65536);
+        cmap.Mapping[0xFFFF].Should().Be(0xFFFF);
+    }
+
+    [Fact(Timeout = 30000)]
+    public void Parse_JunkContent_DoesNotThrowOrHang()
+    {
+        // Assorted garbage: binary noise, over-long hex bounds, dangling
+        // delimiters, an unterminated string literal. Graceful no-crash
+        // parsing is all that is required.
+        var junk = new[]
+        {
+            " <<<<>>>>[[[]]]",
+            "1 begincodespacerange <112233445566778899AABB> <FFFFFFFFFFFFFFFFFFFFFF> endcodespacerange",
+            "1 begincidrange <41> <40> 7 endcidrange",   // hi < lo
+            "begincmap endcmap (unterminated literal",
+            "/ /// %%% < > <zz> begincidchar",
+            "1 beginbfrange <0000> <FFFFFFFF> <0041> endbfrange",
+        };
+
+        foreach (var content in junk)
+        {
+            var cmap = CidCMap.Parse(content);
+            // Decoding arbitrary bytes over whatever survived must also work.
+            cmap.Decode([0x41, 0xFF, 0x00]).Should().NotBeNull();
+        }
     }
 }

--- a/Excise.Core.Tests/Text/ToUnicodeCMapParserCoverageTests.cs
+++ b/Excise.Core.Tests/Text/ToUnicodeCMapParserCoverageTests.cs
@@ -756,8 +756,10 @@ public class ToUnicodeCMapParserCoverageTests
     [Fact]
     public void Parse_OverlongHexBounds_DoNotOverflow()
     {
-        // >8-digit hex must not overflow into negative codes; the leading
-        // 4 bytes win and the parse stays usable.
+        // >8-digit hex must not keep shifting bytes out of the int; the
+        // leading 4 bytes win and the parse stays usable. (4-byte codes may
+        // legitimately wrap negative as ints — UTF-16 surrogate-pair
+        // codespaces do — so no sign restriction here.)
         var parser = ToUnicodeCMapParser.ParseDetailed(Encoding.ASCII.GetBytes(@"
             1 begincodespacerange
             <00112233445566> <FFFFFFFFFFFFFF>
@@ -768,7 +770,9 @@ public class ToUnicodeCMapParserCoverageTests
         "));
 
         parser.MaxCodeBytes.Should().BeLessThanOrEqualTo(4);
-        parser.CodespaceRanges.Should().OnlyContain(r => r.Low >= 0 && r.High >= 0 && r.Bytes <= 4);
+        parser.CodespaceRanges.Should().OnlyContain(r => r.Bytes <= 4);
+        parser.CodespaceRanges[0].Low.Should().Be(0x00112233,
+            "the leading 4 bytes of an over-long bound are kept");
         parser.Mapping[0x41].Should().Be("A");
     }
 }

--- a/Excise.Core.Tests/Text/ToUnicodeCMapParserCoverageTests.cs
+++ b/Excise.Core.Tests/Text/ToUnicodeCMapParserCoverageTests.cs
@@ -709,4 +709,66 @@ public class ToUnicodeCMapParserCoverageTests
         result[0x0011].Should().Be("Q");
         result[0x0012].Should().Be("R");
     }
+
+    // ── #515 slice 4: malformed-CMap resilience ─────────────────────────────
+
+    [Fact(Timeout = 30000)]
+    public void Parse_HugeBfRange_IsCappedWithoutHangingOrExhaustingMemory()
+    {
+        // A hostile incrementing range across the whole positive int space:
+        // a naive expansion would insert 2^31 entries (OOM), and with
+        // <FFFFFFFF> as the bound an int loop counter would wrap and never
+        // terminate. The parser must cap the expansion and keep working.
+        var result = ToUnicodeCMapParser.Parse(@"
+            1 begincodespacerange
+            <00000000> <FFFFFFFF>
+            endcodespacerange
+            1 beginbfrange
+            <00000000> <7FFFFFFF> <0041>
+            endbfrange
+        ");
+
+        result.Count.Should().BeLessThanOrEqualTo(65536);
+        result[0].Should().Be("A");
+    }
+
+    [Fact]
+    public void Parse_BfRangeIncrementingPastUnicode_StopsGracefully()
+    {
+        // Incrementing the destination past U+10FFFF (or into the surrogate
+        // block) can only happen in a malformed range; it must not throw
+        // away the whole CMap via ConvertFromUtf32's exception.
+        var result = ToUnicodeCMapParser.Parse(@"
+            1 begincodespacerange
+            <0000> <FFFF>
+            endcodespacerange
+            1 beginbfrange
+            <0000> <00FF> <D7FE>
+            endbfrange
+        ");
+
+        result[0x0000].Should().Be("\uD7FE");
+        result[0x0001].Should().Be("\uD7FF", "still below the surrogate block");
+        result.Should().NotContainKey(0x0002,
+            "U+D800 is a surrogate — the malformed remainder of the range is dropped, not thrown");
+    }
+
+    [Fact]
+    public void Parse_OverlongHexBounds_DoNotOverflow()
+    {
+        // >8-digit hex must not overflow into negative codes; the leading
+        // 4 bytes win and the parse stays usable.
+        var parser = ToUnicodeCMapParser.ParseDetailed(Encoding.ASCII.GetBytes(@"
+            1 begincodespacerange
+            <00112233445566> <FFFFFFFFFFFFFF>
+            endcodespacerange
+            1 beginbfchar
+            <41> <0041>
+            endbfchar
+        "));
+
+        parser.MaxCodeBytes.Should().BeLessThanOrEqualTo(4);
+        parser.CodespaceRanges.Should().OnlyContain(r => r.Low >= 0 && r.High >= 0 && r.Bytes <= 4);
+        parser.Mapping[0x41].Should().Be("A");
+    }
 }

--- a/Excise.Core/Content/ContentStreamParser.cs
+++ b/Excise.Core/Content/ContentStreamParser.cs
@@ -1034,34 +1034,44 @@ public class ContentStreamParser
             var subtype = _currentFont.GetNameOrNull("Subtype");
             _is2ByteFont = subtype == "Type0";
 
-            // A Type0 font isn't guaranteed to use Identity-H/V's 2-byte
-            // codes — a font can wrap an embedded CMap declaring a narrower
-            // codespace (#659). Only switch to 1-byte on an EXPLICITLY
-            // UNIFORM 1-byte codespace; keep the safe 2-byte default for
-            // Identity-H/V and any 2-byte/mixed-width codespace. Mirrors the
-            // identical fix in TextExtractor.LoadFontGeometry — this parser
-            // feeds redaction's glyph removal, and it must decode the same
-            // bytes the same way TextExtractor does or redaction can target
-            // the wrong glyphs.
+            // Embedded /Encoding CMap streams and registered CMap names both
+            // drive byte segmentation through the parsed CMap's codespace
+            // ranges (mixed 1/2-byte widths, per-byte-range matched) and map
+            // code→CID for width lookup. Mirrors TextExtractor.LoadFontGeometry
+            // EXACTLY — this parser feeds redaction's glyph removal, and it
+            // must decode the same bytes the same way TextExtractor does or
+            // redaction can target the wrong glyphs. #515 #659
             if (_is2ByteFont)
             {
                 var encObj = _page.Document.Resolve(_currentFont.GetOptional("Encoding") ?? PdfNull.Instance);
                 if (encObj is PdfStream encStream)
                 {
-                    var detail = Text.ToUnicodeCMapParser.ParseDetailed(encStream.DecodedData);
-                    if (detail.CodespaceRanges.Count > 0 && detail.MaxCodeBytes == 1)
-                        _is2ByteFont = false;
-
-                    // /WMode 1 in the embedded CMap means vertical writing
-                    // (§9.7.5.2) — mirrors TextExtractor.LoadFontGeometry. #515
                     try
                     {
-                        if (Text.CidCMap.Parse(encStream.DecodedData).WMode == 1)
+                        var embedded = Text.CidCMap.Parse(encStream.DecodedData,
+                            static name => Text.PredefinedCMapProvider.TryGetEncodingCMap(name));
+
+                        // /WMode 1 in the embedded CMap means vertical
+                        // writing (§9.7.5.2). #515
+                        if (embedded.WMode == 1)
                             _isVerticalWriting = true;
+                        if (embedded.CodespaceRanges.Count > 0 || embedded.Mapping.Count > 0)
+                            _registeredEncodingCMap = embedded;
                     }
                     catch (Exception ex) when (ex is not OutOfMemoryException)
                     {
-                        // Best-effort: unreadable CMap keeps horizontal default.
+                        // Best-effort: unreadable CMap keeps identity defaults.
+                    }
+
+                    // Stride fallback for streams the CMap parser could not
+                    // read (#659): an EXPLICITLY UNIFORM 1-byte codespace
+                    // decodes one byte at a time; anything else keeps the
+                    // safe 2-byte default.
+                    if (_registeredEncodingCMap == null)
+                    {
+                        var detail = Text.ToUnicodeCMapParser.ParseDetailed(encStream.DecodedData);
+                        if (detail.CodespaceRanges.Count > 0 && detail.MaxCodeBytes == 1)
+                            _is2ByteFont = false;
                     }
                 }
 

--- a/Excise.Core/Text/CidCMapParser.cs
+++ b/Excise.Core/Text/CidCMapParser.cs
@@ -516,15 +516,18 @@ internal sealed class CidCMap
         if ((hex.Length & 1) != 0)
             hex = "0" + hex;
 
-        // Codes are at most 4 bytes (8 hex digits) per the CMap spec. A
-        // malformed longer string must not overflow the shifts into garbage
-        // (or a negative value that breaks byte-wise comparisons): keep the
-        // leading 4 bytes and clamp to int.MaxValue. #515
+        // Codes are at most 4 bytes (8 hex digits) per the CMap spec — a
+        // malformed longer string must not keep shifting bytes out: keep the
+        // leading 4 bytes only. The raw 32-bit BIT PATTERN is preserved (a
+        // 4-byte code like UniGB-UTF16-H's <D800DC00> wraps negative as an
+        // int) because ReadBigEndian produces the identical wrap for decoded
+        // codes, and the byte-wise codespace comparison is bit-pattern-based
+        // — clamping would destroy the per-byte bounds. #515
         var digits = Math.Min(hex.Length, 8);
-        long value = 0;
+        var value = 0;
         for (var i = 0; i < digits; i++)
-            value = (value << 4) | (uint)HexDigit(hex[i]);
-        return value > int.MaxValue ? int.MaxValue : (int)value;
+            value = (value << 4) | HexDigit(hex[i]);
+        return value;
     }
 
     private static int HexDigit(char c)

--- a/Excise.Core/Text/CidCMapParser.cs
+++ b/Excise.Core/Text/CidCMapParser.cs
@@ -73,10 +73,18 @@ internal sealed class CidCMap
                 if (codespace.Bytes <= 0 || offset + codespace.Bytes > bytes.Length)
                     continue;
 
-                var code = ReadBigEndian(bytes, offset, codespace.Bytes);
-                if (code < codespace.Low || code > codespace.High)
+                // Byte-wise containment (PDF 32000 §9.7.6.2 / Adobe TN #5014):
+                // a code is inside a codespace range only when EVERY byte lies
+                // within the corresponding byte range of the low/high bounds.
+                // A scalar compare wrongly accepts e.g. <81FF> for
+                // <8140> <FEFE> (0x8140 ≤ 0x81FF ≤ 0xFEFE scalar-wise, but
+                // 0xFF is outside the trailing-byte range [0x40,0xFE]),
+                // stealing bytes that belong to another codespace and
+                // mis-segmenting everything after them. #515
+                if (!ContainsByteWise(codespace, bytes, offset))
                     continue;
 
+                var code = ReadBigEndian(bytes, offset, codespace.Bytes);
                 result.Add((code, _codeToCid.TryGetValue(code, out var mappedCid) ? mappedCid : code, codespace.Bytes));
                 offset += codespace.Bytes;
                 matched = true;
@@ -86,14 +94,47 @@ internal sealed class CidCMap
             if (matched)
                 continue;
 
-            var remaining = bytes.Length - offset;
-            var fallbackBytes = remaining >= 2 ? 2 : 1;
+            // Invalid code — no codespace matches byte-wise. Per Adobe TN
+            // #5014's undefined-code handling the LEAD byte determines how
+            // many bytes the invalid code consumes: the (longest) codespace
+            // whose first-byte range contains it claims its full width; a
+            // lead byte no codespace claims consumes a single byte
+            // (mirroring mutool / pdf.js). #515
+            var fallbackBytes = 1;
+            foreach (var codespace in codespaces)
+            {
+                if (codespace.Bytes <= 0)
+                    continue;
+
+                var shift = 8 * (codespace.Bytes - 1);
+                var leadLow = (codespace.Low >> shift) & 0xFF;
+                var leadHigh = (codespace.High >> shift) & 0xFF;
+                if (bytes[offset] >= leadLow && bytes[offset] <= leadHigh)
+                {
+                    fallbackBytes = Math.Min(codespace.Bytes, bytes.Length - offset);
+                    break;
+                }
+            }
+
             var fallbackCode = ReadBigEndian(bytes, offset, fallbackBytes);
             result.Add((fallbackCode, _codeToCid.TryGetValue(fallbackCode, out var fallbackCid) ? fallbackCid : fallbackCode, fallbackBytes));
             offset += fallbackBytes;
         }
 
         return result;
+    }
+
+    private static bool ContainsByteWise(in CodespaceRange range, byte[] bytes, int offset)
+    {
+        for (var i = 0; i < range.Bytes; i++)
+        {
+            var shift = 8 * (range.Bytes - 1 - i);
+            var b = bytes[offset + i];
+            if (b < ((range.Low >> shift) & 0xFF) || b > ((range.High >> shift) & 0xFF))
+                return false;
+        }
+
+        return true;
     }
 
     private static int ReadBigEndian(byte[] bytes, int offset, int length)
@@ -181,7 +222,10 @@ internal sealed class CidCMap
                 if (low.Type != TokenType.HexString || high.Type != TokenType.HexString)
                     break;
 
-                var bytes = Math.Max(1, (low.Text.Length + 1) / 2);
+                // Codes are at most 4 bytes per the CMap spec; clamp so a
+                // malformed over-long hex bound cannot declare a code width
+                // wider than the int the code is read into. #515
+                var bytes = Math.Min(4, Math.Max(1, (low.Text.Length + 1) / 2));
                 Codespaces.Add(new CodespaceRange(HexToInt(low.Text), HexToInt(high.Text), bytes));
                 i += 2;
             }
@@ -279,8 +323,16 @@ internal sealed class CidCMap
             if (highCode < lowCode)
                 return;
 
-            for (var code = lowCode; code <= highCode; code++)
-                Mapping[code] = firstCid + code - lowCode;
+            // Cap the expansion so a malformed range like
+            // <00000000> <7FFFFFFF> cannot hang the parser or exhaust memory
+            // (a naive int loop would also wrap at int.MaxValue and never
+            // terminate). Real CMap ranges vary only in their final byte; the
+            // largest legitimate full range (<0000> <FFFF> N) still fits the
+            // cap exactly. #515
+            const long MaxRangeEntries = 65536;
+            var end = Math.Min(highCode, (long)lowCode + MaxRangeEntries - 1);
+            for (var code = (long)lowCode; code <= end; code++)
+                Mapping[(int)code] = firstCid + (int)(code - lowCode);
         }
 
         private void AddPredefinedCMap(string name)
@@ -464,10 +516,15 @@ internal sealed class CidCMap
         if ((hex.Length & 1) != 0)
             hex = "0" + hex;
 
-        var value = 0;
-        foreach (var c in hex)
-            value = (value << 4) | HexDigit(c);
-        return value;
+        // Codes are at most 4 bytes (8 hex digits) per the CMap spec. A
+        // malformed longer string must not overflow the shifts into garbage
+        // (or a negative value that breaks byte-wise comparisons): keep the
+        // leading 4 bytes and clamp to int.MaxValue. #515
+        var digits = Math.Min(hex.Length, 8);
+        long value = 0;
+        for (var i = 0; i < digits; i++)
+            value = (value << 4) | (uint)HexDigit(hex[i]);
+        return value > int.MaxValue ? int.MaxValue : (int)value;
     }
 
     private static int HexDigit(char c)

--- a/Excise.Core/Text/TextExtractor.cs
+++ b/Excise.Core/Text/TextExtractor.cs
@@ -1475,32 +1475,40 @@ public class TextExtractor
                 _isVerticalWriting = true;
         }
 
-        // A Type0 font is not guaranteed to use Identity-H/V's 2-byte codes —
-        // that's just what every mainstream producer emits. A font can wrap
-        // an embedded CMap declaring a narrower codespace (#659: a real
-        // corpus file uses a single-byte `<00> <FF>` codespace). Decoding
-        // that 2 bytes at a time pairs up unrelated adjacent character codes
-        // into one bogus double-width code, corrupting every character.
-        // Only switch to 1-byte on an EXPLICITLY UNIFORM 1-byte codespace —
-        // any 2-byte or mixed-width codespace keeps the safe 2-byte default,
-        // which is what the vast majority of real-world Type0 fonts need.
+        // An embedded /Encoding CMap STREAM is the font's code→CID map
+        // (§9.7.6.2) exactly like a registered CMap name: its codespace
+        // ranges drive byte segmentation (including mixed 1/2-byte widths,
+        // per-byte-range matched) and its cidchar/cidrange entries give the
+        // CID for width lookup and CID→Unicode decoding. Previously only its
+        // /WMode and a uniform-1-byte heuristic (#659) were honored while
+        // the bytes were still decoded as fixed-stride identity codes — but
+        // the RENDERER already decodes through the parsed CMap, so what was
+        // extracted (and therefore what redaction could match) drifted from
+        // what was drawn. #515
         if (encObj is PdfStream encStream)
         {
-            var detail = ToUnicodeCMapParser.ParseDetailed(encStream.DecodedData);
-            if (detail.CodespaceRanges.Count > 0 && detail.MaxCodeBytes == 1)
-                _is2ByteFont = false;
-
-            // An embedded CMap stream declares its own writing mode via
-            // /WMode 1 (§9.7.5.2) — Identity-V isn't the only vertical
-            // signal. Malformed streams keep horizontal. #515
             try
             {
-                if (CidCMap.Parse(encStream.DecodedData).WMode == 1)
+                var embedded = CidCMap.Parse(encStream.DecodedData,
+                    static name => PredefinedCMapProvider.TryGetEncodingCMap(name));
+                if (embedded.WMode == 1)
                     _isVerticalWriting = true;
+                if (embedded.CodespaceRanges.Count > 0 || embedded.Mapping.Count > 0)
+                    _registeredEncodingCMap = embedded;
             }
             catch (Exception ex) when (ex is not OutOfMemoryException)
             {
-                // Best-effort: an unreadable CMap keeps the horizontal default.
+                // Best-effort: an unreadable CMap keeps the identity defaults.
+            }
+
+            // Stride fallback for streams the CMap parser could not read
+            // (#659): an EXPLICITLY UNIFORM 1-byte codespace decodes one
+            // byte at a time; anything else keeps the safe 2-byte default.
+            if (_registeredEncodingCMap == null)
+            {
+                var detail = ToUnicodeCMapParser.ParseDetailed(encStream.DecodedData);
+                if (detail.CodespaceRanges.Count > 0 && detail.MaxCodeBytes == 1)
+                    _is2ByteFont = false;
             }
         }
 

--- a/Excise.Core/Text/ToUnicodeCMapParser.cs
+++ b/Excise.Core/Text/ToUnicodeCMapParser.cs
@@ -108,7 +108,9 @@ public class ToUnicodeCMapParser
             var hiTok = tokens[i + 1];
             if (loTok.Type != TokenType.HexString || hiTok.Type != TokenType.HexString) break;
 
-            int bytes = (loTok.Text.Length + 1) / 2;
+            // Codes are at most 4 bytes per the CMap spec; clamp malformed
+            // over-long bounds so MaxCodeBytes stays meaningful. #515
+            int bytes = Math.Min(4, Math.Max(1, (loTok.Text.Length + 1) / 2));
             if (bytes > _maxCodeBytes) _maxCodeBytes = bytes;
             int lo = HexToInt(loTok.Text);
             int hi = HexToInt(hiTok.Text);
@@ -158,6 +160,13 @@ public class ToUnicodeCMapParser
             int srcLo = HexToInt(lo.Text);
             int srcHi = HexToInt(hi.Text);
 
+            // Cap the incrementing expansion: a malformed range like
+            // <0000> <7FFFFFFF> must not hang the parser or exhaust memory.
+            // Spec-conforming bfranges vary only in the last byte (≤ 256
+            // codes); a 64K cap keeps even a full 2-byte range intact. #515
+            if ((long)srcHi - srcLo > 0xFFFF)
+                srcHi = srcLo + 0xFFFF;
+
             if (dst.Type == TokenType.HexString)
             {
                 // <lo> <hi> <dstLo> — incrementing destination.
@@ -183,7 +192,16 @@ public class ToUnicodeCMapParser
 
                         var prefix = dstStr.Substring(0, lastIdx);
                         int lastCp = char.ConvertToUtf32(dstStr, lastIdx);
-                        _mapping[code] = prefix + char.ConvertFromUtf32(lastCp + offset);
+                        int nextCp = lastCp + offset;
+
+                        // Incrementing past the Unicode range (or into the
+                        // surrogate block) can only happen in a malformed
+                        // range — stop rather than throw away the whole
+                        // CMap on ConvertFromUtf32's exception. #515
+                        if (nextCp > 0x10FFFF || (nextCp >= 0xD800 && nextCp <= 0xDFFF))
+                            break;
+
+                        _mapping[code] = prefix + char.ConvertFromUtf32(nextCp);
                     }
                 }
                 i += 3;
@@ -313,12 +331,17 @@ public class ToUnicodeCMapParser
     {
         if (hex.Length == 0) return 0;
         if ((hex.Length & 1) != 0) hex = "0" + hex; // odd-length → left-pad
-        int v = 0;
-        foreach (char c in hex)
+
+        // Codes are at most 4 bytes (8 hex digits) per the CMap spec. A
+        // malformed longer string must not overflow the shifts into garbage
+        // (or a negative value): keep the leading 4 bytes and clamp. #515
+        int digits = Math.Min(hex.Length, 8);
+        long v = 0;
+        for (int i = 0; i < digits; i++)
         {
-            v = (v << 4) | HexDigit(c);
+            v = (v << 4) | (uint)HexDigit(hex[i]);
         }
-        return v;
+        return v > int.MaxValue ? int.MaxValue : (int)v;
     }
 
     private static int HexDigit(char c) =>

--- a/Excise.Core/Text/ToUnicodeCMapParser.cs
+++ b/Excise.Core/Text/ToUnicodeCMapParser.cs
@@ -332,16 +332,18 @@ public class ToUnicodeCMapParser
         if (hex.Length == 0) return 0;
         if ((hex.Length & 1) != 0) hex = "0" + hex; // odd-length → left-pad
 
-        // Codes are at most 4 bytes (8 hex digits) per the CMap spec. A
-        // malformed longer string must not overflow the shifts into garbage
-        // (or a negative value): keep the leading 4 bytes and clamp. #515
+        // Codes are at most 4 bytes (8 hex digits) per the CMap spec — a
+        // malformed longer string must not keep shifting bytes out: keep the
+        // leading 4 bytes only. The raw 32-bit bit pattern is preserved
+        // (4-byte codes can wrap negative as ints), matching how decoded
+        // source codes are assembled elsewhere. #515
         int digits = Math.Min(hex.Length, 8);
-        long v = 0;
+        int v = 0;
         for (int i = 0; i < digits; i++)
         {
-            v = (v << 4) | (uint)HexDigit(hex[i]);
+            v = (v << 4) | HexDigit(hex[i]);
         }
-        return v > int.MaxValue ? int.MaxValue : (int)v;
+        return v;
     }
 
     private static int HexDigit(char c) =>

--- a/Excise.Rendering/SkiaRenderer.Text.cs
+++ b/Excise.Rendering/SkiaRenderer.Text.cs
@@ -209,7 +209,12 @@ internal partial class RenderContext
                 var resolved = _page.Document.Resolve(encodingObj);
                 if (resolved is Excise.Core.Primitives.PdfStream stream)
                 {
-                    cmap = CidCMap.Parse(stream.DecodedData);
+                    // Pass the predefined-CMap resolver so an embedded CMap
+                    // that references a registered base via `usecmap` inherits
+                    // its codespaces and mappings — the same wiring the
+                    // extractor and redaction parser use. #515
+                    cmap = CidCMap.Parse(stream.DecodedData,
+                        static name => PredefinedCMapProvider.TryGetEncodingCMap(name));
                 }
                 else if (resolved is Excise.Core.Primitives.PdfName name
                          && name.Value is not ("Identity-H" or "Identity-V"))


### PR DESCRIPTION
#515 slice 4 (parent #512): fix **codespace-range matching to be per-byte-range, not scalar** (PDF 32000 §9.7.6.2), plus CMap hardening — flagged as a follow-up on PR #737.

## The bug (redaction-security)
A codespace `<8140> <FEFE>` must accept a 2-byte code only when byte0 ∈ [0x81,0xFE] AND byte1 ∈ [0x40,0xFE]. The old code compared the whole code as a **scalar** against [0x8140, 0xFEFE], so it wrongly accepted byte-wise-invalid codes like `0x81FF` (0xFF is outside the low-byte range). Mis-segmenting bytes into wrong CIDs corrupts extraction → `RedactText` can't match/remove the text and **reports success anyway** (CLAUDE.md limitation #1).

## Changes (redaction-critical trio kept in lockstep)
Byte-wise codespace membership + CMap hardening + embedded-CMap segmentation, applied consistently across all segmentation sites so redaction bounds track letters:
- `Excise.Core/Text/CidCMapParser.cs` (+78) — per-byte-range matching, 4-byte code bit-pattern preservation in hex parsing.
- `Excise.Core/Text/TextExtractor.cs` (+44) and `Excise.Core/Content/ContentStreamParser.cs` (+44, the redaction parser) — mirrored segmentation.
- `Excise.Core/Text/ToUnicodeCMapParser.cs` (+33), `Excise.Rendering/SkiaRenderer.Text.cs` (+7).

## Independent verification (mine, on develop `a921032`)
| Gate | Result |
|---|---|
| Build | **0 warnings** |
| `verify-true-redaction.sh` | intact |
| **Extraction-parity (#645)** | 332 pages, **98.7% — no regression** (fix only rejects malformed codes absent from the corpus) |
| Redaction | Core 184 ✅ · Rendering 44 ✅ · App 105 ✅ |
| New codespace/CMap tests | **103 ✅** (incl. `CMapCodespaceEdgeCaseTests`: `81 FF` must NOT decode as one 2-byte code, `81 41` must; malformed-CMap resilience; a `RedactText` round-trip w/ carrier-agnostic saved-bytes) |
| Full suites | Core **3578 / 0 failed** · Rendering **3356 / 0 failed** |

## Follow-ups
- #515 slice 6 (glyph-selection matrix) — the last #515 slice.

Refs #515

🤖 Generated with [Claude Code](https://claude.com/claude-code)