### PR TITLE
perf: cut per-token allocation churn in TextExtractor content parse — −34% extract alloc, byte-identical (#600)

### DIFF
--- a/Excise.Core.Tests/Text/TextExtractorParsePinTests.cs
+++ b/Excise.Core.Tests/Text/TextExtractorParsePinTests.cs
@@ -1,0 +1,214 @@
+using AwesomeAssertions;
+using Excise.Core.Document;
+using Excise.Core.Text;
+using System.Text;
+using Xunit;
+
+namespace Excise.Core.Tests.Text;
+
+/// <summary>
+/// Byte-exact pins for the content-stream token parsers in
+/// <see cref="TextExtractor"/> (#600). The #600 hot-path work rewrote
+/// ParseStringLiteral / ParseHexString / ParseName / ParseNumber /
+/// ParseKeyword for allocation, with the contract that extraction output is
+/// BYTE-IDENTICAL — same decoded strings, same Letter values / character
+/// codes / code byte lengths, same positions. These tests pin that contract
+/// on a fixture that deliberately exercises every rewritten path: literal
+/// escapes (named, octal 1–3 digit, escaped parens, line continuation),
+/// nested parentheses, hex strings with whitespace and an odd digit count,
+/// #XX name escapes, integer and real operands, and multi-operator TJ/'
+/// content. Expected values are hand-derived from PDF32000-1 §7.3.4 and
+/// were verified identical on the pre-#600 parser.
+/// </summary>
+public class TextExtractorParsePinTests
+{
+    // Exercises, in order:
+    //  - Tj literal with a 3-digit octal escape (\154 = 'l') and escaped parens
+    //  - Tj literal with leading space, octal escapes, and NESTED parens
+    //  - Td relative positioning with real operands
+    //  - Tj literal with a backslash line-continuation (produces NO character),
+    //    octal 'A' (\101) and octal 0xFF (\377)
+    //  - Tj hex string with embedded whitespace and an ODD digit count
+    //    (trailing nibble padded with 0 -> 0x50 'P')
+    //  - TJ array mixing literals with negative-int and real kern adjustments
+    //  - TL + ' (move-to-next-line-and-show)
+    //  - A #XX hex escape inside the font NAME operand (/F#31 == /F1)
+    private const string PinContent =
+        "BT\n" +
+        "/F1 12 Tf\n" +
+        "1 0 0 1 72 700 Tm\n" +
+        "(Hel\\154o \\(World\\)) Tj\n" +
+        "( Hi\\054 nested (parens) ok) Tj\n" +
+        "-2.5 -14 Td\n" +
+        "(Wrap\\\nped line\\101\\377) Tj\n" +
+        "<48 65 6C6C 6F5> Tj\n" +
+        "[ (Kern) -120 (ed) 250.5 (!) ] TJ\n" +
+        "14 TL\n" +
+        "/F#31 10 Tf\n" +
+        "(Next) '\n" +
+        "ET";
+
+    private const string ExpectedText =
+        "Hello (World)" +
+        " Hi, nested (parens) ok" +
+        "Wrapped lineAÿ" +
+        "HelloP" +
+        "Kerned!" +
+        "Next";
+
+    [Fact]
+    public void ExtractText_TokenParserFixture_IsByteIdentical()
+    {
+        using var doc = PdfDocument.Open(CreatePdfWithContentStream(PinContent));
+        var extractor = new TextExtractor(doc.GetPage(1)) { IncludeFormFieldValues = false };
+
+        extractor.ExtractText().Should().Be(ExpectedText);
+    }
+
+    [Fact]
+    public void ExtractLetters_TokenParserFixture_PinsValuesCodesAndPositions()
+    {
+        using var doc = PdfDocument.Open(CreatePdfWithContentStream(PinContent));
+        var extractor = new TextExtractor(doc.GetPage(1)) { IncludeFormFieldValues = false };
+
+        var letters = extractor.ExtractLetters();
+
+        letters.Should().HaveCount(ExpectedText.Length);
+        string.Concat(letters.Select(l => l.Value)).Should().Be(ExpectedText);
+
+        // First letter: 'H' at the Tm origin, Helvetica 'H' width 722/1000 * 12.
+        var first = letters[0];
+        first.Value.Should().Be("H");
+        first.CharacterCode.Should().Be('H');
+        first.CodeByteLength.Should().Be(1);
+        first.StartX.Should().BeApproximately(72.0, 1e-9);
+        first.StartY.Should().BeApproximately(700.0, 1e-9);
+        first.Width.Should().BeApproximately(8.664, 1e-9);
+        first.FontSize.Should().Be(12);
+        first.FontName.Should().Be("F1");
+        first.IsInHiddenOptionalContent.Should().BeFalse();
+
+        // The octal escape \154 decoded to a real 'l' with the byte value 108.
+        letters[3].Value.Should().Be("l");
+        letters[3].CharacterCode.Should().Be(108);
+
+        // \377 decoded through WinAnsi to U+00FF with the source byte preserved.
+        var yuml = letters.Single(l => l.Value == "ÿ");
+        yuml.CharacterCode.Should().Be(255);
+        yuml.CodeByteLength.Should().Be(1);
+
+        // First letter after "-2.5 -14 Td": 'W' at (72 - 2.5, 700 - 14) — the
+        // line-continuation escape before it must produce NO character.
+        var w = letters.Single(l => l.Value == "W" && l.StartY < 700);
+        w.StartX.Should().BeApproximately(69.5, 1e-9);
+        w.StartY.Should().BeApproximately(686.0, 1e-9);
+
+        // Hex-string letters: <48...> starts with 'H' (0x48); the odd trailing
+        // nibble '5' was padded to 0x50 = 'P'.
+        letters.Single(l => l.Value == "P").CharacterCode.Should().Be(0x50);
+
+        // The #XX name escape resolved /F#31 to font F1 for the final block.
+        var next = letters.Single(l => l.Value == "N");
+        next.FontName.Should().Be("F1");
+        next.FontSize.Should().Be(10);
+
+        // ' moved down by the 14 TL leading from the current line origin.
+        next.StartY.Should().BeApproximately(672.0, 1e-9);
+    }
+
+    [Fact]
+    public void ExtractLetters_TokenParserFixture_TjKernAdjustsPosition()
+    {
+        using var doc = PdfDocument.Open(CreatePdfWithContentStream(PinContent));
+        var extractor = new TextExtractor(doc.GetPage(1)) { IncludeFormFieldValues = false };
+
+        var letters = extractor.ExtractLetters();
+
+        // TJ: [ (Kern) -120 (ed) 250.5 (!) ] — an adjustment a is applied as
+        // tx = -(a / 1000) * fontSize (§9.4.3): the int -120 widens the gap
+        // before "ed" by 1.44; the real 250.5 pulls '!' back by 3.006.
+        // "Kerned!" occupies a fixed index range of the pinned text.
+        var kIndex = ExpectedText.IndexOf("Kerned!", StringComparison.Ordinal);
+        string.Concat(letters.Skip(kIndex).Take(7).Select(l => l.Value)).Should().Be("Kerned!");
+
+        var n = letters[kIndex + 3];  // 'n' of "Kern"
+        var e2 = letters[kIndex + 4]; // 'e' of "ed"
+        (e2.StartX - (n.StartX + n.Width)).Should().BeApproximately(1.44, 1e-9);
+
+        var d = letters[kIndex + 5];  // 'd' of "ed"
+        var bang = letters[kIndex + 6];
+        (bang.StartX - (d.StartX + d.Width)).Should().BeApproximately(-3.006, 1e-9);
+    }
+
+    [Fact]
+    public void ExtractWords_TokenParserFixture_SegmentsUnchanged()
+    {
+        using var doc = PdfDocument.Open(CreatePdfWithContentStream(PinContent));
+        var extractor = new TextExtractor(doc.GetPage(1)) { IncludeFormFieldValues = false };
+
+        var words = extractor.ExtractWords().Select(w => w.Text).ToList();
+
+        words.Should().Contain(new[] { "Hello", "(World)", "Hi,", "nested", "(parens)", "Next" });
+    }
+
+    private static byte[] CreatePdfWithContentStream(string content)
+    {
+        using var ms = new MemoryStream();
+        using var writer = new StreamWriter(ms, new UTF8Encoding(false), leaveOpen: true);
+        writer.NewLine = "\n";
+
+        writer.WriteLine("%PDF-1.4");
+        writer.Flush();
+
+        var offsets = new long[6];
+
+        offsets[1] = ms.Position;
+        writer.WriteLine("1 0 obj");
+        writer.WriteLine("<< /Type /Catalog /Pages 2 0 R >>");
+        writer.WriteLine("endobj");
+        writer.Flush();
+
+        offsets[2] = ms.Position;
+        writer.WriteLine("2 0 obj");
+        writer.WriteLine("<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+        writer.WriteLine("endobj");
+        writer.Flush();
+
+        offsets[3] = ms.Position;
+        writer.WriteLine("3 0 obj");
+        writer.WriteLine("<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>");
+        writer.WriteLine("endobj");
+        writer.Flush();
+
+        offsets[4] = ms.Position;
+        writer.WriteLine("4 0 obj");
+        writer.WriteLine($"<< /Length {content.Length} >>");
+        writer.WriteLine("stream");
+        writer.Write(content);
+        writer.WriteLine();
+        writer.WriteLine("endstream");
+        writer.WriteLine("endobj");
+        writer.Flush();
+
+        offsets[5] = ms.Position;
+        writer.WriteLine("5 0 obj");
+        writer.WriteLine("<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>");
+        writer.WriteLine("endobj");
+        writer.Flush();
+
+        var xrefPos = ms.Position;
+        writer.WriteLine("xref");
+        writer.WriteLine("0 6");
+        writer.WriteLine("0000000000 65535 f ");
+        for (int i = 1; i <= 5; i++)
+            writer.WriteLine($"{offsets[i]:D10} 00000 n ");
+        writer.WriteLine("trailer");
+        writer.WriteLine("<< /Size 6 /Root 1 0 R >>");
+        writer.WriteLine("startxref");
+        writer.WriteLine(xrefPos);
+        writer.WriteLine("%%EOF");
+        writer.Flush();
+
+        return ms.ToArray();
+    }
+}

--- a/Excise.Core/Text/TextExtractor.cs
+++ b/Excise.Core/Text/TextExtractor.cs
@@ -87,6 +87,68 @@ public class TextExtractor
 
     private readonly List<Letter> _letters = new();
 
+    // Marked-content nesting depth of /OC spans that are hidden. Maintained in
+    // lock-step with _optionalContentHiddenStack (BDC/BMC push, EMC pop) so the
+    // per-glyph "am I inside any hidden span?" check in ShowGlyph is O(1)
+    // instead of a per-letter LINQ Any() over the stack (#600).
+    private int _hiddenOptionalContentDepth;
+
+    // Scratch byte buffer reused by ParseStringLiteral/ParseHexString across
+    // calls (#600): each call resets the length, appends its decoded bytes and
+    // copies them into an exact-size result array before returning, so nothing
+    // aliases the scratch. String/hex token parses never nest inside one
+    // another, and a TextExtractor instance is single-threaded by construction
+    // (all parse state already lives in instance fields), so instance-level
+    // reuse is safe.
+    private byte[] _stringScratch = new byte[128];
+    private int _stringScratchLen;
+
+    private void ScratchAdd(byte b)
+    {
+        if (_stringScratchLen == _stringScratch.Length)
+            Array.Resize(ref _stringScratch, _stringScratch.Length * 2);
+        _stringScratch[_stringScratchLen++] = b;
+    }
+
+    // Boxed-int cache for ParseNumber (#600): content streams carry huge
+    // volumes of small integer operands (TJ kern values, Td/Tm coordinates);
+    // boxing each one separately was a measurable share of extraction
+    // allocation. Boxes are immutable and only ever read back via pattern
+    // matching / ToDouble, so sharing instances is observably identical.
+    private const int SmallIntBoxMin = -1024;
+    private const int SmallIntBoxMax = 1024;
+    private static readonly object[] SmallIntBoxes = CreateSmallIntBoxes();
+
+    private static object[] CreateSmallIntBoxes()
+    {
+        var boxes = new object[SmallIntBoxMax - SmallIntBoxMin + 1];
+        for (int i = 0; i < boxes.Length; i++)
+            boxes[i] = SmallIntBoxMin + i;
+        return boxes;
+    }
+
+    private static object BoxInt(int value) =>
+        value >= SmallIntBoxMin && value <= SmallIntBoxMax
+            ? SmallIntBoxes[value - SmallIntBoxMin]
+            : value;
+
+    // Single-character string cache for the Latin-1 range (#600): the decode
+    // fallbacks (DecodeWinAnsi/DecodeMacRoman/identity) allocated a fresh
+    // one-char string per glyph. Cached instances are value-equal to what
+    // ToString() produced; Letter.Value is only ever compared by value.
+    private static readonly string[] Latin1CharStrings = CreateLatin1CharStrings();
+
+    private static string[] CreateLatin1CharStrings()
+    {
+        var strings = new string[256];
+        for (int i = 0; i < strings.Length; i++)
+            strings[i] = ((char)i).ToString();
+        return strings;
+    }
+
+    private static string CharToString(char c) =>
+        c <= '\u00FF' ? Latin1CharStrings[c] : c.ToString();
+
     public TextExtractor(PdfPage page)
     {
         _page = page;
@@ -412,7 +474,7 @@ public class TextExtractor
     public string ExtractText()
     {
         var letters = ExtractLetters();
-        var sb = new StringBuilder();
+        var sb = new StringBuilder(letters.Count + 16); // most letters are 1 char (#600)
         foreach (var letter in letters)
         {
             sb.Append(letter.Value);
@@ -610,7 +672,7 @@ public class TextExtractor
 
     private byte[] ParseStringLiteral(string content, ref int pos)
     {
-        var bytes = new List<byte>();
+        _stringScratchLen = 0; // reuse the scratch buffer across calls (#600)
         pos++; // Skip opening '('
         int parenDepth = 1;
 
@@ -624,14 +686,14 @@ public class TextExtractor
                 var escaped = content[pos];
                 switch (escaped)
                 {
-                    case 'n': bytes.Add((byte)'\n'); break;
-                    case 'r': bytes.Add((byte)'\r'); break;
-                    case 't': bytes.Add((byte)'\t'); break;
-                    case 'b': bytes.Add((byte)'\b'); break;
-                    case 'f': bytes.Add((byte)'\f'); break;
-                    case '(': bytes.Add((byte)'('); break;
-                    case ')': bytes.Add((byte)')'); break;
-                    case '\\': bytes.Add((byte)'\\'); break;
+                    case 'n': ScratchAdd((byte)'\n'); break;
+                    case 'r': ScratchAdd((byte)'\r'); break;
+                    case 't': ScratchAdd((byte)'\t'); break;
+                    case 'b': ScratchAdd((byte)'\b'); break;
+                    case 'f': ScratchAdd((byte)'\f'); break;
+                    case '(': ScratchAdd((byte)'('); break;
+                    case ')': ScratchAdd((byte)')'); break;
+                    case '\\': ScratchAdd((byte)'\\'); break;
                     // REVERSE SOLIDUS followed by an end-of-line marker is a
                     // line-continuation: it produces NO character (PDF32000-1
                     // §7.3.4.2 Table 3). CRLF is one marker, not two — consume
@@ -645,22 +707,25 @@ public class TextExtractor
                     case '\n':
                         break;
                     default:
-                        // Octal escape
+                        // Octal escape: up to 3 octal digits, value truncated
+                        // to a byte exactly like the previous
+                        // (byte)Convert.ToInt32(..., 8) implementation.
                         if (escaped >= '0' && escaped <= '7')
                         {
-                            var octal = new StringBuilder();
-                            octal.Append(escaped);
-                            while (octal.Length < 3 && pos + 1 < content.Length &&
+                            int value = escaped - '0';
+                            int digits = 1;
+                            while (digits < 3 && pos + 1 < content.Length &&
                                    content[pos + 1] >= '0' && content[pos + 1] <= '7')
                             {
                                 pos++;
-                                octal.Append(content[pos]);
+                                value = value * 8 + (content[pos] - '0');
+                                digits++;
                             }
-                            bytes.Add((byte)Convert.ToInt32(octal.ToString(), 8));
+                            ScratchAdd(unchecked((byte)value));
                         }
                         else
                         {
-                            bytes.Add((byte)escaped);
+                            ScratchAdd((byte)escaped);
                         }
                         break;
                 }
@@ -668,53 +733,74 @@ public class TextExtractor
             else if (c == '(')
             {
                 parenDepth++;
-                bytes.Add((byte)c);
+                ScratchAdd((byte)c);
             }
             else if (c == ')')
             {
                 parenDepth--;
                 if (parenDepth > 0)
-                    bytes.Add((byte)c);
+                    ScratchAdd((byte)c);
             }
             else
             {
-                bytes.Add((byte)c);
+                ScratchAdd((byte)c);
             }
             pos++;
         }
 
-        return bytes.ToArray();
+        return _stringScratch.AsSpan(0, _stringScratchLen).ToArray();
     }
 
     private byte[] ParseHexString(string content, ref int pos)
     {
         pos++; // Skip '<'
-        var hex = new StringBuilder();
+        _stringScratchLen = 0; // reuse the scratch buffer across calls (#600)
+        int pendingNibble = -1;
 
         while (pos < content.Length && content[pos] != '>')
         {
             var c = content[pos];
             if (char.IsLetterOrDigit(c))
-                hex.Append(c);
+            {
+                // Same accept-set as before (letter-or-digit collected, all
+                // else skipped); a collected non-hex character still throws
+                // FormatException, as Convert.ToByte(..., 16) previously did.
+                var nibble = HexDigitValue(c);
+                if (nibble < 0)
+                    throw new FormatException($"Invalid hex digit '{c}' in hex string.");
+                if (pendingNibble < 0)
+                {
+                    pendingNibble = nibble;
+                }
+                else
+                {
+                    ScratchAdd((byte)((pendingNibble << 4) | nibble));
+                    pendingNibble = -1;
+                }
+            }
             pos++;
         }
         pos++; // Skip '>'
 
-        var hexStr = hex.ToString();
-        if (hexStr.Length % 2 == 1)
-            hexStr += "0"; // Pad with 0 if odd length
+        if (pendingNibble >= 0)
+            ScratchAdd((byte)(pendingNibble << 4)); // Pad with 0 if odd length
 
-        var bytes = new byte[hexStr.Length / 2];
-        for (int i = 0; i < bytes.Length; i++)
-        {
-            bytes[i] = Convert.ToByte(hexStr.Substring(i * 2, 2), 16);
-        }
-        return bytes;
+        return _stringScratch.AsSpan(0, _stringScratchLen).ToArray();
     }
+
+    private static int HexDigitValue(char c) => c switch
+    {
+        >= '0' and <= '9' => c - '0',
+        >= 'a' and <= 'f' => c - 'a' + 10,
+        >= 'A' and <= 'F' => c - 'A' + 10,
+        _ => -1
+    };
 
     private List<object> ParseArray(string content, ref int pos)
     {
-        var result = new List<object>();
+        // Presized for the typical TJ show-array shape (alternating strings
+        // and kern adjustments) instead of growing from the default 4 (#600).
+        var result = new List<object>(16);
         pos++; // Skip '['
 
         while (pos < content.Length)
@@ -737,7 +823,8 @@ public class TextExtractor
     private string ParseName(string content, ref int pos)
     {
         pos++; // Skip '/'
-        var sb = new StringBuilder();
+        int segStart = pos;
+        StringBuilder? sb = null; // only needed when a #XX escape occurs (rare)
 
         while (pos < content.Length)
         {
@@ -747,34 +834,39 @@ public class TextExtractor
                 break;
 
             // Handle #XX hex escape
-            if (c == '#' && pos + 2 < content.Length)
+            if (c == '#' && pos + 2 < content.Length &&
+                int.TryParse(content.AsSpan(pos + 1, 2),
+                    System.Globalization.NumberStyles.HexNumber, null, out var code))
             {
-                var hex = content.Substring(pos + 1, 2);
-                if (int.TryParse(hex, System.Globalization.NumberStyles.HexNumber, null, out var code))
-                {
-                    sb.Append((char)code);
-                    pos += 3;
-                    continue;
-                }
+                sb ??= new StringBuilder();
+                sb.Append(content, segStart, pos - segStart);
+                sb.Append((char)code);
+                pos += 3;
+                segStart = pos;
+                continue;
             }
 
-            sb.Append(c);
             pos++;
         }
 
+        if (sb == null)
+            return string.Concat("/", content.AsSpan(segStart, pos - segStart));
+
+        sb.Append(content, segStart, pos - segStart);
         return "/" + sb.ToString();
     }
 
     private object ParseNumber(string content, ref int pos)
     {
-        var sb = new StringBuilder();
+        int start = pos;
+        bool hasDot = false;
 
         while (pos < content.Length)
         {
             var c = content[pos];
             if (char.IsDigit(c) || c == '-' || c == '+' || c == '.')
             {
-                sb.Append(c);
+                if (c == '.') hasDot = true;
                 pos++;
             }
             else
@@ -783,34 +875,34 @@ public class TextExtractor
             }
         }
 
-        var str = sb.ToString();
-        if (str.Contains('.'))
+        var span = content.AsSpan(start, pos - start);
+        if (hasDot)
         {
-            return double.TryParse(str, System.Globalization.NumberStyles.Float,
+            return double.TryParse(span, System.Globalization.NumberStyles.Float,
                 System.Globalization.CultureInfo.InvariantCulture, out var d) ? d : 0.0;
         }
-        return int.TryParse(str, out var i) ? i : 0;
+        return BoxInt(int.TryParse(span, out var i) ? i : 0);
     }
 
     private string ParseKeyword(string content, ref int pos)
     {
-        var sb = new StringBuilder();
+        int start = pos;
 
         while (pos < content.Length)
         {
             var c = content[pos];
             if (char.IsLetterOrDigit(c) || c == '\'' || c == '"' || c == '*')
-            {
-                sb.Append(c);
                 pos++;
-            }
             else
-            {
                 break;
-            }
         }
 
-        return sb.ToString();
+        // Return the cached instance for known tokens (operators and common
+        // keywords) — value-identical to the substring, but allocation-free
+        // for the overwhelmingly common case (#600).
+        return KnownKeywordLookup.TryGetValue(content.AsSpan(start, pos - start), out var known)
+            ? known
+            : content.Substring(start, pos - start);
     }
 
     private void SkipDictionary(string content, ref int pos)
@@ -860,6 +952,16 @@ public class TextExtractor
     {
         return Operators.Contains(token);
     }
+
+    // Span-keyed lookup returning the cached string instance for known content
+    // stream tokens, so ParseKeyword does not allocate a fresh string per
+    // operator (#600). Covers every operator plus the non-operator keywords
+    // that commonly appear as operands.
+    private static readonly HashSet<string> KnownKeywords =
+        new(Operators.Concat(new[] { "true", "false", "null" }));
+
+    private static readonly HashSet<string>.AlternateLookup<ReadOnlySpan<char>> KnownKeywordLookup =
+        KnownKeywords.GetAlternateLookup<ReadOnlySpan<char>>();
 
     private void ExecuteOperator(string op, List<object> operands)
     {
@@ -1056,7 +1158,12 @@ public class TextExtractor
                 break;
 
             case "BDC":
-                _optionalContentHiddenStack.Push(IsHiddenOptionalContentSpan(operands));
+                {
+                    var hidden = IsHiddenOptionalContentSpan(operands);
+                    _optionalContentHiddenStack.Push(hidden);
+                    if (hidden)
+                        _hiddenOptionalContentDepth++;
+                }
                 break;
 
             case "BMC":
@@ -1064,8 +1171,8 @@ public class TextExtractor
                 break;
 
             case "EMC":
-                if (_optionalContentHiddenStack.Count > 0)
-                    _optionalContentHiddenStack.Pop();
+                if (_optionalContentHiddenStack.Count > 0 && _optionalContentHiddenStack.Pop())
+                    _hiddenOptionalContentDepth--;
                 break;
         }
     }
@@ -1394,7 +1501,10 @@ public class TextExtractor
             byteLength // 1 for simple fonts and 1-byte-codespace Type0 (#659), 2 for Identity-H/V; per-code under a mixed-width registered CMap (#515)
         )
         {
-            IsInHiddenOptionalContent = _optionalContentHiddenStack.Any(hidden => hidden),
+            // O(1) counter kept in lock-step with _optionalContentHiddenStack;
+            // equivalent to _optionalContentHiddenStack.Any(hidden => hidden)
+            // without the per-letter enumeration (#600).
+            IsInHiddenOptionalContent = _hiddenOptionalContentDepth > 0,
             IsCidFont = _isCidFont
         };
         _letters.Add(letter);
@@ -1650,7 +1760,7 @@ public class TextExtractor
         // coincidence and mis-maps codes 128–159 (#715 / #515).
         if (_toUnicodeIdentity && charCode is >= 0 and <= 0xFFFF && !char.IsSurrogate((char)charCode))
         {
-            return ((char)charCode).ToString();
+            return CharToString((char)charCode);
         }
 
         // Registered CID→Unicode (#515 slice 2): the Adobe-<Ordering>-UCS2 CMap
@@ -2159,7 +2269,7 @@ public class TextExtractor
         // WinAnsiEncoding (Windows Code Page 1252)
         // Most chars map directly, special handling for 128-159
         if (charCode < 128 || charCode >= 160)
-            return ((char)charCode).ToString();
+            return CharToString((char)charCode);
 
         // Special mappings for 128-159
         return charCode switch
@@ -2191,7 +2301,7 @@ public class TextExtractor
             156 => "\u0153", // Latin small ligature oe
             158 => "\u017E", // Latin small letter z with caron
             159 => "\u0178", // Latin capital letter Y with diaeresis
-            _ => ((char)charCode).ToString()
+            _ => CharToString((char)charCode)
         };
     }
 
@@ -2199,7 +2309,7 @@ public class TextExtractor
     {
         // MacRomanEncoding - simplified, handle special chars 128-255
         if (charCode < 128)
-            return ((char)charCode).ToString();
+            return CharToString((char)charCode);
 
         // Mac Roman special characters (subset)
         return charCode switch
@@ -2236,7 +2346,7 @@ public class TextExtractor
             157 => "\u00F9", // ù
             158 => "\u00FB", // û
             159 => "\u00FC", // ü
-            _ => ((char)charCode).ToString()
+            _ => CharToString((char)charCode)
         };
     }
 


### PR DESCRIPTION
#596 perf slice on the text-extraction hot path (#597 baseline: extraction parse + un-presized accumulators = 62% of extract trace, 247ms/637MB).

## Change (allocation-only, byte-identical extraction)
Presize/reuse/span across the token parsers in `Excise.Core/Text/TextExtractor.cs` — no decode semantics changed:
- `ParseStringLiteral`/`ParseHexString`: per-instance reused scratch byte buffer (was `new List&lt;byte&gt;()` + `StringBuilder` per literal/escape); octal/hex computed arithmetically with identical truncation + same `FormatException` set.
- `ParseName`/`ParseNumber`/`ParseKeyword`: parse from `AsSpan` slices; keywords resolved to cached string instances via `HashSet.GetAlternateLookup&lt;ReadOnlySpan&lt;char&gt;&gt;`; small-int boxes + Latin-1 single-char strings cached (immutable, value-compared only).
- `ShowGlyph`: per-letter LINQ `Any()` → an `int` depth counter kept in lock-step with the BDC/BMC/EMC stack.
- All new members **private** (no public-API surface change). `TextExtractor` is single-threaded per instance — state was already unsynchronized instance fields; nothing static-mutable added.

## Byte-identical proof (this is the redaction-critical extraction path)
Full per-letter data (Value, CharacterCode, CodeByteLength, positions, glyph rect, font, hidden-OC flag, word segmentation) dumped for every page of all 13 corpus PDFs (smoke + sample incl. CJK/Type0 + scrambled) with base vs new parser — **1.13M-line dumps byte-identical** (`cmp`).

## Performance
- text-extract allocation: **717 → 471 MB (−34%)** (agent-measured; my run confirmed the time delta)
- text-extract time: **−12%** (my min-2 measurement); search time **−21%**

## Correctness (my verification, on the branch)
| Gate | Result |
|---|---|
| Build | **0 warnings** |
| **Extraction-parity (#645)** | 332 pages, **98.7% — unchanged** (byte-identical) |
| `verify-true-redaction.sh` | intact |
| Redaction | Core 185 ✅ · Rendering 44 ✅ · App 105 ✅ |
| Full `Excise.Core.Tests` | **3590 / 0 failed** (incl. `PublicApiApprovalTests` — no public change) |
| New pin tests | `TextExtractorParsePinTests` (full text + Letter values/codes/positions on escapes, nested parens, hex, name escapes, TJ kerns) — **pass against pre-change parser** |

## Follow-ups
- `Encoding.Latin1.GetString` per content stream (remaining large single alloc) — byte-span parser rewrite, higher risk/bigger win.
- Same StringBuilder-per-token patterns likely in `ContentStreamParser.cs` (redaction-side parse).

Refs #600

🤖 Generated with [Claude Code](https://claude.com/claude-code)