### PR TITLE
perf: cache parsed content-stream ops + render-path metadata-free parse (#598)

### DIFF
--- a/Excise.Core.Tests/Content/ContentStreamParserMetadataModeTests.cs
+++ b/Excise.Core.Tests/Content/ContentStreamParserMetadataModeTests.cs
@@ -1,0 +1,76 @@
+using System.Text;
+using AwesomeAssertions;
+using Excise.Core.Content;
+using Xunit;
+
+namespace Excise.Core.Tests.Content;
+
+/// <summary>
+/// Guards the invariant behind the renderer's metadata-free parse mode
+/// (#598): with <see cref="ContentStreamParser.ComputeOperatorMetadata"/>
+/// off, the parsed operator sequence — names, operands, inline-image bytes —
+/// must be byte-for-byte identical to a full parse. Only the annotations
+/// (BoundingBox, decoded TextContent) may differ. This is what makes the
+/// renderer's use of the mode pixel-identical: its input operators are
+/// provably the same.
+/// </summary>
+public class ContentStreamParserMetadataModeTests
+{
+    private const string RepresentativeStream =
+        "q 0.5 0 0 0.5 10 20 cm " +
+        "1 0 0 rg 10 10 80 80 re f " +
+        "BT /F1 12 Tf 100 700 Td (Hello \\(world\\)) Tj " +
+        "[(kerned) -120 (text)] TJ ET " +
+        "0 0 100 100 re W n " +
+        "BI /W 2 /H 2 /CS /G /BPC 8 ID \x01\x02\x03\x04 EI " +
+        "/Fm1 Do Q";
+
+    [Fact]
+    public void MetadataFreeParse_YieldsIdenticalOperatorsAndOperands()
+    {
+        var bytes = Encoding.Latin1.GetBytes(RepresentativeStream);
+
+        var full = new ContentStreamParser(bytes).Parse();
+        var lean = new ContentStreamParser(bytes) { ComputeOperatorMetadata = false }.Parse();
+
+        lean.Operators.Count.Should().Be(full.Operators.Count);
+        for (var i = 0; i < full.Operators.Count; i++)
+        {
+            lean.Operators[i].Name.Should().Be(full.Operators[i].Name);
+            // ToString serializes operands; identical text means identical
+            // operand values in identical order.
+            lean.Operators[i].ToString().Should().Be(full.Operators[i].ToString(),
+                $"operator #{i} must be unaffected by the metadata mode");
+            (lean.Operators[i].InlineImageData ?? Array.Empty<byte>())
+                .Should().Equal(full.Operators[i].InlineImageData ?? Array.Empty<byte>());
+        }
+
+        // Round-trip through the writer must be identical too — the writer
+        // reads only names/operands/inline bytes, exactly what a renderer
+        // replay consumes.
+        var writer = new ContentStreamWriter();
+        writer.Write(lean).Should().Equal(writer.Write(full));
+    }
+
+    [Fact]
+    public void MetadataFreeParse_SkipsBoundsAnnotations()
+    {
+        var bytes = Encoding.Latin1.GetBytes(RepresentativeStream);
+
+        var full = new ContentStreamParser(bytes).Parse();
+        var lean = new ContentStreamParser(bytes) { ComputeOperatorMetadata = false }.Parse();
+
+        full.Operators.Should().Contain(op => op.BoundingBox != null,
+            "the full parse computes bounds (redaction depends on them)");
+        lean.Operators.Should().OnlyContain(op => op.BoundingBox == null,
+            "the metadata-free parse must not emit bounds computed from untracked state");
+    }
+
+    [Fact]
+    public void DefaultMode_ComputesMetadata_RedactionContractUnchanged()
+    {
+        // Redaction and extraction construct the parser without touching
+        // ComputeOperatorMetadata; the default must stay ON.
+        new ContentStreamParser(Array.Empty<byte>()).ComputeOperatorMetadata.Should().BeTrue();
+    }
+}

--- a/Excise.Core/Content/ContentStreamParser.cs
+++ b/Excise.Core/Content/ContentStreamParser.cs
@@ -39,8 +39,10 @@ public class ContentStreamParser
     /// ⚠️ Redaction and text extraction rely on the metadata pass and MUST
     /// keep the default (true): LetterFinder/GlyphRemover match on the
     /// decoded operator text and bounds this pass produces.
+    /// Internal — a parser tuning option, not a public SemVer commitment;
+    /// Excise.Rendering reaches it via InternalsVisibleTo (see #598).
     /// </summary>
-    public bool ComputeOperatorMetadata { get; set; } = true;
+    internal bool ComputeOperatorMetadata { get; set; } = true;
 
     /// <summary>
     /// Upper bound on an inline image's data scan when no <c>/L</c> length is

--- a/Excise.Core/Content/ContentStreamParser.cs
+++ b/Excise.Core/Content/ContentStreamParser.cs
@@ -27,6 +27,22 @@ public class ContentStreamParser
     public int MaxNestingDepth { get; set; } = 256;
 
     /// <summary>
+    /// When false, the parser skips the state-tracking pass that annotates
+    /// each operator with <see cref="ContentOperator.BoundingBox"/> and the
+    /// decoded <see cref="ContentOperator.TextContent"/> — the font
+    /// resolution, ToUnicode CMap parsing, glyph-width advances, graphics
+    /// state cloning and path-bounds accumulation that exist only to compute
+    /// that metadata. Operator names, operands, and inline-image data are
+    /// byte-for-byte identical either way. Intended for callers that
+    /// re-execute the operators under their own full state machine and never
+    /// read the metadata (Excise.Rendering does this — see #598).
+    /// ⚠️ Redaction and text extraction rely on the metadata pass and MUST
+    /// keep the default (true): LetterFinder/GlyphRemover match on the
+    /// decoded operator text and bounds this pass produces.
+    /// </summary>
+    public bool ComputeOperatorMetadata { get; set; } = true;
+
+    /// <summary>
     /// Upper bound on an inline image's data scan when no <c>/L</c> length is
     /// declared (#347). Inline images are meant to be small (§8.9.7); this is
     /// far larger than any legitimate one and just bounds malicious input.
@@ -143,7 +159,8 @@ public class ContentStreamParser
         var op = new ContentOperator(name, operands.ToList());
 
         // Execute operator to update state and calculate bounds
-        ExecuteOperator(name, operands, op);
+        if (ComputeOperatorMetadata)
+            ExecuteOperator(name, operands, op);
 
         return op;
     }
@@ -969,10 +986,12 @@ public class ContentStreamParser
         }
 
         // Compute operator bounds from current CTM (inline image fills the unit square
-        // mapped through the CTM, i.e. the four corners (0,0),(1,0),(1,1),(0,1))
-        var b = TransformBounds(0, 0, 1, 1);
+        // mapped through the CTM, i.e. the four corners (0,0),(1,0),(1,1),(0,1)).
+        // Skipped in metadata-free mode — the CTM is not tracked there, so a
+        // computed box would be wrong rather than merely absent.
         var op = new ContentOperator("BI", new PdfObject[] { imageParams });
-        op.BoundingBox = b;
+        if (ComputeOperatorMetadata)
+            op.BoundingBox = TransformBounds(0, 0, 1, 1);
         op.InlineImageData = imageData;
         return op;
     }

--- a/Excise.Rendering.Tests/FormXObjectParseCacheTests.cs
+++ b/Excise.Rendering.Tests/FormXObjectParseCacheTests.cs
@@ -1,0 +1,172 @@
+using Excise.Core.Document;
+using Excise.Core.Primitives;
+using AwesomeAssertions;
+using SkiaSharp;
+using Xunit;
+
+namespace Excise.Rendering.Tests;
+
+/// <summary>
+/// Guards the content-stream parse cache on the render hot path (#598).
+/// A Form XObject invoked N times on a page must be content-stream-parsed
+/// once, while every invocation still executes under its own graphics
+/// state (CTM, fill colour, ...) — the cache holds the PARSE, never the
+/// drawn result.
+/// </summary>
+public class FormXObjectParseCacheTests
+{
+    [Fact]
+    public void FormInvokedManyTimes_ParsesOnce_AndHonorsPerInvocationState()
+    {
+        // Form paints the unit-square-ish rect WITHOUT setting a colour, so
+        // each invocation inherits the fill colour in force at the Do site.
+        const string formContent = "0 0 40 40 re f";
+
+        // Nine invocations of the same form at distinct translations with
+        // distinct fill colours: red / green / blue repeating.
+        var content = string.Join(" ",
+            Invocation(60, 700, "1 0 0 rg"),
+            Invocation(160, 700, "0 1 0 rg"),
+            Invocation(260, 700, "0 0 1 rg"),
+            Invocation(60, 600, "1 0 0 rg"),
+            Invocation(160, 600, "0 1 0 rg"),
+            Invocation(260, 600, "0 0 1 rg"),
+            Invocation(60, 500, "1 0 0 rg"),
+            Invocation(160, 500, "0 1 0 rg"),
+            Invocation(260, 500, "0 0 1 rg"));
+
+        var pdfData = FormPdfBuilder.Build(content, formContent);
+        using var doc = PdfDocument.Open(pdfData);
+        var renderer = new SkiaRenderer();
+
+        RenderContext.ContentStreamParseCacheHits = 0;
+        using var bitmap = renderer.RenderPage(doc.GetPage(1), new RenderOptions { Dpi = 72 });
+
+        // 9 invocations of the same decoded form bytes → 1 parse, 8 cache hits.
+        RenderContext.ContentStreamParseCacheHits.Should().BeGreaterThanOrEqualTo(8,
+            "a form invoked N times must be content-stream-parsed once");
+
+        // Per-invocation graphics state must still apply: each instance sits
+        // at its own translation and carries its own fill colour.
+        // Dpi 72 → 1 unit = 1 px; bitmap y = pageHeight (792) - pdf y.
+        PixelAt(bitmap, 80, 720).Should().Be(new SKColor(255, 0, 0), "first column is red");
+        PixelAt(bitmap, 180, 720).Should().Be(new SKColor(0, 255, 0), "second column is green");
+        PixelAt(bitmap, 280, 720).Should().Be(new SKColor(0, 0, 255), "third column is blue");
+        PixelAt(bitmap, 80, 520).Should().Be(new SKColor(255, 0, 0), "cached parse must not freeze first-invocation state");
+        PixelAt(bitmap, 280, 520).Should().Be(new SKColor(0, 0, 255), "blue column repeats");
+
+        // And outside every instance the page stays white.
+        PixelAt(bitmap, 400, 720).Should().Be(SKColors.White);
+    }
+
+    [Fact]
+    public void FormStreamMutatedBetweenRenders_RendersNewContent()
+    {
+        const string formContent = "0 g 0 0 40 40 re f";
+        var content = "q 1 0 0 1 100 700 cm /Fm1 Do Q";
+        var pdfData = FormPdfBuilder.Build(content, formContent);
+        using var doc = PdfDocument.Open(pdfData);
+        var renderer = new SkiaRenderer();
+
+        using (var before = renderer.RenderPage(doc.GetPage(1), new RenderOptions { Dpi = 72 }))
+        {
+            PixelAt(before, 120, 720).Should().Be(SKColors.Black, "original form paints black at 100..140 x 700..740");
+        }
+
+        // Replace the form's content: same box, moved 200pt right. The
+        // DecodedData setter installs a NEW byte[] instance, so no cached
+        // parse (reference-keyed) can ever serve the old operators.
+        var form = ResolveForm(doc);
+        form.DecodedData = System.Text.Encoding.ASCII.GetBytes("0 g 200 0 40 40 re f");
+
+        using var after = renderer.RenderPage(doc.GetPage(1), new RenderOptions { Dpi = 72 });
+        PixelAt(after, 120, 720).Should().Be(SKColors.White, "old form content must not survive the mutation");
+        PixelAt(after, 320, 720).Should().Be(SKColors.Black, "new form content must render");
+    }
+
+    private static PdfStream ResolveForm(PdfDocument doc)
+    {
+        var resources = doc.GetPage(1).Resources!;
+        var xobjects = (PdfDictionary)doc.Resolve(resources.GetOptional("XObject")!)!;
+        return (PdfStream)doc.Resolve(xobjects.GetOptional("Fm1")!)!;
+    }
+
+    private static string Invocation(int tx, int ty, string fill) =>
+        $"q {fill} 1 0 0 1 {tx} {ty} cm /Fm1 Do Q";
+
+    private static SKColor PixelAt(SKBitmap bitmap, int pdfX, int pdfY) =>
+        bitmap.GetPixel(pdfX, 792 - pdfY);
+
+    private static class FormPdfBuilder
+    {
+        public static byte[] Build(string content, string formContent)
+        {
+            using var ms = new MemoryStream();
+            using var writer = new StreamWriter(ms, System.Text.Encoding.ASCII, leaveOpen: true);
+            writer.NewLine = "\n";
+
+            writer.WriteLine("%PDF-1.4");
+            writer.Flush();
+
+            var offsets = new long[6];
+
+            offsets[1] = ms.Position;
+            writer.WriteLine("1 0 obj");
+            writer.WriteLine("<< /Type /Catalog /Pages 2 0 R >>");
+            writer.WriteLine("endobj");
+            writer.Flush();
+
+            offsets[2] = ms.Position;
+            writer.WriteLine("2 0 obj");
+            writer.WriteLine("<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+            writer.WriteLine("endobj");
+            writer.Flush();
+
+            offsets[3] = ms.Position;
+            writer.WriteLine("3 0 obj");
+            writer.WriteLine("<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792]");
+            writer.WriteLine("   /Contents 4 0 R");
+            writer.WriteLine("   /Resources << /XObject << /Fm1 5 0 R >> >> >>");
+            writer.WriteLine("endobj");
+            writer.Flush();
+
+            offsets[4] = ms.Position;
+            writer.WriteLine("4 0 obj");
+            writer.WriteLine($"<< /Length {content.Length} >>");
+            writer.WriteLine("stream");
+            writer.Write(content);
+            writer.WriteLine();
+            writer.WriteLine("endstream");
+            writer.WriteLine("endobj");
+            writer.Flush();
+
+            offsets[5] = ms.Position;
+            writer.WriteLine("5 0 obj");
+            writer.WriteLine("<< /Type /XObject /Subtype /Form /BBox [0 0 612 792]");
+            writer.WriteLine($"   /Matrix [1 0 0 1 0 0] /Length {formContent.Length} >>");
+            writer.WriteLine("stream");
+            writer.Write(formContent);
+            writer.WriteLine();
+            writer.WriteLine("endstream");
+            writer.WriteLine("endobj");
+            writer.Flush();
+
+            long xrefPos = ms.Position;
+            writer.WriteLine("xref");
+            writer.WriteLine("0 6");
+            writer.WriteLine("0000000000 65535 f ");
+            for (int i = 1; i <= 5; i++)
+                writer.WriteLine($"{offsets[i]:D10} 00000 n ");
+            writer.Flush();
+
+            writer.WriteLine("trailer");
+            writer.WriteLine("<< /Root 1 0 R /Size 6 >>");
+            writer.WriteLine("startxref");
+            writer.WriteLine(xrefPos.ToString());
+            writer.WriteLine("%%EOF");
+            writer.Flush();
+
+            return ms.ToArray();
+        }
+    }
+}

--- a/Excise.Rendering/SkiaRenderer.Text.cs
+++ b/Excise.Rendering/SkiaRenderer.Text.cs
@@ -2346,7 +2346,10 @@ internal partial class RenderContext
         float? wx = null;
         try
         {
+            // Metadata-free parse (#598): only the first operator's
+            // name/operands are read here.
             var content = new ContentStreamParser(charProc.DecodedData, _page)
+                { ComputeOperatorMetadata = false }
                 .Parse(_cancellationToken);
             var first = content.Operators.Count > 0 ? content.Operators[0] : null;
             if (first is { Name: "d0" or "d1" } && first.Operands.Count >= 1)

--- a/Excise.Rendering/SkiaRenderer.cs
+++ b/Excise.Rendering/SkiaRenderer.cs
@@ -967,7 +967,13 @@ internal partial class RenderContext
         // so a stream mutated between renders can never serve stale operators.
         if (!_parsedContentByBytes.TryGetValue(contentBytes, out var content))
         {
+            // Metadata-free parse (#598): the renderer re-executes every
+            // operator under its own graphics/text state machine and never
+            // reads the parser-computed BoundingBox/TextContent, so skip the
+            // parser's own state-tracking pass (font resolution, ToUnicode
+            // CMaps, glyph-width advances, bounds accumulation).
             content = new ContentStreamParser(contentBytes, _page)
+                { ComputeOperatorMetadata = false }
                 .Parse(_cancellationToken);
             _parsedContentByBytes[contentBytes] = content;
         }

--- a/Excise.Rendering/SkiaRenderer.cs
+++ b/Excise.Rendering/SkiaRenderer.cs
@@ -440,6 +440,16 @@ internal partial class RenderContext
     private readonly Dictionary<(int ObjectNumber, int Generation, int TargetWidth, int TargetHeight), SoftMaskAlpha?> _softMaskAlphaByReference = new();
     private readonly Dictionary<Excise.Core.Primitives.PdfStream, Dictionary<(int TargetWidth, int TargetHeight), SoftMaskAlpha?>> _softMaskAlphaByStream =
         new(ReferenceEqualityComparer.Instance);
+    // Parsed content-stream operators per source byte[] instance (#598) — see
+    // ExecuteContentBytes. Reference-keyed like the other per-stream caches;
+    // lifetime is this RenderContext (a single page render).
+    private readonly Dictionary<byte[], Excise.Core.Content.ContentStream> _parsedContentByBytes =
+        new(ReferenceEqualityComparer.Instance);
+    // Observability hook for tests: parse-cache hits on the current thread
+    // (rendering executes synchronously on the calling thread). Thread-static
+    // so parallel test collections cannot interfere with each other's counts.
+    [ThreadStatic]
+    internal static long ContentStreamParseCacheHits;
     private readonly Dictionary<(int ObjectNumber, int Generation, ImageBitmapCacheKey Key), SKBitmap?> _imageBitmapByReference = new();
     private readonly Dictionary<Excise.Core.Primitives.PdfStream, Dictionary<ImageBitmapCacheKey, SKBitmap?>> _imageBitmapByStream =
         new(ReferenceEqualityComparer.Instance);
@@ -940,8 +950,32 @@ internal partial class RenderContext
 
     private void ExecuteContentBytes(byte[] contentBytes)
     {
-        var content = new ContentStreamParser(contentBytes, _page)
-            .Parse(_cancellationToken);
+        // Parsed-operator cache for repeatedly executed content streams (#598).
+        // A Form XObject invoked N times on a page, a Type 3 CharProc executed
+        // per glyph occurrence, and a tiling pattern cell stamped per tile all
+        // hand this method the SAME byte[] instance (PdfStream caches its
+        // decoded bytes), and re-parsing it per execution was the tractable
+        // share of the form-execution hot path in the #597 render trace.
+        // This caches the PARSE only — never the drawn result: the cached
+        // ContentOperator list is immutable data the renderer only reads, and
+        // every execution still runs the full operator interpreter under the
+        // invocation's own graphics state / CTM / clip / resource scope.
+        // Keying by byte[] REFERENCE gives natural invalidation (replacing a
+        // stream's data via SetDecodedData/SetEncodedData or the DecodedData
+        // setter produces a new array instance and therefore a cache miss),
+        // and the cache lives only for this RenderContext (one page render),
+        // so a stream mutated between renders can never serve stale operators.
+        if (!_parsedContentByBytes.TryGetValue(contentBytes, out var content))
+        {
+            content = new ContentStreamParser(contentBytes, _page)
+                .Parse(_cancellationToken);
+            _parsedContentByBytes[contentBytes] = content;
+        }
+        else
+        {
+            ContentStreamParseCacheHits++;
+        }
+
         ExecuteContentOperators(content.Operators);
     }
 


### PR DESCRIPTION
#596 perf slice on the form-XObject / content-stream render path (#597 baseline's 44%-of-render chunk).

## Assessment (the honest finding)
The 44% is **partly inherent** — running a form's content operators is real work any renderer must do. But two optimizable sub-parts were found:
1. **Repeated content-stream re-parsing** — a form/content byte[] was re-parsed on each invocation.
2. **Render-path metadata overhead** — `ContentStreamParser` computed per-operator `BoundingBox`/`TextContent` metadata (font resolution, ToUnicode CMap parsing, glyph-width advances, graphics-state cloning, path-bounds) that **only redaction/extraction use** — the renderer re-executes operators under its own state machine and never reads it.

## Changes
- `SkiaRenderer.cs` (+44): cache parsed operators per content-stream byte[] in RenderContext (parse once per unique stream, not per invocation). Cycle detection (`_formXObjectStack`) preserved.
- `ContentStreamParser.cs` (+27): **internal** `ComputeOperatorMetadata` flag (default **true**); the render path sets it false to skip the metadata pass. Operator names/operands/inline-image bytes are byte-for-byte identical either way. **Redaction/extraction keep the default (true)** — the flag is scoped so it can never affect redaction bounds. Kept `internal` (via existing InternalsVisibleTo), not public — no SemVer surface change.
- `SkiaRenderer.Text.cs` (+3): Type 3 CharProc wx-peek uses the metadata-free parse.

## Performance — my independent before/after (min of 3, render workflows)
Render total **−4.7%**; wins concentrated on multi-page form docs: irs-pub509 all-page −13.6%, irs-w4 all-page −10.2%, scotus-anderson first-page −22%. Tiny single-page docs are within ±noise. Modest overall — the 44% is largely inherent draw work; the parse-cache + metadata-skip remove the tractable overhead.

## Correctness (my verification, on the branch)
| Gate | Result |
|---|---|
| Build | **0 warnings** |
| **Visual regression (--release)** | all PASS, **0 changed baselines — pixel-identical** |
| Extraction-parity (#645) | 332 pages, **98.7%** |
| Redaction | Core 187 ✅ · Rendering 44 ✅ · App 105 ✅ (metadata flag defaults on — redaction unaffected) |
| Full suites | Core **3594 / 0 failed** · Rendering **3610 / 0 failed** |
| New tests | `ContentStreamParserMetadataModeTests` (metadata-free ≡ metadata-on for operator bytes), `FormXObjectParseCacheTests` (parse-once, correctness under repeated invocation) |

## Follow-up
Remaining render hot leaves per the #597 baseline: soft-mask compositing (14.4%, #599), glyph-path text (25%, #600).

Refs #598

🤖 Generated with [Claude Code](https://claude.com/claude-code)