### PR TITLE
fix: replace flaky wall-clock cache-hit assertion with render-count spy (#733)

### DIFF
--- a/Excise.App.Tests/Integration/ThumbnailCacheTests.cs
+++ b/Excise.App.Tests/Integration/ThumbnailCacheTests.cs
@@ -49,6 +49,8 @@ public class ThumbnailCacheTests
 
                 bmp.Should().NotBeNull("first call must produce a thumbnail");
                 bmp!.Width.Should().BeGreaterThan(50);
+                svc1.RenderCount.Should().Be(1,
+                    "the first call over an empty cache must render the page");
 
                 var cacheFile = await WaitForCacheFileAsync(svc1.CacheDir, "p00002.webp");
                 cacheFile.Should().NotBeNull(
@@ -57,6 +59,10 @@ public class ThumbnailCacheTests
 
             // Second service instance over the same file — the same hash
             // dir is already populated, so this must NOT need to render.
+            // Asserted via the renderer-invocation counter, not wall-clock:
+            // an absolute timing threshold raced render time on loaded CI
+            // runners and flaked (#733). The counter asserts the intent
+            // ("no re-render") deterministically.
             using (var svc2 = new ThumbnailCacheService(pdfPath, doc, NullLogger.Instance))
             {
                 var sw = Stopwatch.StartNew();
@@ -66,13 +72,9 @@ public class ThumbnailCacheTests
 
                 bmp.Should().NotBeNull();
                 bmp!.Width.Should().BeGreaterThan(50);
-
-                // Cache hit should be at least an order of magnitude faster
-                // than rendering. Ballpark: render ~50-200ms, decode ~1-10ms.
-                // Keep the threshold generous so test isn't flaky.
-                sw.ElapsedMilliseconds.Should().BeLessThan(100,
-                    "cache hit should be a sub-100ms WebP decode rather than " +
-                    "a full re-render of the page");
+                svc2.RenderCount.Should().Be(0,
+                    "the second instance must serve the thumbnail from the " +
+                    "disk cache without invoking the renderer (#733)");
             }
         }
         finally

--- a/Excise.App/Services/ThumbnailCacheService.cs
+++ b/Excise.App/Services/ThumbnailCacheService.cs
@@ -46,6 +46,17 @@ public sealed class ThumbnailCacheService : IDisposable
     private readonly int _thumbnailDpi;
     private bool _disposed;
 
+    // Test seam (#733): counts renderer invocations so tests can assert
+    // "cache hit did not re-render" directly instead of via a flaky
+    // wall-clock threshold. Interlocked because renders run on the pool.
+    private int _renderCount;
+
+    /// <summary>
+    /// Number of times this instance invoked the renderer (as opposed to
+    /// serving a disk-cache hit). Test observability only — see issue #733.
+    /// </summary>
+    internal int RenderCount => Volatile.Read(ref _renderCount);
+
     private static readonly string RendererCacheIdentity =
         typeof(SkiaRenderer).Module.ModuleVersionId.ToString("N");
 
@@ -236,6 +247,7 @@ public sealed class ThumbnailCacheService : IDisposable
                 ct.ThrowIfCancellationRequested();
                 if (pageIndex < 0 || pageIndex >= _doc.PageCount) return null;
                 var page = _doc.GetPage(pageIndex + 1);
+                Interlocked.Increment(ref _renderCount);
                 var bmp = _renderer.RenderPage(page,
                     new RenderOptions { Dpi = _thumbnailDpi });
                 if (bmp == null) return null;


### PR DESCRIPTION
Fixes the intermittent CI failure of `ThumbnailCacheTests.FirstCallRenders_SecondCallLoadsFromDisk` (seen on Windows/macOS, e.g. PR #732's initial run).

## Problem
The test asserted a cache hit completes in `< 100ms` **absolute wall-clock** — a threshold overlapping its own stated render range (~50–200ms), so on a loaded runner a legitimate WebP-decode + disk-read cache hit exceeded it and failed. It was a brittle timing *proxy* for 'the second call didn't re-render.'

## Fix — assert the intent directly (render-count spy)
- `ThumbnailCacheService.cs`: minimal internal seam — `_renderCount` incremented (`Interlocked`) at the single `_renderer.RenderPage` call site, exposed as `internal int RenderCount` (via existing InternalsVisibleTo). Behavior-preserving.
- `ThumbnailCacheTests.cs`: asserts `svc1.RenderCount == 1` (first call renders) and `svc2.RenderCount == 0` (second instance serves from disk without re-rendering). Stopwatch timings kept as diagnostic output only.

**Deterministic:** whether the renderer ran is a discrete recorded fact — machine load can't change the counter. A cache-path regression now fails 100% of the time instead of only when the machine is fast enough to notice.

## Verification
Build 0 warnings; `--filter Thumbnail` **20/20** pass. App-only, disjoint from other in-flight work.

Fixes #733

🤖 Generated with [Claude Code](https://claude.com/claude-code)