### PR TITLE
perf: focused workflow regression-budget gate — locks in the #596 wins (#602)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,6 +261,18 @@ jobs:
             --include-cli-render \
             --fail-on-regression
 
+      - name: Performance budget check (warn-only; #602)
+        # Focused workflow perf budgets (scripts/check-perf-budgets.sh vs
+        # tests/perf-budgets/workflow-budgets.json). WARN-ONLY here by design:
+        # shared runners are far too wall-time-variable for a blocking perf
+        # gate, and this runner has no smoke corpus (see the note above), so
+        # the script SKIPs cleanly. Hard enforcement is local
+        # (scripts/check-perf-budgets.sh, default --mode fail) and in
+        # release-smoke's perf-budget gate on a known developer machine.
+        # A perf budget breach is a performance signal, never a correctness
+        # failure - it must not block a PR from a noisy runner.
+        run: scripts/check-perf-budgets.sh --mode warn || true
+
       - name: Run Excise.Ocr.Tests
         run: |
           dotnet test Excise.Ocr.Tests --no-build -c Debug \

--- a/CI_GATES.md
+++ b/CI_GATES.md
@@ -141,6 +141,47 @@ If CI performance tests fail unexpectedly:
 2. Check if hardware has changed
 3. Adjust thresholds in the test file if needed (with justification in commit message)
 
+### Workflow Performance Budgets (#602)
+
+`scripts/check-perf-budgets.sh` is the focused regression gate that locks in
+the #596 hot-path wins (#743 save/redaction-save, #598/#599 render, #600
+extraction). It runs `Excise.RenderTools profile-workflows` over the smoke
+corpus (`scripts/download-smoke-corpus.sh`) min-of-N times and compares each
+workflow against the checked-in budgets in
+`tests/perf-budgets/workflow-budgets.json`.
+
+Design decisions (the reasoning matters more than the numbers — read the
+budgets file's `policy`/`machineCaveat` fields for the current values):
+
+- **Allocation is the hard gate; time is advisory.** Managed allocation is
+  nearly run- and machine-invariant, so a modest band over baseline is a
+  reliable regression signal. Wall time varies 5–15% run-to-run and far more
+  across machine classes, so it only warns by default; `--time-gate fail`
+  turns the 2× time band into a failure on a known machine class
+  (release-smoke does this).
+- **It is a PERFORMANCE gate, never a correctness gate.** It has its own
+  distinct gate name (`perf-budget` in release-smoke), its own report
+  (`perf-budget-report.json`, `"kind": "performance-budget"`), and it SKIPs
+  (exit 0) when the corpus or budgets are absent instead of pretending to be
+  a quality failure.
+- **CI is warn-only** (`--mode warn || true` in `ci.yml`): shared runners are
+  too wall-time-variable for a blocking perf gate, and they have no smoke
+  corpus anyway. Hard enforcement is local (`scripts/check-perf-budgets.sh`,
+  default `--mode fail`) and in release-smoke's `perf-budget` gate on a known
+  developer machine. A dedicated stable perf lane can flip CI to blocking
+  later.
+- **A regression report names the workflow and its owning hot path**
+  (writer/object store, redaction pipeline + scrubber, renderer, text
+  extractor), the metric that breached (allocation vs time), and the worst
+  per-PDF contributor.
+- **Partial runs stay useful**: each pass writes incremental NDJSON, and the
+  aggregate report is rewritten after every pass; a partial corpus gates the
+  intersection of budgeted and measured PDFs and reports what was skipped.
+
+Re-baselining after an intentional perf change:
+`scripts/check-perf-budgets.sh --update` on a quiet machine, Release build,
+then commit the rewritten budgets file with the justification.
+
 ## Headless GUI Testing
 
 Excise.App.Tests uses Avalonia UI and requires a display. On headless CI:

--- a/Excise.App.Tests/Documentation/DocumentationClaimTests.cs
+++ b/Excise.App.Tests/Documentation/DocumentationClaimTests.cs
@@ -208,7 +208,7 @@ public class DocumentationClaimTests
         script.Should().Contain("latest-gui-workflow-hotspots.json");
         script.Should().Contain("latest-performance-baseline.json");
         script.Should().Contain("benchmark-hotpaths.json");
-        releaseSmoke.Should().Contain("automation,ux,benchmark,aot,pdf20,corpus-resilience,adversarial-extraction,tests");
+        releaseSmoke.Should().Contain("automation,ux,benchmark,perf-budget,aot,pdf20,corpus-resilience,adversarial-extraction,tests");
         releaseSmoke.Should().Contain("run-benchmarks.sh suite");
         checklist.Should().Contain("benchmark-report.json");
         checklist.Should().Contain("benchmark-hotpaths.json");

--- a/scripts/check-perf-budgets.sh
+++ b/scripts/check-perf-budgets.sh
@@ -1,0 +1,387 @@
+#!/usr/bin/env bash
+# Focused performance regression gate for the #596/#602 hot-path budgets.
+#
+# Runs the stable workflow subset (profile-workflows: save-roundtrip,
+# redaction-save, all-page-render, text-extract + advisory render/open/search
+# steps) on the smoke corpus min-of-N times and compares against the
+# checked-in budgets in tests/perf-budgets/workflow-budgets.json.
+#
+# Design (see issue #602):
+#   - ALLOCATION is the hard gate. Managed allocation (GC bytes on the driver
+#     thread) is nearly machine- and run-invariant, so a +30% band catches a
+#     real regression (e.g. redaction-save back to 3+ GB after #743's -72%)
+#     without flaking on machine variance.
+#   - TIME is advisory by default (warn at 1.5x, fail at 2.0x only with
+#     --time-gate fail). Wall time varies 5-15% run-to-run and far more across
+#     machine classes; min-of-N absorbs run noise but not a slower machine.
+#     release-smoke (a known developer machine) opts into --time-gate fail;
+#     shared CI stays warn-only.
+#   - Budgets are compared over the INTERSECTION of budgeted and measured
+#     PDFs, so a partial corpus gates what ran and reports what was skipped.
+#   - A missing corpus or missing budgets file SKIPS (exit 0) with a clear
+#     message - this is a performance signal, not a correctness gate, and it
+#     must never masquerade as one (CI runners have no smoke corpus).
+#   - Violations name the WORKFLOW and its owning hot path (writer/object
+#     store, redaction pipeline, renderer, text extractor), plus the worst
+#     per-PDF contributor - not just a PDF filename.
+#
+# Reproducing / re-baselining the budgets:
+#   scripts/download-smoke-corpus.sh              # corpus (gitignored)
+#   scripts/check-perf-budgets.sh --update        # rewrites budgets from HEAD
+# Budgets must be captured in Release on a quiet machine; the machine class,
+# commit, and capture command are stamped into the budgets file. Absolute ms
+# baselines are only comparable within a machine class - allocation baselines
+# travel across machines, which is why allocation is the hard gate.
+#
+# Exit codes: 0 pass/skip/warn-mode, 1 budget violation (fail mode), 2 usage.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$ROOT"
+
+CONFIG="${CONFIG:-Release}"
+RUNS=3
+CORPUS="${EXCISE_PERF_CORPUS:-test-pdfs/smoke}"
+BUDGETS="tests/perf-budgets/workflow-budgets.json"
+OUTPUT_DIR="${EXCISE_PERF_OUTPUT_DIR:-logs/perf-budgets/latest}"
+MODE="fail"
+TIME_GATE="${EXCISE_PERF_TIME_GATE:-warn}"
+UPDATE=0
+NO_BUILD=0
+
+usage() {
+    cat <<'EOF'
+Focused performance regression gate (#602).
+
+Usage: scripts/check-perf-budgets.sh [options]
+
+Options:
+  --runs N            Profiling passes; min per (pdf,step) is compared (default 3).
+  --corpus DIR        PDF corpus (default test-pdfs/smoke; get it via
+                      scripts/download-smoke-corpus.sh). Missing dir => SKIP, exit 0.
+  --budgets FILE      Budgets file (default tests/perf-budgets/workflow-budgets.json).
+  --output-dir DIR    Report/run output (default logs/perf-budgets/latest).
+  --mode fail|warn    fail: exit 1 on hard-budget violation (local default).
+                      warn: always exit 0, print violations (CI default - shared
+                      runners are too variable for a blocking wall-time gate,
+                      and have no smoke corpus anyway).
+  --time-gate warn|fail
+                      Whether a 2.0x time breach fails (only meaningful with
+                      --mode fail). Default warn: time is machine-variable;
+                      allocation is the hard signal. release-smoke passes
+                      --time-gate fail (known machine class).
+  --update            Rewrite the budgets file from this measurement (baselines
+                      re-anchor; tolerance bands and hot-path metadata kept).
+  --no-build          Skip building Excise.RenderTools.
+  -h, --help          This help.
+
+Environment: CONFIG (Release required for gating; non-Release forces warn mode),
+             EXCISE_PERF_CORPUS, EXCISE_PERF_OUTPUT_DIR, EXCISE_PERF_TIME_GATE.
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --runs) RUNS="$2"; shift 2 ;;
+        --corpus) CORPUS="$2"; shift 2 ;;
+        --budgets) BUDGETS="$2"; shift 2 ;;
+        --output-dir) OUTPUT_DIR="$2"; shift 2 ;;
+        --mode) MODE="$2"; shift 2 ;;
+        --time-gate) TIME_GATE="$2"; shift 2 ;;
+        --update) UPDATE=1; shift ;;
+        --no-build) NO_BUILD=1; shift ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "Unknown option: $1" >&2; usage >&2; exit 2 ;;
+    esac
+done
+
+case "$MODE" in fail|warn) ;; *) echo "--mode must be fail|warn" >&2; exit 2 ;; esac
+case "$TIME_GATE" in fail|warn) ;; *) echo "--time-gate must be fail|warn" >&2; exit 2 ;; esac
+
+if [ ! -d "$CORPUS" ]; then
+    echo "perf-budgets: SKIPPED - corpus not found at $CORPUS"
+    echo "perf-budgets: fetch it with scripts/download-smoke-corpus.sh (gitignored)."
+    exit 0
+fi
+
+if [ "$UPDATE" != "1" ] && [ ! -f "$BUDGETS" ]; then
+    echo "perf-budgets: SKIPPED - budgets file not found at $BUDGETS (run with --update to create it)."
+    exit 0
+fi
+
+if [ "$CONFIG" != "Release" ]; then
+    echo "perf-budgets: CONFIG=$CONFIG is not Release; budgets are Release-anchored - forcing --mode warn."
+    MODE="warn"
+fi
+
+TOOL="tools/Excise.RenderTools/bin/$CONFIG/net10.0/Excise.RenderTools.dll"
+if [ "$NO_BUILD" != "1" ]; then
+    echo "perf-budgets: building Excise.RenderTools ($CONFIG)"
+    dotnet build tools/Excise.RenderTools/Excise.RenderTools.csproj -c "$CONFIG" --nologo -v quiet
+fi
+if [ ! -f "$TOOL" ]; then
+    echo "perf-budgets: ERROR - $TOOL not found (build failed or wrong CONFIG)" >&2
+    exit 2
+fi
+
+mkdir -p "$OUTPUT_DIR"
+REPORT="$OUTPUT_DIR/perf-budget-report.json"
+
+# Min-of-N: each pass writes its own incremental NDJSON + JSON under run-i/;
+# the comparison below re-runs after EVERY pass so a partial/interrupted run
+# still leaves a usable perf-budget-report.json behind.
+for i in $(seq 1 "$RUNS"); do
+    echo "perf-budgets: profiling pass $i/$RUNS"
+    dotnet "$TOOL" profile-workflows \
+        --corpus "$CORPUS" \
+        --output-dir "$OUTPUT_DIR/run-$i" \
+        --page-limit 8 --dpi 96 --zoom-dpi 192 --search-term the \
+        > "$OUTPUT_DIR/run-$i.log" 2>&1
+
+    python3 - "$OUTPUT_DIR" "$BUDGETS" "$REPORT" "$MODE" "$TIME_GATE" "$UPDATE" "$i" "$RUNS" "$CORPUS" <<'PY'
+import glob, json, os, platform, subprocess, sys
+
+out_dir, budgets_path, report_path, mode, time_gate, update, run_no, runs, corpus = sys.argv[1:10]
+update = update == "1"
+final = run_no == runs
+
+# Metadata for budgeted workflows: gate class + owning hot path. The hard set
+# is the #596 optimization surface (#743 save/redaction-save, #598/#599 render,
+# #600 extract); the rest are advisory (reported, warned, never failing).
+WORKFLOWS = {
+    "save-roundtrip": ("hard",
+        "Excise.Core writer/object store: PdfDocument.SaveToBytes -> WriteObjects -> "
+        "GetObject/GetObjectFromStream object-stream materialization (#743; #597 report s3.1)"),
+    "redaction-save": ("hard",
+        "Excise.Core redaction pipeline + writer: RedactArea + StructureTreeRedactionScrubber "
+        "tree walk + SaveToBytes (#743; #597 report s3.4). SECURITY-CRITICAL: never win this "
+        "budget by short-cutting the glyph-removal pipeline - see CLAUDE.md redaction rules."),
+    "all-page-render": ("hard",
+        "Excise.Rendering SkiaRenderer: form-XObject execution (#598), DeviceCMYK blend + "
+        "soft-mask compositing (#599), glyph-path text (#600); #597 report s3.2"),
+    "text-extract": ("hard",
+        "Excise.Core TextExtractor: content parse + letter accumulators + font/XObject "
+        "resource materialization (#600; #597 report s3.3)"),
+    "first-page-render": ("advisory", "Excise.Rendering SkiaRenderer first-page latency (#598/#599)"),
+    "navigation-rerender": ("advisory", "Excise.Rendering re-render on navigation (#598/#601)"),
+    "zoom-rerender": ("advisory", "Excise.Rendering re-render at zoom DPI (#598/#599/#601)"),
+    "open": ("advisory", "Excise.Core parser: open to first structural access (#597)"),
+    "search": ("advisory", "Excise.Core word segmentation + term scan over cached letters (#600)"),
+}
+POLICY = {
+    "allocation": {"warnRatio": 1.15, "failRatio": 1.30, "minDeltaMB": 10,
+                   "note": "managed GC bytes, driver thread; machine-stable => HARD gate; "
+                           "deltas under minDeltaMB never warn/fail (micro-noise floor)"},
+    "time": {"warnRatio": 1.50, "failRatio": 2.00, "minDeltaMs": 100,
+             "note": "wall ms, min-of-N; machine-variable => advisory unless --time-gate fail; "
+                     "deltas under minDeltaMs never warn/fail (fixed-overhead noise floor)"},
+}
+
+# ---- aggregate: min per (pdf, step) across completed runs ------------------
+best = {}   # (pdf, step) -> {"ms":, "bytes":, "errors":}
+for prof in sorted(glob.glob(os.path.join(out_dir, "run-*", "workflow-profile.json"))):
+    with open(prof) as f:
+        data = json.load(f)
+    for rec in data.get("perPdf", []):
+        key = (rec["pdf"], rec["step"])
+        cur = best.setdefault(key, {"ms": float("inf"), "bytes": float("inf"), "errors": 0})
+        if rec.get("status") == "ERROR":
+            cur["errors"] += 1
+            continue
+        cur["ms"] = min(cur["ms"], rec["elapsedMs"])
+        cur["bytes"] = min(cur["bytes"], rec["allocatedBytes"])
+
+measured = {}  # step -> {pdf: {"ms":, "mb":}}
+errors = {}
+for (pdf, step), v in best.items():
+    if v["ms"] == float("inf"):
+        errors.setdefault(step, []).append(pdf)
+        continue
+    measured.setdefault(step, {})[pdf] = {
+        "ms": round(v["ms"], 2), "mb": round(v["bytes"] / (1024.0 * 1024.0), 3)}
+
+# ---- update mode: rewrite budgets from this measurement --------------------
+if update:
+    if not final:
+        sys.exit(0)
+    commit = subprocess.run(["git", "rev-parse", "--short", "HEAD"],
+                            capture_output=True, text=True).stdout.strip()
+    import datetime
+    budgets = {
+        "schemaVersion": 1,
+        "issues": ["#596", "#602"],
+        "capturedUtc": datetime.datetime.now(datetime.timezone.utc)
+            .strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "commit": commit,
+        "machine": f"{platform.machine()} / {platform.platform()} / .NET SDK "
+                   + subprocess.run(["dotnet", "--version"], capture_output=True,
+                                    text=True).stdout.strip(),
+        "reproduce": ("scripts/download-smoke-corpus.sh && scripts/check-perf-budgets.sh --update "
+                      "(Release build, quiet machine; page-limit 8, dpi 96, zoom-dpi 192, "
+                      f"search-term 'the', min of {runs} passes per (pdf,step))"),
+        "machineCaveat": ("Time baselines (ms) are only comparable on this machine class; "
+                          "re-baseline with --update on a different class, or gate time as warn. "
+                          "Allocation baselines (MB) are machine-stable and are the hard gate."),
+        "config": {"pageLimit": 8, "dpi": 96, "zoomDpi": 192, "searchTerm": "the",
+                   "runs": int(runs), "buildConfig": "Release",
+                   "aggregation": "min per (pdf,step) across runs; gate compares sums over "
+                                  "the intersection of budgeted and measured PDFs"},
+        "policy": POLICY,
+        "workflows": {},
+    }
+    for step, (gate, hot) in WORKFLOWS.items():
+        per = measured.get(step)
+        if not per:
+            continue
+        budgets["workflows"][step] = {
+            "gate": gate,
+            "hotPath": hot,
+            "baseline": {
+                "totalMs": round(sum(p["ms"] for p in per.values()), 1),
+                "totalAllocatedMB": round(sum(p["mb"] for p in per.values()), 1),
+            },
+            "perPdf": dict(sorted(per.items())),
+        }
+    os.makedirs(os.path.dirname(budgets_path), exist_ok=True)
+    with open(budgets_path, "w") as f:
+        json.dump(budgets, f, indent=2)
+        f.write("\n")
+    print(f"perf-budgets: budgets rewritten -> {budgets_path} (commit {commit})")
+    sys.exit(0)
+
+# ---- compare mode ----------------------------------------------------------
+with open(budgets_path) as f:
+    budgets = json.load(f)
+policy = budgets.get("policy", POLICY)
+a_warn, a_fail = policy["allocation"]["warnRatio"], policy["allocation"]["failRatio"]
+t_warn, t_fail = policy["time"]["warnRatio"], policy["time"]["failRatio"]
+a_floor = policy["allocation"].get("minDeltaMB", 10)
+t_floor = policy["time"].get("minDeltaMs", 100)
+
+rows, failures, warnings = [], [], []
+for step, spec in budgets.get("workflows", {}).items():
+    gate = spec.get("gate", "advisory")
+    per_budget = spec.get("perPdf", {})
+    per_meas = measured.get(step, {})
+    common = sorted(set(per_budget) & set(per_meas))
+    missing = sorted(set(per_budget) - set(per_meas))
+    row = {"workflow": step, "gate": gate, "pdfsCompared": len(common),
+           "pdfsMissing": missing, "status": "PASS", "checks": []}
+
+    if errors.get(step):
+        row["status"] = "ERROR"
+        row["errorPdfs"] = errors[step]
+        msg = f"{step}: workflow ERRORED on {', '.join(errors[step])} in every pass"
+        (failures if gate == "hard" else warnings).append(
+            {"workflow": step, "metric": "error", "message": msg,
+             "hotPath": spec.get("hotPath", "")})
+    if not common:
+        row["status"] = "SKIPPED" if row["status"] == "PASS" else row["status"]
+        rows.append(row)
+        continue
+
+    base_ms = sum(per_budget[p]["ms"] for p in common)
+    base_mb = sum(per_budget[p]["mb"] for p in common)
+    meas_ms = sum(per_meas[p]["ms"] for p in common)
+    meas_mb = sum(per_meas[p]["mb"] for p in common)
+
+    def worst(metric):
+        return max(common, key=lambda p: per_meas[p][metric] / max(per_budget[p][metric], 1e-9))
+
+    for metric, base, meas, warn_r, fail_r, floor, unit, hard_capable in (
+            ("allocation", base_mb, meas_mb, a_warn, a_fail, a_floor, "MB", True),
+            ("time", base_ms, meas_ms, t_warn, t_fail, t_floor, "ms", time_gate == "fail")):
+        ratio = meas / max(base, 1e-9)
+        check = {"metric": metric, "baseline": round(base, 1), "measured": round(meas, 1),
+                 "ratio": round(ratio, 3), "warnRatio": warn_r, "failRatio": fail_r,
+                 "unit": unit, "verdict": "ok"}
+        if ratio > warn_r and (meas - base) >= floor:
+            w = worst("mb" if metric == "allocation" else "ms")
+            hint = ("allocation regression - machine-stable signal; look for per-call/"
+                    "per-object churn on the hot path" if metric == "allocation" else
+                    "wall-time regression - re-run to rule out machine noise; if it "
+                    "reproduces, profile with dotnet-trace (see #597 baseline README)")
+            msg = (f"{step} [{gate}] {metric}: {meas:.1f}{unit} vs budget "
+                   f"{base:.1f}{unit} x{warn_r if ratio <= fail_r else fail_r} "
+                   f"(ratio {ratio:.2f}); worst contributor: {w}; {hint}")
+            entry = {"workflow": step, "metric": metric, "ratio": round(ratio, 3),
+                     "worstPdf": w, "message": msg, "hotPath": spec.get("hotPath", "")}
+            if ratio > fail_r and gate == "hard" and hard_capable:
+                check["verdict"] = "fail"
+                row["status"] = "FAIL"
+                failures.append(entry)
+            else:
+                check["verdict"] = "warn"
+                if row["status"] == "PASS":
+                    row["status"] = "WARN"
+                warnings.append(entry)
+        row["checks"].append(check)
+    rows.append(row)
+
+report = {
+    "schemaVersion": 1,
+    "issues": ["#596", "#602"],
+    "kind": "performance-budget",
+    "note": "Performance signal only - reported separately from correctness/quality gates.",
+    "mode": mode, "timeGate": time_gate,
+    "runsCompleted": int(run_no), "runsPlanned": int(runs),
+    "partial": not final,
+    "corpus": corpus,
+    "budgetsFile": budgets_path,
+    "budgetsCommit": budgets.get("commit"),
+    "budgetsMachine": budgets.get("machine"),
+    "workflows": rows,
+    "failures": failures,
+    "warnings": warnings,
+}
+with open(report_path, "w") as f:
+    json.dump(report, f, indent=2)
+    f.write("\n")
+
+if not final:
+    print(f"perf-budgets: pass {run_no}/{runs} aggregated (partial report -> {report_path})")
+    sys.exit(0)
+
+print()
+print(f"perf-budgets: report -> {report_path}")
+print(f"perf-budgets: budgets {budgets_path} (captured {budgets.get('capturedUtc')} "
+      f"@ {budgets.get('commit')} on {budgets.get('machine')})")
+print()
+print(f"{'workflow':<22} {'gate':<9} {'alloc MB (budget)':>20} {'time ms (budget)':>20} status")
+for r in rows:
+    a = next((c for c in r["checks"] if c["metric"] == "allocation"), None)
+    t = next((c for c in r["checks"] if c["metric"] == "time"), None)
+    fmt = lambda c: f"{c['measured']:.0f} ({c['baseline']:.0f})" if c else "-"
+    print(f"{r['workflow']:<22} {r['gate']:<9} {fmt(a):>20} {fmt(t):>20} {r['status']}")
+    miss = r.get("pdfsMissing", [])
+    if miss:
+        shown = ", ".join(miss[:3]) + (f", +{len(miss) - 3} more" if len(miss) > 3 else "")
+        print(f"    (gated {r['pdfsCompared']} of {r['pdfsCompared'] + len(miss)} budgeted "
+              f"PDFs; not measured: {shown})")
+print()
+for w in warnings:
+    print(f"WARN: {w['message']}")
+    print(f"      hot path: {w['hotPath']}")
+for fl in failures:
+    print(f"FAIL: {fl['message']}")
+    print(f"      hot path: {fl['hotPath']}")
+if failures:
+    if mode == "fail":
+        print("\nperf-budgets: FAIL - performance budget violated (performance signal, "
+              "not a correctness failure).")
+        sys.exit(1)
+    print("\nperf-budgets: violations found, but --mode warn => exit 0 "
+          "(shared-CI posture; run locally with --mode fail on a stable machine).")
+elif warnings:
+    print("\nperf-budgets: PASS with warnings.")
+else:
+    print("\nperf-budgets: PASS - all workflows within budget.")
+sys.exit(0)
+PY
+    rc=$?
+    if [ "$rc" != "0" ]; then
+        exit "$rc"
+    fi
+done

--- a/scripts/release-smoke.sh
+++ b/scripts/release-smoke.sh
@@ -51,7 +51,7 @@ Options:
   --packaged-gui-focus-input
                       Also run focus-taking native key/mouse smoke.
   --no-build          Skip the initial build gate.
-  --only=a,b          Run only named gates: docs,build,redaction,signature,ui,accessibility,automation,ux,benchmark,aot,pdf20,corpus-resilience,adversarial-extraction,tests,visual,package,packaged-gui,diffcheck.
+  --only=a,b          Run only named gates: docs,build,redaction,signature,ui,accessibility,automation,ux,benchmark,perf-budget,aot,pdf20,corpus-resilience,adversarial-extraction,tests,visual,package,packaged-gui,diffcheck.
   -h, --help          Show this help.
 EOF
 }
@@ -398,6 +398,13 @@ run_gate "accessibility" scripts/run-accessibility-smoke.sh --config "$CONFIG" -
 run_gate "automation" scripts/run-automation-smoke.sh --config "$CONFIG" --output "$LOG_DIR/automation"
 run_gate "ux" scripts/run-ux-icon-audit.sh --config "$CONFIG" --output "$LOG_DIR/ux-icon-audit"
 run_gate "benchmark" env CONFIG="$CONFIG" scripts/run-benchmarks.sh suite --output-dir "$LOG_DIR/benchmarks" --page-limit 2 --dpi 96 --timeout-ms 20000 --oracles all --fail-on-regression
+# #602: focused workflow performance budgets (allocation-anchored hard gate,
+# time gated too on this known machine class). A distinct PERFORMANCE gate,
+# reported separately from the correctness/quality gates above; silently SKIPs
+# (exit 0) when test-pdfs/smoke is absent, like the other corpus gates here.
+# Always measures a Release build regardless of $CONFIG (budgets are
+# Release-anchored). Output: logs/perf-budgets/latest/perf-budget-report.json.
+run_gate "perf-budget" env CONFIG=Release EXCISE_PERF_OUTPUT_DIR="$LOG_DIR/perf-budgets" scripts/check-perf-budgets.sh --time-gate fail
 run_aot_gate
 run_gate "pdf20" scripts/run-pdf20-renderer-conformance.sh --run-tests
 

--- a/tests/perf-budgets/workflow-budgets.json
+++ b/tests/perf-budgets/workflow-budgets.json
@@ -1,0 +1,487 @@
+{
+  "schemaVersion": 1,
+  "issues": [
+    "#596",
+    "#602"
+  ],
+  "capturedUtc": "2026-07-25T09:30:45Z",
+  "commit": "f694d9a",
+  "machine": "arm64 / macOS-26.5.2-arm64-arm-64bit-Mach-O / .NET SDK 10.0.300",
+  "reproduce": "scripts/download-smoke-corpus.sh && scripts/check-perf-budgets.sh --update (Release build, quiet machine; page-limit 8, dpi 96, zoom-dpi 192, search-term 'the', min of 3 passes per (pdf,step))",
+  "machineCaveat": "Time baselines (ms) are only comparable on this machine class; re-baseline with --update on a different class, or gate time as warn. Allocation baselines (MB) are machine-stable and are the hard gate.",
+  "config": {
+    "pageLimit": 8,
+    "dpi": 96,
+    "zoomDpi": 192,
+    "searchTerm": "the",
+    "runs": 3,
+    "buildConfig": "Release",
+    "aggregation": "min per (pdf,step) across runs; gate compares sums over the intersection of budgeted and measured PDFs"
+  },
+  "policy": {
+    "allocation": {
+      "warnRatio": 1.15,
+      "failRatio": 1.3,
+      "minDeltaMB": 10,
+      "note": "managed GC bytes, driver thread; machine-stable => HARD gate; deltas under minDeltaMB never warn/fail (micro-noise floor)"
+    },
+    "time": {
+      "warnRatio": 1.5,
+      "failRatio": 2.0,
+      "minDeltaMs": 100,
+      "note": "wall ms, min-of-N; machine-variable => advisory unless --time-gate fail; deltas under minDeltaMs never warn/fail (fixed-overhead noise floor)"
+    }
+  },
+  "workflows": {
+    "save-roundtrip": {
+      "gate": "hard",
+      "hotPath": "Excise.Core writer/object store: PdfDocument.SaveToBytes -> WriteObjects -> GetObject/GetObjectFromStream object-stream materialization (#743; #597 report s3.1)",
+      "baseline": {
+        "totalMs": 801.0,
+        "totalAllocatedMB": 804.0
+      },
+      "perPdf": {
+        "cdc-vis-covid-19.pdf": {
+          "ms": 10.68,
+          "mb": 3.047
+        },
+        "irs-1040-instructions.pdf": {
+          "ms": 612.49,
+          "mb": 561.962
+        },
+        "irs-1040.pdf": {
+          "ms": 20.99,
+          "mb": 22.079
+        },
+        "irs-pub509-2026.pdf": {
+          "ms": 25.89,
+          "mb": 31.527
+        },
+        "irs-w4.pdf": {
+          "ms": 17.61,
+          "mb": 26.149
+        },
+        "irs-w9.pdf": {
+          "ms": 6.07,
+          "mb": 9.583
+        },
+        "scotus-trump-v-anderson.pdf": {
+          "ms": 7.86,
+          "mb": 7.817
+        },
+        "scotus-trump-v-us.pdf": {
+          "ms": 33.6,
+          "mb": 40.485
+        },
+        "state-ds11-passport.pdf": {
+          "ms": 35.25,
+          "mb": 57.366
+        },
+        "state-ds82-passport-renewal.pdf": {
+          "ms": 30.55,
+          "mb": 43.948
+        }
+      }
+    },
+    "redaction-save": {
+      "gate": "hard",
+      "hotPath": "Excise.Core redaction pipeline + writer: RedactArea + StructureTreeRedactionScrubber tree walk + SaveToBytes (#743; #597 report s3.4). SECURITY-CRITICAL: never win this budget by short-cutting the glyph-removal pipeline - see CLAUDE.md redaction rules.",
+      "baseline": {
+        "totalMs": 1126.6,
+        "totalAllocatedMB": 1212.8
+      },
+      "perPdf": {
+        "cdc-vis-covid-19.pdf": {
+          "ms": 31.63,
+          "mb": 15.924
+        },
+        "irs-1040-instructions.pdf": {
+          "ms": 439.26,
+          "mb": 575.894
+        },
+        "irs-1040.pdf": {
+          "ms": 102.43,
+          "mb": 50.762
+        },
+        "irs-pub509-2026.pdf": {
+          "ms": 80.8,
+          "mb": 63.874
+        },
+        "irs-w4.pdf": {
+          "ms": 51.68,
+          "mb": 34.744
+        },
+        "irs-w9.pdf": {
+          "ms": 32.66,
+          "mb": 16.543
+        },
+        "scotus-trump-v-anderson.pdf": {
+          "ms": 17.89,
+          "mb": 10.873
+        },
+        "scotus-trump-v-us.pdf": {
+          "ms": 49.22,
+          "mb": 46.885
+        },
+        "state-ds11-passport.pdf": {
+          "ms": 245.77,
+          "mb": 281.726
+        },
+        "state-ds82-passport-renewal.pdf": {
+          "ms": 75.27,
+          "mb": 115.619
+        }
+      }
+    },
+    "all-page-render": {
+      "gate": "hard",
+      "hotPath": "Excise.Rendering SkiaRenderer: form-XObject execution (#598), DeviceCMYK blend + soft-mask compositing (#599), glyph-path text (#600); #597 report s3.2",
+      "baseline": {
+        "totalMs": 1265.9,
+        "totalAllocatedMB": 954.2
+      },
+      "perPdf": {
+        "cdc-vis-covid-19.pdf": {
+          "ms": 37.77,
+          "mb": 15.261
+        },
+        "irs-1040-instructions.pdf": {
+          "ms": 99.4,
+          "mb": 31.87
+        },
+        "irs-1040.pdf": {
+          "ms": 26.84,
+          "mb": 12.286
+        },
+        "irs-pub509-2026.pdf": {
+          "ms": 148.31,
+          "mb": 74.838
+        },
+        "irs-w4.pdf": {
+          "ms": 63.45,
+          "mb": 30.674
+        },
+        "irs-w9.pdf": {
+          "ms": 51.68,
+          "mb": 6.056
+        },
+        "scotus-trump-v-anderson.pdf": {
+          "ms": 44.2,
+          "mb": 14.102
+        },
+        "scotus-trump-v-us.pdf": {
+          "ms": 63.41,
+          "mb": 20.621
+        },
+        "state-ds11-passport.pdf": {
+          "ms": 452.58,
+          "mb": 431.288
+        },
+        "state-ds82-passport-renewal.pdf": {
+          "ms": 278.28,
+          "mb": 317.175
+        }
+      }
+    },
+    "text-extract": {
+      "gate": "hard",
+      "hotPath": "Excise.Core TextExtractor: content parse + letter accumulators + font/XObject resource materialization (#600; #597 report s3.3)",
+      "baseline": {
+        "totalMs": 198.2,
+        "totalAllocatedMB": 389.4
+      },
+      "perPdf": {
+        "cdc-vis-covid-19.pdf": {
+          "ms": 10.09,
+          "mb": 4.152
+        },
+        "irs-1040-instructions.pdf": {
+          "ms": 18.1,
+          "mb": 17.5
+        },
+        "irs-1040.pdf": {
+          "ms": 5.58,
+          "mb": 2.492
+        },
+        "irs-pub509-2026.pdf": {
+          "ms": 32.01,
+          "mb": 40.895
+        },
+        "irs-w4.pdf": {
+          "ms": 6.76,
+          "mb": 4.435
+        },
+        "irs-w9.pdf": {
+          "ms": 6.58,
+          "mb": 5.392
+        },
+        "scotus-trump-v-anderson.pdf": {
+          "ms": 7.17,
+          "mb": 10.565
+        },
+        "scotus-trump-v-us.pdf": {
+          "ms": 8.76,
+          "mb": 12.26
+        },
+        "state-ds11-passport.pdf": {
+          "ms": 65.13,
+          "mb": 179.188
+        },
+        "state-ds82-passport-renewal.pdf": {
+          "ms": 37.99,
+          "mb": 112.489
+        }
+      }
+    },
+    "first-page-render": {
+      "gate": "advisory",
+      "hotPath": "Excise.Rendering SkiaRenderer first-page latency (#598/#599)",
+      "baseline": {
+        "totalMs": 321.0,
+        "totalAllocatedMB": 179.2
+      },
+      "perPdf": {
+        "cdc-vis-covid-19.pdf": {
+          "ms": 63.7,
+          "mb": 6.973
+        },
+        "irs-1040-instructions.pdf": {
+          "ms": 36.0,
+          "mb": 8.466
+        },
+        "irs-1040.pdf": {
+          "ms": 19.01,
+          "mb": 10.965
+        },
+        "irs-pub509-2026.pdf": {
+          "ms": 20.7,
+          "mb": 14.146
+        },
+        "irs-w4.pdf": {
+          "ms": 12.08,
+          "mb": 4.149
+        },
+        "irs-w9.pdf": {
+          "ms": 11.06,
+          "mb": 3.056
+        },
+        "scotus-trump-v-anderson.pdf": {
+          "ms": 6.6,
+          "mb": 1.542
+        },
+        "scotus-trump-v-us.pdf": {
+          "ms": 7.26,
+          "mb": 2.81
+        },
+        "state-ds11-passport.pdf": {
+          "ms": 107.53,
+          "mb": 87.983
+        },
+        "state-ds82-passport-renewal.pdf": {
+          "ms": 37.09,
+          "mb": 39.111
+        }
+      }
+    },
+    "navigation-rerender": {
+      "gate": "advisory",
+      "hotPath": "Excise.Rendering re-render on navigation (#598/#601)",
+      "baseline": {
+        "totalMs": 385.9,
+        "totalAllocatedMB": 293.5
+      },
+      "perPdf": {
+        "cdc-vis-covid-19.pdf": {
+          "ms": 32.65,
+          "mb": 14.933
+        },
+        "irs-1040-instructions.pdf": {
+          "ms": 23.47,
+          "mb": 6.816
+        },
+        "irs-1040.pdf": {
+          "ms": 22.73,
+          "mb": 11.31
+        },
+        "irs-pub509-2026.pdf": {
+          "ms": 36.64,
+          "mb": 22.206
+        },
+        "irs-w4.pdf": {
+          "ms": 20.85,
+          "mb": 3.241
+        },
+        "irs-w9.pdf": {
+          "ms": 18.75,
+          "mb": 2.429
+        },
+        "scotus-trump-v-anderson.pdf": {
+          "ms": 9.79,
+          "mb": 1.933
+        },
+        "scotus-trump-v-us.pdf": {
+          "ms": 14.7,
+          "mb": 5.756
+        },
+        "state-ds11-passport.pdf": {
+          "ms": 124.41,
+          "mb": 126.644
+        },
+        "state-ds82-passport-renewal.pdf": {
+          "ms": 81.96,
+          "mb": 98.198
+        }
+      }
+    },
+    "zoom-rerender": {
+      "gate": "advisory",
+      "hotPath": "Excise.Rendering re-render at zoom DPI (#598/#599/#601)",
+      "baseline": {
+        "totalMs": 231.0,
+        "totalAllocatedMB": 164.8
+      },
+      "perPdf": {
+        "cdc-vis-covid-19.pdf": {
+          "ms": 18.03,
+          "mb": 5.818
+        },
+        "irs-1040-instructions.pdf": {
+          "ms": 18.4,
+          "mb": 1.928
+        },
+        "irs-1040.pdf": {
+          "ms": 17.38,
+          "mb": 6.709
+        },
+        "irs-pub509-2026.pdf": {
+          "ms": 18.83,
+          "mb": 10.52
+        },
+        "irs-w4.pdf": {
+          "ms": 11.58,
+          "mb": 1.974
+        },
+        "irs-w9.pdf": {
+          "ms": 12.02,
+          "mb": 1.472
+        },
+        "scotus-trump-v-anderson.pdf": {
+          "ms": 6.14,
+          "mb": 1.14
+        },
+        "scotus-trump-v-us.pdf": {
+          "ms": 9.08,
+          "mb": 2.375
+        },
+        "state-ds11-passport.pdf": {
+          "ms": 76.9,
+          "mb": 91.425
+        },
+        "state-ds82-passport-renewal.pdf": {
+          "ms": 42.61,
+          "mb": 41.478
+        }
+      }
+    },
+    "open": {
+      "gate": "advisory",
+      "hotPath": "Excise.Core parser: open to first structural access (#597)",
+      "baseline": {
+        "totalMs": 36.3,
+        "totalAllocatedMB": 36.1
+      },
+      "perPdf": {
+        "cdc-vis-covid-19.pdf": {
+          "ms": 6.65,
+          "mb": 0.553
+        },
+        "irs-1040-instructions.pdf": {
+          "ms": 22.18,
+          "mb": 26.378
+        },
+        "irs-1040.pdf": {
+          "ms": 0.82,
+          "mb": 0.987
+        },
+        "irs-pub509-2026.pdf": {
+          "ms": 0.97,
+          "mb": 1.416
+        },
+        "irs-w4.pdf": {
+          "ms": 0.61,
+          "mb": 1.128
+        },
+        "irs-w9.pdf": {
+          "ms": 0.53,
+          "mb": 0.683
+        },
+        "scotus-trump-v-anderson.pdf": {
+          "ms": 0.65,
+          "mb": 0.718
+        },
+        "scotus-trump-v-us.pdf": {
+          "ms": 2.57,
+          "mb": 2.971
+        },
+        "state-ds11-passport.pdf": {
+          "ms": 0.63,
+          "mb": 0.666
+        },
+        "state-ds82-passport-renewal.pdf": {
+          "ms": 0.7,
+          "mb": 0.627
+        }
+      }
+    },
+    "search": {
+      "gate": "advisory",
+      "hotPath": "Excise.Core word segmentation + term scan over cached letters (#600)",
+      "baseline": {
+        "totalMs": 32.1,
+        "totalAllocatedMB": 22.1
+      },
+      "perPdf": {
+        "cdc-vis-covid-19.pdf": {
+          "ms": 2.72,
+          "mb": 1.039
+        },
+        "irs-1040-instructions.pdf": {
+          "ms": 6.21,
+          "mb": 1.648
+        },
+        "irs-1040.pdf": {
+          "ms": 1.09,
+          "mb": 1.049
+        },
+        "irs-pub509-2026.pdf": {
+          "ms": 3.51,
+          "mb": 2.392
+        },
+        "irs-w4.pdf": {
+          "ms": 4.58,
+          "mb": 3.02
+        },
+        "irs-w9.pdf": {
+          "ms": 4.29,
+          "mb": 4.685
+        },
+        "scotus-trump-v-anderson.pdf": {
+          "ms": 2.29,
+          "mb": 2.444
+        },
+        "scotus-trump-v-us.pdf": {
+          "ms": 3.32,
+          "mb": 3.157
+        },
+        "state-ds11-passport.pdf": {
+          "ms": 0.81,
+          "mb": 1.341
+        },
+        "state-ds82-passport-renewal.pdf": {
+          "ms": 3.32,
+          "mb": 1.357
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
#596 capstone: convert the perf wins (#743 −45% redaction-save, #599 −37% CMYK render, #598 form-XObject, #600 −34% extract alloc) into a **checked-in regression gate** so they can't silently erode — without making dev brittle. **Infra/gate only — no product hot-path code changed.**

## The gate — `scripts/check-perf-budgets.sh`
Runs `profile-workflows` over `test-pdfs/smoke` **min-of-N (default 3)** vs checked-in budgets in `tests/perf-budgets/workflow-budgets.json`:
- **Allocation-anchored hard gate** (fail ×1.30, warn ×1.15) — managed-GC allocation proved run-invariant (ratios 0.999–1.001), so it's the robust signal. **Wall-time is advisory** (warn ×1.5; fail ×2.0 only with `--time-gate fail`). Absolute noise floors (10 MB / 100 ms) prevent micro-corpus flake.
- **Hard-gated:** save-roundtrip, redaction-save, all-page-render, text-extract (the optimized workflows). Five more advisory.
- **Attribution:** each violation names the workflow, its owning hot path (redaction-save carries a *never short-cut the glyph pipeline to win this budget* warning), the breaching metric with alloc-vs-time hint, and the worst per-PDF contributor.
- Incremental JSON (partial runs useful); missing corpus/budgets → clean SKIP exit 0.

## CI wiring — blocks vs warns
- **release-smoke: BLOCKS** (own `perf-budget` gate, `--time-gate fail`) — t2 runs on the baseline machine class.
- **GitHub CI: WARN-ONLY** — shared runners are too wall-time-variable to block on (a flaky perf gate trains people to ignore red), and CI has no smoke corpus so it SKIPs today. Documented in `CI_GATES.md` with the flip-to-blocking path (dedicated stable lane).
- Explicitly a **performance signal, never a correctness failure** (`kind: performance-budget`).

## Validation (mine — I ran the gate)
- **PASS on develop** `f694d9a`: allocation ratios ~1.00 on all 9 workflows, huge headroom under the bands.
- **Catches a regression:** with per-PDF budgets tightened 4×, gate **exit 1**, `redaction-save … FAIL … vs budget … x1.3 (ratio 4.00); worst contributor: irs-1040.pdf`, names the hot path. Warn-mode exits 0 on the same input.
- Budgets lock in the wins vs pre-optimization (`01e8348`): redaction-save **1213 MB** (was 4378), text-extract **389 MB** (was 637), save **804 MB** (was 3953). A revert trips the ×1.30 band by 3–4×.

## Machine caveat (stamped in budgets)
Apple-silicon macOS, .NET 10.0.300, Release. Allocation baselines travel across machines; ms baselines are machine-class-local (re-baseline with `--update` or gate time as warn elsewhere).

## Follow-ups
GUI latency budgets (#601) need the serial UI suite (#619); a dedicated stable perf lane would let CI flip warn→block.

Refs #602 (note: #602 was previously closed for partial infra; this adds the actual budgets+gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)