### PR TITLE
perf: bound + bulk-access DeviceCMYK blend-path mask — up to −37% CMYK-page render, pixel-identical (#599)

### DIFF
--- a/Excise.Rendering.Tests/Excise.Rendering.Tests.csproj
+++ b/Excise.Rendering.Tests/Excise.Rendering.Tests.csproj
@@ -5,6 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!-- xUnit1051 (prefer TestContext.Current.CancellationToken) is a style
          suggestion; several tests deliberately pass their own tokens (e.g. the
          cancellation tests). Suppressed to match Excise.Core.Tests. -->

--- a/Excise.Rendering.Tests/Visual/DeviceCmykBlendPathRenderTests.cs
+++ b/Excise.Rendering.Tests/Visual/DeviceCmykBlendPathRenderTests.cs
@@ -1,0 +1,183 @@
+using System.Text;
+using AwesomeAssertions;
+using Excise.Core.Document;
+using SkiaSharp;
+
+namespace Excise.Rendering.Tests.Visual;
+
+/// <summary>
+/// Pins the pixel behavior of the DeviceCMYK blend-path fill hot path
+/// (RenderContext.TryPaintDeviceCmykBlendPath) after the #599 optimization
+/// (bounded, reused coverage mask + bulk raw pixel access). The expected
+/// values were captured from the pre-optimization renderer and verified
+/// byte-identical against it (A/B PNG comparison over synthetic fixtures at
+/// 96/150 DPI and 6 pages each of the DS-11/DS-82 passport forms).
+/// </summary>
+public sealed class DeviceCmykBlendPathRenderTests
+{
+    [Fact]
+    public void RenderPage_DeviceCmykGroupBlendFills_ProducePinnedColors()
+    {
+        using var doc = PdfDocument.Open(BuildCmykBlendMixPdf());
+        using var bitmap = new SkiaRenderer().RenderPage(
+            doc.GetPage(1),
+            new RenderOptions { Dpi = 96, BackgroundColor = SKColors.White });
+
+        bitmap.Width.Should().Be(400);
+        bitmap.Height.Should().Be(400);
+
+        // Interior probes (no antialiasing involvement), pre-change values.
+        AssertPixel(bitmap, 67, 333, new SKColor(0, 174, 239), "pure cyan fill");
+        AssertPixel(bitmap, 133, 267, new SKColor(236, 0, 140), "magenta painted over cyan");
+        AssertPixel(bitmap, 267, 293, new SKColor(255, 242, 0), "half-alpha yellow via CMYK backdrop compositing");
+        AssertPixel(bitmap, 200, 133, new SKColor(189, 0, 137), "Multiply blend fill");
+        AssertPixel(bitmap, 253, 147, new SKColor(213, 38, 158), "Screen blend triangle interior");
+        AssertPixel(bitmap, 67, 67, new SKColor(255, 255, 255), "untouched background");
+
+        // The dashed DeviceCMYK stroke also routes through the blend path
+        // (stroke style + dash path effect). Dash segmentation is sensitive to
+        // the mask surface cull rect, so assert the dashes actually landed.
+        CountDarkPixels(bitmap, yStart: 55, yEnd: 80).Should().BeGreaterThan(1200,
+            "the dashed black DeviceCMYK stroke must rasterize through the blend-path mask");
+    }
+
+    [Fact]
+    public void RenderPage_DeviceCmykKnockoutAndIsolatedGroups_ProducePinnedColors()
+    {
+        using var doc = PdfDocument.Open(BuildCmykGroupsPdf());
+        using var bitmap = new SkiaRenderer().RenderPage(
+            doc.GetPage(1),
+            new RenderOptions { Dpi = 96, BackgroundColor = SKColors.White });
+
+        AssertPixel(bitmap, 80, 320, new SKColor(59, 194, 210), "knockout group fill");
+        AssertPixel(bitmap, 160, 200, new SKColor(207, 149, 108), "isolated group Lighten/ColorDodge stack");
+        AssertPixel(bitmap, 20, 20, new SKColor(228, 221, 242), "page-level CMYK wash backdrop");
+    }
+
+    private static void AssertPixel(SKBitmap bitmap, int x, int y, SKColor expected, string because)
+    {
+        var actual = bitmap.GetPixel(x, y);
+        var delta = Math.Max(
+            Math.Abs(actual.Red - expected.Red),
+            Math.Max(Math.Abs(actual.Green - expected.Green), Math.Abs(actual.Blue - expected.Blue)));
+        delta.Should().BeLessThanOrEqualTo(2,
+            $"pixel ({x},{y}) [{because}] expected {expected} but was {actual}");
+        actual.Alpha.Should().Be(255, because);
+    }
+
+    private static int CountDarkPixels(SKBitmap bitmap, int yStart, int yEnd)
+    {
+        var count = 0;
+        for (var y = yStart; y < yEnd; y++)
+        {
+            for (var x = 0; x < bitmap.Width; x++)
+            {
+                var c = bitmap.GetPixel(x, y);
+                if (c.Red < 90 && c.Green < 90 && c.Blue < 90)
+                    count++;
+            }
+        }
+
+        return count;
+    }
+
+    /// <summary>
+    /// One page inside a DeviceCMYK transparency group: opaque and half-alpha
+    /// `k` fills, Multiply/Screen blend fills, an antialiased triangle, and a
+    /// dashed DeviceCMYK stroke — every entry style of
+    /// TryPaintDeviceCmykBlendPath.
+    /// </summary>
+    private static byte[] BuildCmykBlendMixPdf()
+    {
+        const string content =
+            "1 0 0 0 k 20 20 120 120 re f\n" +
+            "0 1 0 0 k 80 80 120 120 re f\n" +
+            "/GA gs 0 0 1 0 k 140 20 120 120 re f\n" +
+            "/GM gs 0.3 0.6 0 0.1 k 60 150 180 100 re f\n" +
+            "/GS gs 150 150 m 280 160 l 200 290 l h f\n" +
+            "/GD gs 0 0 0 1 K 4 w [6 3] 0 d 1 J 1 j 30 260 m 270 240 l S\n";
+        const string resources =
+            "/ExtGState << /GA << /ca 0.5 >> /GZ << /ca 0 >> /GM << /BM /Multiply >> " +
+            "/GS << /BM /Screen >> /GD << /BM /Darken >> >>";
+        return BuildSinglePagePdf(content, resources, extraObjects: null);
+    }
+
+    /// <summary>
+    /// Nested DeviceCMYK form groups: a knockout (/K true) group with a
+    /// zero-alpha fill and a Multiply fill, and an isolated (/I true) group
+    /// with Lighten/ColorDodge fills — the knockout-reset, zero-alpha-shape,
+    /// and direct-blend-function branches of the blend loop.
+    /// </summary>
+    private static byte[] BuildCmykGroupsPdf()
+    {
+        const string content =
+            "0.1 0.1 0 0 k 0 0 300 300 re f\n" +
+            "q 1 0 0 1 20 20 cm /F1 Do Q\n" +
+            "q 1 0 0 1 90 90 cm /F2 Do Q\n";
+        const string knockoutForm =
+            "0.8 0 0.2 0 k 10 10 120 120 re f\n" +
+            "/GM gs 0 0.7 0 0 k 60 60 120 120 re f\n" +
+            "/GZ gs 1 0 0 0 k 30 100 80 80 re f\n";
+        const string isolatedForm =
+            "0.2 0.4 0.6 0 k 20 20 100 100 re f\n" +
+            "/GL gs 0.6 0.1 0 0 k 60 40 100 100 re f\n" +
+            "/GC gs 0 0.2 0.9 0 k 40 80 100 100 re f\n";
+        var extraObjects = new (int Number, string Dictionary, string StreamContent)[]
+        {
+            (5,
+             "/Type /XObject /Subtype /Form /BBox [0 0 200 200] " +
+             "/Group << /S /Transparency /CS /DeviceCMYK /K true >> " +
+             "/Resources << /ExtGState << /GZ << /ca 0 >> /GM << /BM /Multiply >> >> >>",
+             knockoutForm),
+            (6,
+             "/Type /XObject /Subtype /Form /BBox [0 0 200 200] " +
+             "/Group << /S /Transparency /CS /DeviceCMYK /I true >> " +
+             "/Resources << /ExtGState << /GL << /BM /Lighten >> /GC << /BM /ColorDodge >> >> >>",
+             isolatedForm),
+        };
+        return BuildSinglePagePdf(content, "/XObject << /F1 5 0 R /F2 6 0 R >>", extraObjects);
+    }
+
+    private static byte[] BuildSinglePagePdf(
+        string content,
+        string resources,
+        (int Number, string Dictionary, string StreamContent)[]? extraObjects)
+    {
+        var sb = new StringBuilder();
+        var objectCount = 4 + (extraObjects?.Length ?? 0);
+        var offsets = new long[objectCount + 1];
+        sb.Append("%PDF-1.7\n");
+
+        offsets[1] = sb.Length;
+        sb.Append("1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n");
+
+        offsets[2] = sb.Length;
+        sb.Append("2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n");
+
+        offsets[3] = sb.Length;
+        sb.Append("3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /Contents 4 0 R\n");
+        sb.Append("   /Group << /S /Transparency /CS /DeviceCMYK >>\n");
+        sb.Append($"   /Resources << {resources} >>\n>>\nendobj\n");
+
+        offsets[4] = sb.Length;
+        sb.Append($"4 0 obj\n<< /Length {content.Length} >>\nstream\n{content}\nendstream\nendobj\n");
+
+        if (extraObjects != null)
+        {
+            foreach (var (number, dictionary, streamContent) in extraObjects)
+            {
+                offsets[number] = sb.Length;
+                sb.Append($"{number} 0 obj\n<< {dictionary} /Length {streamContent.Length} >>\n");
+                sb.Append($"stream\n{streamContent}\nendstream\nendobj\n");
+            }
+        }
+
+        var xref = sb.Length;
+        sb.Append($"xref\n0 {objectCount + 1}\n0000000000 65535 f \n");
+        for (var i = 1; i <= objectCount; i++)
+            sb.Append($"{offsets[i]:D10} 00000 n \n");
+        sb.Append($"trailer\n<< /Root 1 0 R /Size {objectCount + 1} >>\nstartxref\n{xref}\n%%EOF\n");
+
+        return Encoding.ASCII.GetBytes(sb.ToString());
+    }
+}

--- a/Excise.Rendering.Tests/Visual/DeviceCmykBlendPixelContractTests.cs
+++ b/Excise.Rendering.Tests/Visual/DeviceCmykBlendPixelContractTests.cs
@@ -1,0 +1,68 @@
+using AwesomeAssertions;
+using SkiaSharp;
+
+namespace Excise.Rendering.Tests.Visual;
+
+/// <summary>
+/// Pins the two SkiaSharp equivalences the #599 DeviceCMYK blend-path
+/// optimization depends on for pixel-identical output. The hot loop in
+/// RenderContext.TryPaintDeviceCmykBlendPath replaced per-pixel
+/// SKBitmap.GetPixel/SetPixel P/Invokes with raw span access over
+/// premultiplied Rgba8888 pixels; that is only sound while:
+///   1. RenderContext.WritePremulRgba stores exactly the bytes
+///      SKBitmap.SetPixel would store, and
+///   2. the raw alpha byte equals GetPixel(x, y).Alpha.
+/// If a SkiaSharp upgrade ever changes either contract, these tests fail
+/// before the visual suite has to notice.
+/// </summary>
+public sealed class DeviceCmykBlendPixelContractTests
+{
+    [Fact]
+    public void WritePremulRgba_MatchesSetPixel_ForAllAlphaChannelPairs()
+    {
+        using var bitmap = new SKBitmap(256, 1, SKColorType.Rgba8888, SKAlphaType.Premul);
+        var expected = new byte[256 * 4];
+        var actual = new byte[256 * 4];
+
+        for (var alpha = 0; alpha <= 255; alpha++)
+        {
+            for (var value = 0; value <= 255; value++)
+                bitmap.SetPixel(value, 0, new SKColor((byte)value, (byte)value, (byte)value, (byte)alpha));
+            bitmap.GetPixelSpan().CopyTo(expected);
+
+            for (var value = 0; value <= 255; value++)
+            {
+                RenderContext.WritePremulRgba(
+                    actual, value * 4, (byte)value, (byte)value, (byte)value, (byte)alpha);
+            }
+
+            actual.Should().Equal(expected,
+                $"WritePremulRgba must store exactly what SKBitmap.SetPixel stores (alpha={alpha})");
+        }
+    }
+
+    [Fact]
+    public void RawAlphaByte_MatchesGetPixelAlpha_ForPremulPixels()
+    {
+        using var bitmap = new SKBitmap(64, 1, SKColorType.Rgba8888, SKAlphaType.Premul);
+        var random = new Random(599);
+
+        for (var i = 0; i < 2000; i++)
+        {
+            var x = random.Next(64);
+            var alpha = (byte)random.Next(256);
+            var premul = (byte)random.Next(alpha + 1); // valid premul channel <= alpha
+            var pixels = new byte[] { premul, premul, premul, alpha };
+
+            var span = GetWritableSpan(bitmap);
+            pixels.CopyTo(span.Slice(x * 4, 4));
+            bitmap.NotifyPixelsChanged();
+
+            bitmap.GetPixel(x, 0).Alpha.Should().Be(alpha,
+                "premultiplication never alters the alpha byte, so raw reads must agree with GetPixel");
+        }
+    }
+
+    private static unsafe Span<byte> GetWritableSpan(SKBitmap bitmap)
+        => new((void*)bitmap.GetPixels(), bitmap.RowBytes * bitmap.Height);
+}

--- a/Excise.Rendering/SkiaRenderer.Images.cs
+++ b/Excise.Rendering/SkiaRenderer.Images.cs
@@ -569,6 +569,8 @@ internal partial class RenderContext
         foreach (var typeface in _embeddedTypefaces.Values)
             typeface.Dispose();
         _embeddedTypefaces.Clear();
+        _deviceCmykBlendMask?.Dispose();
+        _deviceCmykBlendMask = null;
     }
 
     private static bool TryGetImageReferenceKey(

--- a/Excise.Rendering/SkiaRenderer.Paths.cs
+++ b/Excise.Rendering/SkiaRenderer.Paths.cs
@@ -679,9 +679,10 @@ internal partial class RenderContext
     /// <summary>
     /// Premultiplies one channel exactly as Skia's SetPixel/erase does for a
     /// premul bitmap: round(value * alpha / 255) via the SkMulDiv255Round
-    /// integer identity.
+    /// integer identity. Internal so DeviceCmykBlendPixelContractTests can pin
+    /// the equivalence against SKBitmap.SetPixel exhaustively.
     /// </summary>
-    private static byte PremulChannel(byte value, byte alpha)
+    internal static byte PremulChannel(byte value, byte alpha)
     {
         var prod = (alpha * value) + 128;
         return (byte)((prod + (prod >> 8)) >> 8);
@@ -692,7 +693,7 @@ internal partial class RenderContext
     /// Rgba8888 bitmap with no color space (see
     /// DeviceCmykBlendPixelContractTests for the exhaustive equivalence pin).
     /// </summary>
-    private static void WritePremulRgba(Span<byte> pixels, int offset, byte r, byte g, byte b, byte a)
+    internal static void WritePremulRgba(Span<byte> pixels, int offset, byte r, byte g, byte b, byte a)
     {
         pixels[offset] = PremulChannel(r, a);
         pixels[offset + 1] = PremulChannel(g, a);

--- a/Excise.Rendering/SkiaRenderer.Paths.cs
+++ b/Excise.Rendering/SkiaRenderer.Paths.cs
@@ -427,6 +427,27 @@ internal partial class RenderContext
         _currentPath = null;
     }
 
+    // Reusable coverage mask for TryPaintDeviceCmykBlendPath (#599). Grows to
+    // the largest path bounds seen during this context's render and is cleared
+    // before each use, so per-path work is a bounded memset + one rasterization
+    // instead of a full-page bitmap allocation per painted path. Disposed in
+    // DisposeOwnedResources.
+    private SKBitmap? _deviceCmykBlendMask;
+
+    private SKBitmap GetDeviceCmykBlendMask(int width, int height)
+    {
+        var existing = _deviceCmykBlendMask;
+        if (existing != null && existing.Width >= width && existing.Height >= height)
+            return existing;
+
+        // Grow-only: never shrink below a size already needed this render.
+        var newWidth = Math.Max(width, existing?.Width ?? 0);
+        var newHeight = Math.Max(height, existing?.Height ?? 0);
+        existing?.Dispose();
+        _deviceCmykBlendMask = new SKBitmap(newWidth, newHeight, SKColorType.Rgba8888, SKAlphaType.Premul);
+        return _deviceCmykBlendMask;
+    }
+
     private bool TryPaintDeviceCmykBlendPath(SKPath path, DeviceCmykColor? sourceCmyk, float alpha)
         => TryPaintDeviceCmykBlendPath(
             path,
@@ -473,7 +494,20 @@ internal partial class RenderContext
         if (right <= left || bottom <= top)
             return true;
 
-        using var mask = new SKBitmap(_rootBitmap.Width, _rootBitmap.Height, SKColorType.Rgba8888, SKAlphaType.Premul);
+        // Rasterize path coverage into a mask bounded to the path's device-space
+        // bounds (the only pixels the loop below ever reads), not the full page.
+        // The mask canvas gets the same total matrix post-translated by the
+        // integer offset (-left, -top); an integer pixel translation leaves
+        // Skia's antialiased coverage of every in-window pixel byte-identical
+        // to the previous full-page mask. Deliberately NOT intersected with the
+        // canvas clip: the previous full-page mask ignored the clip too, and
+        // shrinking to the clip would change which pixels composite.
+        var maskWidth = right - left;
+        var maskHeight = bottom - top;
+        var mask = GetDeviceCmykBlendMask(maskWidth, maskHeight);
+        var maskMatrix = matrix;
+        maskMatrix.TransX -= left;
+        maskMatrix.TransY -= top;
         using (var maskCanvas = new SKCanvas(mask))
         using (var maskPaint = new SKPaint
         {
@@ -499,19 +533,29 @@ internal partial class RenderContext
             if (pathEffect != null)
                 maskPaint.PathEffect = pathEffect;
             maskCanvas.Clear(SKColors.Transparent);
-            maskCanvas.SetMatrix(matrix);
+            maskCanvas.SetMatrix(maskMatrix);
             maskCanvas.DrawPath(path, maskPaint);
         }
 
         _canvas.Flush();
         var source = sourceCmyk.Value;
+
+        // Bulk pixel access: one managed span over the mask instead of a
+        // GetPixel P/Invoke per scanned pixel. The mask is premultiplied
+        // Rgba8888; premultiplication never changes the alpha byte, so reading
+        // byte offset 3 yields exactly what GetPixel(x, y).Alpha returned.
+        var maskRowBytes = mask.RowBytes;
+        var maskPixels = mask.GetPixelSpan();
         for (var y = top; y < bottom; y++)
         {
+            var maskRowStart = (y - top) * maskRowBytes;
             for (var x = left; x < right; x++)
             {
-                var coverage = mask.GetPixel(x, y).Alpha / 255.0;
-                if (coverage <= 0)
+                var maskAlpha = maskPixels[maskRowStart + ((x - left) * 4) + 3];
+                if (maskAlpha == 0)
                     continue;
+
+                var coverage = maskAlpha / 255.0;
 
                 var effectiveAlpha = Math.Clamp(alpha * coverage, 0, 1);
                 if (effectiveAlpha <= 0)

--- a/Excise.Rendering/SkiaRenderer.Paths.cs
+++ b/Excise.Rendering/SkiaRenderer.Paths.cs
@@ -498,16 +498,27 @@ internal partial class RenderContext
         // bounds (the only pixels the loop below ever reads), not the full page.
         // The mask canvas gets the same total matrix post-translated by the
         // integer offset (-left, -top); an integer pixel translation leaves
-        // Skia's antialiased coverage of every in-window pixel byte-identical
-        // to the previous full-page mask. Deliberately NOT intersected with the
-        // canvas clip: the previous full-page mask ignored the clip too, and
-        // shrinking to the clip would change which pixels composite.
-        var maskWidth = right - left;
-        var maskHeight = bottom - top;
+        // Skia's antialiased fill coverage of every in-window pixel
+        // byte-identical to the previous full-page mask. Deliberately NOT
+        // intersected with the canvas clip: the previous full-page mask ignored
+        // the clip too, and shrinking to the clip would change which pixels
+        // composite.
+        //
+        // Strokes keep the full root-bitmap surface: Skia's dash path effect
+        // consumes the surface cull rect while segmenting the dash, so a
+        // smaller surface changes dash phase accumulation and thus coverage
+        // (observed as pixel diffs on dashed DeviceCMYK strokes). They still
+        // benefit from mask reuse, the window-only clear, and the bulk span
+        // read below.
+        var boundMaskToWindow = style == SKPaintStyle.Fill && pathEffect == null;
+        var maskOriginX = boundMaskToWindow ? left : 0;
+        var maskOriginY = boundMaskToWindow ? top : 0;
+        var maskWidth = boundMaskToWindow ? right - left : _rootBitmap.Width;
+        var maskHeight = boundMaskToWindow ? bottom - top : _rootBitmap.Height;
         var mask = GetDeviceCmykBlendMask(maskWidth, maskHeight);
         var maskMatrix = matrix;
-        maskMatrix.TransX -= left;
-        maskMatrix.TransY -= top;
+        maskMatrix.TransX -= maskOriginX;
+        maskMatrix.TransY -= maskOriginY;
         using (var maskCanvas = new SKCanvas(mask))
         using (var maskPaint = new SKPaint
         {
@@ -532,7 +543,18 @@ internal partial class RenderContext
         {
             if (pathEffect != null)
                 maskPaint.PathEffect = pathEffect;
+
+            // Clear only the pixels the loop below reads. The draw itself stays
+            // unclipped so the surface-wide cull rect (and therefore dash
+            // segmentation) is untouched; stale pixels the path may repaint
+            // outside the window are never read.
+            maskCanvas.Save();
+            maskCanvas.ClipRect(
+                SKRect.Create(left - maskOriginX, top - maskOriginY, right - left, bottom - top),
+                SKClipOperation.Intersect,
+                antialias: false);
             maskCanvas.Clear(SKColors.Transparent);
+            maskCanvas.Restore();
             maskCanvas.SetMatrix(maskMatrix);
             maskCanvas.DrawPath(path, maskPaint);
         }
@@ -556,10 +578,10 @@ internal partial class RenderContext
         var rootPixels = GetRootPixelSpan();
         for (var y = top; y < bottom; y++)
         {
-            var maskRowStart = (y - top) * maskRowBytes;
+            var maskRowStart = (y - maskOriginY) * maskRowBytes;
             for (var x = left; x < right; x++)
             {
-                var maskAlpha = maskPixels[maskRowStart + ((x - left) * 4) + 3];
+                var maskAlpha = maskPixels[maskRowStart + ((x - maskOriginX) * 4) + 3];
                 if (maskAlpha == 0)
                     continue;
 

--- a/Excise.Rendering/SkiaRenderer.Paths.cs
+++ b/Excise.Rendering/SkiaRenderer.Paths.cs
@@ -540,12 +540,20 @@ internal partial class RenderContext
         _canvas.Flush();
         var source = sourceCmyk.Value;
 
-        // Bulk pixel access: one managed span over the mask instead of a
-        // GetPixel P/Invoke per scanned pixel. The mask is premultiplied
-        // Rgba8888; premultiplication never changes the alpha byte, so reading
-        // byte offset 3 yields exactly what GetPixel(x, y).Alpha returned.
+        // Bulk pixel access: one managed span over the mask (and one over the
+        // root bitmap) instead of a GetPixel/SetPixel P/Invoke per pixel.
+        // Both bitmaps are premultiplied Rgba8888 with no color space:
+        //   - reading: premultiplication never changes the alpha byte, so byte
+        //     offset 3 yields exactly what GetPixel(x, y).Alpha returned — and
+        //     alpha is the only channel this loop ever reads;
+        //   - writing: SetPixel on such a bitmap stores round(channel*alpha/255)
+        //     per channel with the alpha byte unchanged, replicated bit-exactly
+        //     by WritePremulRgba (pinned exhaustively over all 256x256
+        //     (alpha, channel) pairs by DeviceCmykBlendPixelContractTests).
         var maskRowBytes = mask.RowBytes;
         var maskPixels = mask.GetPixelSpan();
+        var rootRowBytes = _rootBitmap.RowBytes;
+        var rootPixels = GetRootPixelSpan();
         for (var y = top; y < bottom; y++)
         {
             var maskRowStart = (y - top) * maskRowBytes;
@@ -561,9 +569,9 @@ internal partial class RenderContext
                 if (effectiveAlpha <= 0)
                 {
                     if (_deviceCmykKnockoutGroupDepth > 0)
-                        ResetDeviceCmykKnockoutPixel(x, y, 0);
+                        ResetDeviceCmykKnockoutPixel(rootPixels, rootRowBytes, x, y, 0);
                     else if (_deviceCmykPreserveZeroAlphaShape)
-                        PreserveDeviceCmykShapePixel(x, y, coverage);
+                        PreserveDeviceCmykShapePixel(rootPixels, rootRowBytes, x, y, coverage);
                     continue;
                 }
 
@@ -601,10 +609,15 @@ internal partial class RenderContext
                     continue;
                 }
 
-                var dst = _rootBitmap.GetPixel(x, y);
+                var rootOffset = (y * rootRowBytes) + (x * 4);
+                var dstAlphaByte = rootPixels[rootOffset + 3];
                 if (_deviceCmykKnockoutGroupDepth > 0)
                 {
-                    dst = ResetDeviceCmykKnockoutPixel(x, y, 0);
+                    // The reset writes alpha 0, so the destination alpha the
+                    // final composite sees is 0 (previously dst.Alpha of the
+                    // SKColor returned by the reset — always its alpha arg).
+                    ResetDeviceCmykKnockoutPixel(rootPixels, rootRowBytes, x, y, 0);
+                    dstAlphaByte = 0;
                     backdrop = _deviceCmykBackdrop.Get(x, y);
                 }
 
@@ -619,48 +632,82 @@ internal partial class RenderContext
                 _deviceCmykBackdrop.CompositeSourceOver(x, y, blended, effectiveAlpha);
                 var output = _deviceCmykBackdrop.Get(x, y);
                 var (r, g, b) = DeviceCmykToRgb(output);
-                var dstAlpha = dst.Alpha / 255.0;
+                var dstAlpha = dstAlphaByte / 255.0;
                 var outAlpha = effectiveAlpha + (dstAlpha * (1 - effectiveAlpha));
-                var outColor = new SKColor(
+                WritePremulRgba(
+                    rootPixels,
+                    rootOffset,
                     ToByte(r),
                     ToByte(g),
                     ToByte(b),
                     ToByte(outAlpha));
-                _rootBitmap.SetPixel(x, y, outColor);
             }
         }
 
+        // SetPixel bumped the bitmap's generation per write; raw span writes do
+        // not, so invalidate once for any downstream consumer that snapshots
+        // the root bitmap (e.g. transparency-group backdrop seeding).
+        _rootBitmap.NotifyPixelsChanged();
         return true;
     }
 
-    private SKColor ResetDeviceCmykKnockoutPixel(int x, int y, byte alpha)
+    private unsafe Span<byte> GetRootPixelSpan()
+        => new((void*)_rootBitmap!.GetPixels(), _rootBitmap.RowBytes * _rootBitmap.Height);
+
+    /// <summary>
+    /// Premultiplies one channel exactly as Skia's SetPixel/erase does for a
+    /// premul bitmap: round(value * alpha / 255) via the SkMulDiv255Round
+    /// integer identity.
+    /// </summary>
+    private static byte PremulChannel(byte value, byte alpha)
+    {
+        var prod = (alpha * value) + 128;
+        return (byte)((prod + (prod >> 8)) >> 8);
+    }
+
+    /// <summary>
+    /// Byte-exact replacement for SKBitmap.SetPixel on a premultiplied
+    /// Rgba8888 bitmap with no color space (see
+    /// DeviceCmykBlendPixelContractTests for the exhaustive equivalence pin).
+    /// </summary>
+    private static void WritePremulRgba(Span<byte> pixels, int offset, byte r, byte g, byte b, byte a)
+    {
+        pixels[offset] = PremulChannel(r, a);
+        pixels[offset + 1] = PremulChannel(g, a);
+        pixels[offset + 2] = PremulChannel(b, a);
+        pixels[offset + 3] = a;
+    }
+
+    private void ResetDeviceCmykKnockoutPixel(Span<byte> rootPixels, int rootRowBytes, int x, int y, byte alpha)
     {
         var initialBackdrop = _deviceCmykKnockoutInitialBackdrop?.Get(x, y)
                               ?? new DeviceCmykColor(0, 0, 0, 0);
         var initialAlpha = _deviceCmykKnockoutInitialBackdrop?.GetAlpha(x, y) ?? (alpha / 255.0);
         _deviceCmykBackdrop!.Set(x, y, initialBackdrop, initialAlpha);
         var (initialR, initialG, initialB) = DeviceCmykToRgb(initialBackdrop);
-        var dst = new SKColor(
+        WritePremulRgba(
+            rootPixels,
+            (y * rootRowBytes) + (x * 4),
             ToByte(initialR),
             ToByte(initialG),
             ToByte(initialB),
             alpha);
-        _rootBitmap!.SetPixel(x, y, dst);
-        return dst;
     }
 
-    private void PreserveDeviceCmykShapePixel(int x, int y, double coverage)
+    private void PreserveDeviceCmykShapePixel(Span<byte> rootPixels, int rootRowBytes, int x, int y, double coverage)
     {
         var backdrop = _deviceCmykBackdrop!.Get(x, y);
         var (r, g, b) = DeviceCmykToRgb(backdrop);
-        var dst = _rootBitmap!.GetPixel(x, y);
-        var dstAlpha = dst.Alpha / 255.0;
+        var offset = (y * rootRowBytes) + (x * 4);
+        var dstAlpha = rootPixels[offset + 3] / 255.0;
         var outAlpha = Math.Clamp(coverage, 0, 1) + (dstAlpha * (1 - Math.Clamp(coverage, 0, 1)));
-        _rootBitmap.SetPixel(x, y, new SKColor(
+        WritePremulRgba(
+            rootPixels,
+            offset,
             ToByte(r),
             ToByte(g),
             ToByte(b),
-            ToByte(outAlpha)));
+            ToByte(outAlpha));
     }
 
     private enum PdfSeparableBlendMode


### PR DESCRIPTION
#596 perf slice targeting the #597 baseline's #2 hot path. `TryPaintDeviceCmykBlendPath` (`SkiaRenderer.Paths.cs`) allocated a **full-page SKBitmap mask per painted path** and ran a **per-pixel `GetPixel`/`SetPixel` P/Invoke loop** (3 P/Invokes/pixel) — 16.4% of the render trace, ~4.3 GB native bitmap churn on the passport forms.

## Change (pixel-identical by construction + proof)
- **Bounded mask:** mask sized to the path's device bounds (the only pixels the loop reads), integer-translated — Skia AA fill coverage stays byte-identical. Deliberately NOT clip-intersected (old mask ignored the clip; intersecting would change compositing).
- **Bulk access:** mask alpha via `GetPixelSpan()`; root bitmap raw span; writes via `WritePremulRgba` (replicates `SetPixel`'s premul store — **verified against `SKBitmap.SetPixel` over all 65,536 (alpha,channel) pairs**).
- **Mask reuse:** one grow-only cached mask per RenderContext.
- **Stroke/dash exception** (found by A/B, not theory): dashed CMYK strokes couple to the surface cull-rect, so strokes keep a root-sized mask (window-only `Clear`).
- **Direct proof:** A/B byte-comparison of rendered PNGs — 3 synthetic CMYK fixtures × 2 DPIs + 6 pages each of DS-11/DS-82 = **18/18 byte-identical**.

## Performance — my independent before/after (min of 3, Release, `profile-workflows --steps first-page-render,all-page-render`)
| Doc / step | Before | After | Delta |
|---|---:|---:|---:|
| **ds82-passport all-page** | 642 ms | 406 ms | **−36.8%** |
| ds11-passport all-page | 570 ms | 511 ms | −10.2% |
| ds11-passport first-page | 134 ms | 109 ms | −18.9% |
| non-CMYK smoke docs | — | — | ±noise, no regression |
(Eliminated churn was *native* SKBitmap memory — the managed GC counter never saw it.)

## Correctness (my verification, on the branch)
| Gate | Result |
|---|---|
| Build | **0 warnings** |
| **Visual regression (--release)** | all groups PASS, **0 changed baseline files — pixel-identical** |
| CMYK differentials (Altona/Ghent) | **37 / 0 failed** |
| Extraction-parity (#645) | 332 pages, **98.7%** |
| Redaction | Core 188 ✅ · Rendering 44 ✅ · App 105 ✅ |
| Full `Excise.Rendering.Tests` | **3611 / 0 failed** |
| New tests | `DeviceCmykBlendPixelContractTests` (exhaustive premul≡SetPixel pin — fails on a SkiaSharp upgrade), `DeviceCmykBlendPathRenderTests` (colors pinned to pre-change renderer) |

## Follow-ups (#599 remainder)
Soft-mask compositing (`RenderWithCurrentSoftMask`, 14.4% — baseline row 6) is the next-largest leaf (explains ds11's smaller gain). Per-covered-pixel backdrop math (`DeviceCmykBackdrop`/`DeviceCmykToRgb` rounding) is table-flattenable if more is needed.

Refs #599

🤖 Generated with [Claude Code](https://claude.com/claude-code)