### PR TITLE
perf: cache /ObjStm index + batch-materialize contained objects — ~45% faster redaction-save (#743)

### DIFF
--- a/Excise.Core.Tests/Parsing/ObjectStreamResolutionTests.cs
+++ b/Excise.Core.Tests/Parsing/ObjectStreamResolutionTests.cs
@@ -367,6 +367,163 @@ public class ObjectStreamResolutionTests
         doc.PageCount.Should().Be(1);
     }
 
+    // ── /ObjStm materialization cache (#743) ─────────────────────────────
+    // GetObjectFromStream caches the parsed object-stream index and batch-
+    // materializes all N contained objects on first touch instead of
+    // re-parsing the index per fetch. These tests pin the invariant that
+    // this is caching only: identical resolution regardless of fetch order,
+    // cache hits return the cached instance, and malformed streams degrade
+    // exactly as the old per-fetch path did (exception on the broken object
+    // only, no crash/hang, siblings still resolve).
+
+    [Fact]
+    public void ObjStmCache_FetchOrderDoesNotChangeResolvedValues()
+    {
+        // Two documents over the same file: one fetches every compressed
+        // object in ascending order, the other in descending order (so each
+        // object stream is first touched via a different contained object).
+        // Every object must serialize identically — fetch order and cache
+        // state must not affect resolution.
+        if (!File.Exists(ScrambledBirthCert)) return;
+
+        using var docAsc = PdfDocument.Open(ScrambledBirthCert);
+        using var docDesc = PdfDocument.Open(ScrambledBirthCert);
+
+        var compressed = GetXRef(docAsc)
+            .Where(e => e.Value.IsCompressed)
+            .Select(e => e.Key)
+            .OrderBy(n => n)
+            .ToList();
+        compressed.Should().NotBeEmpty("fixture must exercise the /ObjStm path");
+
+        var ascending = compressed
+            .ToDictionary(n => n, n => Excise.Core.Writing.PdfObjectWriter.Serialize(docAsc.GetObject(n)));
+        var descending = ((IEnumerable<int>)compressed).Reverse()
+            .ToDictionary(n => n, n => Excise.Core.Writing.PdfObjectWriter.Serialize(docDesc.GetObject(n)));
+
+        foreach (var n in compressed)
+        {
+            descending[n].Should().Be(ascending[n],
+                $"compressed object {n} must resolve to the same value regardless of fetch order");
+        }
+    }
+
+    [Fact]
+    public void ObjStmCache_RepeatedFetchReturnsCachedInstance()
+    {
+        if (!File.Exists(ScrambledBirthCert)) return;
+
+        using var doc = PdfDocument.Open(ScrambledBirthCert);
+        var compressed = GetXRef(doc).First(e => e.Value.IsCompressed).Key;
+
+        var first = doc.GetObject(compressed);
+        var second = doc.GetObject(compressed);
+        second.Should().BeSameAs(first,
+            "a second fetch of the same compressed object must be a cache hit");
+    }
+
+    [Fact]
+    public void ObjStmCache_BrokenObjectOffset_ThrowsOnThatObjectOnly_SiblingsResolve()
+    {
+        // Object stream whose index maps object 3 to an offset far past the
+        // end of the decoded data. The old per-fetch path threw when (and
+        // only when) the broken object was requested; the batch-materialized
+        // path must behave identically: siblings in the same stream resolve,
+        // the broken object throws, nothing crashes or hangs.
+        var pdf = BuildObjStmPdf(objThreeOffset: 9999);
+        using var doc = PdfDocument.Open(new MemoryStream(pdf));
+
+        doc.Catalog.Should().NotBeNull("catalog lives in the ObjStm and is intact");
+
+        var good = doc.GetObject(2);
+        good.Should().BeOfType<PdfDictionary>("the intact sibling object must resolve");
+        ((PdfDictionary)good).GetStringOrNull("Foo").Should().Be("bar");
+
+        var act = () => doc.GetObject(3);
+        act.Should().Throw<Exception>(
+            "the object whose offset points past the end of the stream must fail as before");
+
+        // And the failure must not have poisoned the stream's cache entry.
+        doc.GetObject(2).Should().BeSameAs(good);
+    }
+
+    [Fact]
+    public void ObjStmCache_TruncatedIndex_ThrowsParseException_NoHang()
+    {
+        // /N claims 3 pairs but the index region only contains 2 — the
+        // index parse itself fails. Must surface PdfParseException on any
+        // compressed fetch, same as the old per-fetch index parse.
+        var pdf = BuildObjStmPdf(objThreeOffset: 9999, truncateIndex: true);
+        var act = () =>
+        {
+            using var doc = PdfDocument.Open(new MemoryStream(pdf));
+            doc.GetObject(2);
+        };
+        act.Should().Throw<Exception>(
+            "a truncated /ObjStm index must fail cleanly, not crash or hang");
+    }
+
+    /// <summary>
+    /// Build a minimal PDF 1.5 whose catalog and two more objects live in a
+    /// single /ObjStm referenced from an xref stream. Object 3's offset in
+    /// the ObjStm index is caller-controlled so tests can point it past the
+    /// end of the decoded data. With <paramref name="truncateIndex"/> the
+    /// index region declares 3 pairs (/N 3) but carries only 2.
+    /// </summary>
+    private static byte[] BuildObjStmPdf(int objThreeOffset, bool truncateIndex = false)
+    {
+        var latin1 = System.Text.Encoding.Latin1;
+        using var ms = new MemoryStream();
+        void W(string s) { var b = latin1.GetBytes(s); ms.Write(b, 0, b.Length); }
+
+        W("%PDF-1.5\n");
+
+        // obj 4: pages tree (regular, uncompressed)
+        long off4 = ms.Position;
+        W("4 0 obj\n<< /Type /Pages /Kids [] /Count 0 >>\nendobj\n");
+
+        // obj 5: the object stream. Contained objects:
+        //   index 0 -> obj 1 (catalog), index 1 -> obj 2, index 2 -> obj 3
+        string body = "<< /Type /Catalog /Pages 4 0 R >>\n<< /Foo (bar) >>\n<< /Baz true >>\n";
+        int off1 = 0;
+        int off2 = body.IndexOf("<< /Foo", StringComparison.Ordinal);
+        string index = truncateIndex
+            ? $"1 {off1} 2 {off2}\n"
+            : $"1 {off1} 2 {off2} 3 {objThreeOffset}\n";
+        string objStmData = index + body;
+        int first = latin1.GetByteCount(index);
+
+        long off5 = ms.Position;
+        W($"5 0 obj\n<< /Type /ObjStm /N 3 /First {first} /Length {latin1.GetByteCount(objStmData)} >>\nstream\n");
+        W(objStmData);
+        W("endstream\nendobj\n");
+
+        // obj 6: xref stream. /W [1 2 1]; rows for objects 0..6.
+        long off6 = ms.Position;
+        var rows = new List<byte>();
+        void Row(byte type, long mid, byte low)
+        {
+            rows.Add(type);
+            rows.Add((byte)((mid >> 8) & 0xFF));
+            rows.Add((byte)(mid & 0xFF));
+            rows.Add(low);
+        }
+        Row(0, 0, 0xFF);          // obj 0: free
+        Row(2, 5, 0);             // obj 1: in stream 5, index 0
+        Row(2, 5, 1);             // obj 2: in stream 5, index 1
+        Row(2, 5, 2);             // obj 3: in stream 5, index 2
+        Row(1, off4, 0);          // obj 4: regular at off4
+        Row(1, off5, 0);          // obj 5: regular at off5
+        Row(1, off6, 0);          // obj 6: the xref stream itself
+
+        W($"6 0 obj\n<< /Type /XRef /Size 7 /W [1 2 1] /Root 1 0 R /Length {rows.Count} >>\nstream\n");
+        ms.Write(rows.ToArray(), 0, rows.Count);
+        W("\nendstream\nendobj\n");
+
+        W($"startxref\n{off6}\n%%EOF\n");
+        return ms.ToArray();
+    }
+
     private static IReadOnlyDictionary<int, Excise.Core.Parsing.XRefEntry> GetXRef(PdfDocument doc)
     {
         // _xref is private; expose via reflection so this test can verify

--- a/Excise.Core/Document/PdfDocument.cs
+++ b/Excise.Core/Document/PdfDocument.cs
@@ -893,6 +893,37 @@ public class PdfDocument : IDisposable
       }
     }
 
+    // ── Object-stream materialization cache (#743, epic #596) ───────────────
+    // GetObjectFromStream used to re-parse the full N-pair /ObjStm index and
+    // construct a fresh PdfParser + PdfLexer + MemoryStream for EVERY
+    // contained-object fetch — 76,233 parser instantiations + index re-parses
+    // on one save of irs-1040-instructions.pdf (785 streams), 67% of the save
+    // workflow and ~3.2 GB of managed allocation (#597 baseline, see
+    // docs/performance-baselines/2026-07-25-hotpath-baseline/). Instead, the
+    // first touch of an object stream parses the index once and batch-parses
+    // all N contained objects in a single pass; subsequent fetches are O(1)
+    // array lookups. Results are keyed by (stream, index) exactly like the
+    // old per-fetch path — the same byte offsets are parsed with the same
+    // parser configuration, just once instead of once per fetch — so object
+    // resolution is value-identical. This is caching only.
+    //
+    // Thread-safety: read and mutated only inside GetObjectFromStream, which
+    // is reachable only from GetObject under _parseLock (same discipline as
+    // _objectCache). Invalidation: an entry is keyed to the container
+    // PdfStream instance and its decoded buffer; if the container object or
+    // its decoded bytes are ever replaced (e.g. RemoveObject then re-parse),
+    // the identity check misses and the index is rebuilt from the new bytes.
+    private sealed class ObjectStreamCacheEntry
+    {
+        public required PdfStream Source { get; init; }
+        public required byte[] Data { get; init; }
+        public required int First { get; init; }
+        public required (int ObjNum, int Offset)[] Offsets { get; init; }
+        public required PdfObject?[] Objects { get; init; }
+    }
+
+    private readonly Dictionary<int, ObjectStreamCacheEntry> _objectStreamCache = new();
+
     /// <summary>
     /// Get an object from an object stream.
     /// </summary>
@@ -909,6 +940,42 @@ public class PdfDocument : IDisposable
         }
 
         var data = streamObj.DecodedData;
+
+        // Parse the index and batch-materialize on first touch (#743).
+        if (!_objectStreamCache.TryGetValue(streamNumber, out var cached)
+            || !ReferenceEquals(cached.Source, streamObj)
+            || !ReferenceEquals(cached.Data, data))
+        {
+            cached = MaterializeObjectStream(streamObj, data);
+            _objectStreamCache[streamNumber] = cached;
+        }
+
+        if (index < 0 || index >= cached.Offsets.Length)
+            throw new PdfParseException($"Index {index} out of range in object stream {streamNumber}");
+
+        // The batch pass already parsed this slot; a null slot means that one
+        // object failed to parse — retry it here so the caller sees the same
+        // exception the old per-fetch path would have thrown.
+        var obj = cached.Objects[index];
+        if (obj != null)
+            return obj;
+
+        using var retryParser = new PdfParser(data);
+        retryParser.Seek(cached.First + cached.Offsets[index].Offset);
+        obj = retryParser.ParseObject();
+        cached.Objects[index] = obj;
+        return obj;
+    }
+
+    /// <summary>
+    /// Parse an /ObjStm's N-pair index once and batch-parse all N contained
+    /// objects with a single parser pass (#743). Per-object parse failures
+    /// leave the slot null; the failure is surfaced only if that specific
+    /// object is requested, matching the old lazy per-fetch behavior on
+    /// malformed streams.
+    /// </summary>
+    private static ObjectStreamCacheEntry MaterializeObjectStream(PdfStream streamObj, byte[] data)
+    {
         int n = streamObj.GetInt("N"); // Number of objects
         int first = streamObj.GetInt("First"); // Offset to first object
 
@@ -930,13 +997,28 @@ public class PdfDocument : IDisposable
             );
         }
 
-        // Find and parse the requested object
-        if (index < 0 || index >= n)
-            throw new PdfParseException($"Index {index} out of range in object stream {streamNumber}");
+        var objects = new PdfObject?[n];
+        for (int i = 0; i < n; i++)
+        {
+            try
+            {
+                parser.Seek(first + offsets[i].Offset);
+                objects[i] = parser.ParseObject();
+            }
+            catch (Exception ex) when (ex is not OutOfMemoryException)
+            {
+                // Leave the slot null; surfaced on direct request.
+            }
+        }
 
-        int offset = first + offsets[index].Offset;
-        parser.Seek(offset);
-        return parser.ParseObject();
+        return new ObjectStreamCacheEntry
+        {
+            Source = streamObj,
+            Data = data,
+            First = first,
+            Offsets = offsets,
+            Objects = objects,
+        };
     }
 
     /// <summary>


### PR DESCRIPTION
First #596 optimization slice, targeting the #597 baseline's #1 hot path: `GetObjectFromStream` re-parsed the full N-entry ObjStm index and rebuilt a parser/lexer **on every contained-object fetch** (76,233 instantiations where 785 suffice on object-stream-heavy PDFs).

## Fix (`Excise.Core/Document/PdfDocument.cs`, +94)
Per-ObjStm cache (`_objectStreamCache`): on first touch, parse the index once and batch-materialize all N contained objects; subsequent fetches are O(1). **Pure caching — object resolution is byte-identical** (same decoded bytes, offsets, parser config; index-parse code retained verbatim). Malformed streams degrade exactly as before (per-object lazy failure; bad index throws before caching). Cache is keyed to the container `PdfStream` instance + decoded buffer by reference, so re-parse/replace invalidates it; mutated only under the existing `_parseLock`.

## Performance — my independent before/after (min of 2 runs, `irs-1040-instructions.pdf`, 785 ObjStms / 76,233 objects, Release)
Built develop and the branch separately, ran `Excise.RenderTools profile-workflows --corpus test-pdfs/smoke --steps save-roundtrip,redaction-save` on each:
| Workflow | Before | After | Delta |
|---|---|---|---|
| **save-roundtrip** | 1078 ms | 619 ms | **−43% time** |
| **redaction-save** | 917 ms | 506 ms | **−45% time** |
| open (lazy) | 23.3 ms | 23.6 ms | unchanged |

(Agent-measured allocation on the same doc: save 3327→587 MB, redaction-save 3346→603 MB — **~−82%**, consistent with 76k→785 instantiations.) redaction-save is a daily-driver flow, so this is a real user-facing win on real government PDFs.

## Correctness (my verification, on the branch)
| Gate | Result |
|---|---|
| Build | **0 warnings** |
| `verify-true-redaction.sh` | intact |
| **Extraction-parity (#645)** | 332 pages, **98.7% — unchanged** |
| Redaction | Core 188 ✅ · Rendering 44 ✅ · App 105 ✅ |
| Full suites | Core **3596 / 0 failed** · Rendering **3608 / 0 failed** |
| New tests | `ObjectStreamResolutionTests` — fetch-order-independence, cache-hit, per-object malformed failure, truncated-index no-hang; **all also pass against the pre-fix code** (pin behavior, not new-code quirks) |

## Follow-up
Remaining allocation on that doc is now default-capacity Dictionary/List growth in `PdfParser`/`PdfDictionary` (baseline row 3) + writer serialization — a separate #596 slice.

Refs #743

🤖 Generated with [Claude Code](https://claude.com/claude-code)