### PR TITLE
feat(a11y): announce tagged-PDF /Alt figure descriptions to screen readers — #631 slice

### DIFF
--- a/Excise.Avalonia.Tests/AssemblyInfo.cs
+++ b/Excise.Avalonia.Tests/AssemblyInfo.cs
@@ -1,0 +1,9 @@
+using Xunit;
+
+// The automation-peer tests (#631) run through a shared
+// HeadlessUnitTestSession dispatcher. Running other collections in parallel
+// with session dispatch can deadlock the in-process runner (observed: full
+// `dotnet run` hangs at "Starting"; `-parallel none` passes). The suite is
+// sub-second, so serial execution costs nothing. Same precedent as
+// Excise.App.Tests (#363).
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/Excise.Avalonia.Tests/Excise.Avalonia.Tests.csproj
+++ b/Excise.Avalonia.Tests/Excise.Avalonia.Tests.csproj
@@ -23,6 +23,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- Headless Avalonia platform for automation-peer tests (#631). Only the
+         base package: tests dispatch through HeadlessUnitTestSession from
+         plain [Fact]s, deliberately avoiding Avalonia.Headless.XUnit's
+         [AvaloniaFact] and its xunit.v3 TestContext bug (#337). -->
+    <PackageReference Include="Avalonia.Headless" Version="12.0.5" />
     <PackageReference Include="AwesomeAssertions" Version="9.4.0" />
     <PackageReference Include="PublicApiGenerator" Version="11.5.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />

--- a/Excise.Avalonia.Tests/HeadlessTestApp.cs
+++ b/Excise.Avalonia.Tests/HeadlessTestApp.cs
@@ -1,0 +1,18 @@
+using Avalonia;
+using Avalonia.Headless;
+
+[assembly: AvaloniaTestApplication(typeof(Excise.Avalonia.Tests.HeadlessTestApp))]
+
+namespace Excise.Avalonia.Tests;
+
+/// <summary>
+/// Entry point for the headless Avalonia session used by the automation-peer
+/// tests (#631). Pure headless drawing — no Skia render platform — because
+/// peer-tree tests only exercise the accessibility surface, never pixels.
+/// </summary>
+public sealed class HeadlessTestApp : Application
+{
+    public static AppBuilder BuildAvaloniaApp() =>
+        AppBuilder.Configure<HeadlessTestApp>()
+            .UseHeadless(new AvaloniaHeadlessPlatformOptions());
+}

--- a/Excise.Avalonia.Tests/PdfViewerAccessibilityTests.cs
+++ b/Excise.Avalonia.Tests/PdfViewerAccessibilityTests.cs
@@ -1,0 +1,401 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia.Automation;
+using Avalonia.Automation.Peers;
+using Avalonia.Headless;
+using AwesomeAssertions;
+using Excise.Avalonia.Automation;
+using Excise.Avalonia.Controls;
+using Excise.Core.Authoring;
+using Excise.Core.Document;
+using Excise.Core.Primitives;
+using Xunit;
+
+namespace Excise.Avalonia.Tests;
+
+/// <summary>
+/// Headless tests for the document-content accessibility surface (#631):
+/// the <see cref="PdfViewerAutomationPeer"/> tree that makes the rendered
+/// page — otherwise an opaque bitmap — readable by screen readers. Covers
+/// the synthetic page-text child (extractable text in reading order, updated
+/// on navigation/swap/rewrite) and the tagged-PDF <c>/Alt</c> description
+/// children for figures.
+///
+/// Runs through <see cref="HeadlessUnitTestSession"/> from plain [Fact]s
+/// (not [AvaloniaFact]) to keep clear of the Avalonia.Headless.XUnit
+/// TestContext bug (#337).
+/// </summary>
+public class PdfViewerAccessibilityTests
+{
+    // ── harness ──────────────────────────────────────────────────────────
+
+    private static Task<T> OnUiThread<T>(Func<T> body) =>
+        HeadlessUnitTestSession.GetOrStartForAssembly(typeof(HeadlessTestApp).Assembly)
+            .Dispatch(body, CancellationToken.None);
+
+    private static Task<T> OnUiThread<T>(Func<Task<T>> body) =>
+        HeadlessUnitTestSession.GetOrStartForAssembly(typeof(HeadlessTestApp).Assembly)
+            .Dispatch(body, CancellationToken.None);
+
+    /// <summary>
+    /// Wait (bounded) for the viewer's asynchronous page-change pipeline to
+    /// notify the automation tree, until the peer serves
+    /// <paramref name="expectedCount"/> /Alt description children.
+    /// </summary>
+    private static async Task<List<AutomationPeer>> AltChildrenEventually(
+        AutomationPeer peer, int expectedCount)
+    {
+        for (int i = 0; i < 200; i++)
+        {
+            var alts = AltTextChildren(peer);
+            if (alts.Count == expectedCount)
+                return alts;
+            await Task.Delay(10);
+            global::Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+        }
+        return AltTextChildren(peer);
+    }
+
+    private static (PdfViewerControl Viewer, PdfViewerAutomationPeer Peer) CreateViewerWithPeer(
+        PdfDocument? document)
+    {
+        var viewer = new PdfViewerControl();
+        if (document != null)
+            viewer.Document = document;
+        var peer = (PdfViewerAutomationPeer)ControlAutomationPeer.CreatePeerForElement(viewer);
+        return (viewer, peer);
+    }
+
+    private static AutomationPeer PageTextChild(AutomationPeer peer) =>
+        peer.GetChildren().First(c => c.GetClassName() == "PdfPageText");
+
+    private static List<AutomationPeer> AltTextChildren(AutomationPeer peer) =>
+        peer.GetChildren().Where(c => c.GetClassName() == "PdfFigureAltText").ToList();
+
+    private static string Normalized(string? s) =>
+        string.Join(" ", (s ?? string.Empty).Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries));
+
+    // ── fixtures ─────────────────────────────────────────────────────────
+
+    /// <summary>Untagged two-page document with distinct per-page text.</summary>
+    private static PdfDocument TwoPageTextDoc() =>
+        PdfDocument.Open(PdfDocumentBuilder.Create()
+            .Paragraph("Alpha page one")
+            .PageBreak()
+            .Paragraph("Beta page two")
+            .SaveToBytes());
+
+    /// <summary>
+    /// Two-page document with a structure tree containing one /Figure whose
+    /// /Alt describes an image on <paramref name="altPage"/>. The /Pg entry
+    /// is the page dictionary itself (the parser resolves both direct
+    /// dictionaries and references).
+    /// </summary>
+    private static PdfDocument DocWithFigureAlt(int altPage)
+    {
+        var doc = TwoPageTextDoc();
+
+        var figure = new PdfDictionary();
+        figure["S"] = new PdfName("Figure");
+        figure["Alt"] = new PdfString("Bar chart of quarterly revenue");
+        figure["Pg"] = doc.GetPage(altPage).Dictionary;
+
+        var root = new PdfDictionary();
+        root["Type"] = new PdfName("StructTreeRoot");
+        root["K"] = figure;
+        doc.Catalog["StructTreeRoot"] = root;
+        return doc;
+    }
+
+    /// <summary>
+    /// A complete single-page tagged PDF written byte-for-byte, where the
+    /// /Figure's /Pg is a true indirect reference (3 0 R) — the shape every
+    /// real-world tagged PDF has, exercising page resolution through the
+    /// document's object cache rather than direct-dictionary identity.
+    /// </summary>
+    private static byte[] RawTaggedPdfWithFigureAlt()
+    {
+        const string content = "BT /F1 12 Tf 72 720 Td (Gamma loaded fixture) Tj ET";
+        var objects = new[]
+        {
+            "<< /Type /Catalog /Pages 2 0 R /StructTreeRoot 6 0 R /MarkInfo << /Marked true >> >>",
+            "<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] " +
+                "/Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>",
+            "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+            $"<< /Length {content.Length} >>\nstream\n{content}\nendstream",
+            "<< /Type /StructTreeRoot /K 7 0 R >>",
+            "<< /Type /StructElem /S /Figure /Alt (Official signature stamp) /Pg 3 0 R >>",
+        };
+
+        var sb = new StringBuilder("%PDF-1.7\n");
+        var offsets = new long[objects.Length + 1];
+        for (int i = 0; i < objects.Length; i++)
+        {
+            offsets[i + 1] = sb.Length; // ASCII-only, so char count == byte offset
+            sb.Append($"{i + 1} 0 obj\n{objects[i]}\nendobj\n");
+        }
+        long xref = sb.Length;
+        sb.Append($"xref\n0 {objects.Length + 1}\n0000000000 65535 f \n");
+        for (int i = 1; i <= objects.Length; i++)
+            sb.Append($"{offsets[i]:0000000000} 00000 n \n");
+        sb.Append($"trailer\n<< /Size {objects.Length + 1} /Root 1 0 R >>\nstartxref\n{xref}\n%%EOF");
+        return Encoding.ASCII.GetBytes(sb.ToString());
+    }
+
+    /// <summary>
+    /// A builder-authored tagged two-page PDF (struct elements carry no /Pg
+    /// of their own — their pages live on /MCR reference kids), round-tripped
+    /// through save/load, with an /Alt injected onto page 1's paragraph
+    /// element. Exercises the MCR-kid page-resolution path.
+    /// </summary>
+    private static PdfDocument TaggedDocWithAltViaMcr()
+    {
+        var doc = PdfDocument.Open(PdfDocumentBuilder.Create()
+            .Tagged()
+            .Paragraph("Tagged alpha")
+            .PageBreak()
+            .Paragraph("Tagged beta")
+            .SaveToBytes());
+
+        // Find the first /P struct element (page 1's paragraph) and give it
+        // an /Alt. Walk raw dictionaries — the injected fixture must not
+        // depend on the code under test.
+        var pElem = FindFirstStructElement(doc, "P")
+            ?? throw new InvalidOperationException("tagged fixture has no /P element");
+        pElem["Alt"] = new PdfString("Injected paragraph description");
+        return doc;
+    }
+
+    private static PdfDictionary? FindFirstStructElement(PdfDocument doc, string structType)
+    {
+        var rootObj = doc.Catalog.GetOptional("StructTreeRoot");
+        if (rootObj == null) return null;
+        var root = doc.Resolve(rootObj) as PdfDictionary;
+
+        PdfDictionary? Walk(PdfObject? k)
+        {
+            if (k == null) return null;
+            var resolved = doc.Resolve(k);
+            if (resolved is PdfArray arr)
+                return arr.Select(Walk).FirstOrDefault(d => d != null);
+            if (resolved is PdfDictionary d)
+            {
+                if (d.GetNameOrNull("S") == structType) return d;
+                return Walk(d.GetOptional("K"));
+            }
+            return null;
+        }
+
+        return Walk(root?.GetOptional("K"));
+    }
+
+    // ── page-text peer ───────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ViewerPeer_IsDocumentRole_WithPageTextFirstChild()
+    {
+        await OnUiThread(() =>
+        {
+            var (_, peer) = CreateViewerWithPeer(document: null);
+
+            peer.GetAutomationControlType().Should().Be(AutomationControlType.Document);
+
+            var children = peer.GetChildren();
+            children.Should().NotBeEmpty("the page-text node must exist even with no document");
+            var textChild = children[0];
+            textChild.GetClassName().Should().Be("PdfPageText",
+                "the document text must be the first thing a screen reader reaches");
+            textChild.GetAutomationControlType().Should().Be(AutomationControlType.Text);
+            textChild.IsContentElement().Should().BeTrue();
+            textChild.IsControlElement().Should().BeTrue();
+            (textChild.GetName() ?? string.Empty).Should().BeEmpty("no document is loaded");
+            textChild.GetParent().Should().BeSameAs(peer, "an orphaned peer is invisible to AT");
+            return true;
+        });
+    }
+
+    [Fact]
+    public async Task PageTextPeer_ExposesCurrentPageText()
+    {
+        await OnUiThread(() =>
+        {
+            var (_, peer) = CreateViewerWithPeer(TwoPageTextDoc());
+
+            Normalized(PageTextChild(peer).GetName())
+                .Should().Contain("Alpha page one", "page 1 text must be screen-reader visible")
+                .And.NotContain("Beta", "page 2 content must not bleed into page 1");
+            return true;
+        });
+    }
+
+    [Fact]
+    public async Task PageTextPeer_NameFollowsPageNavigation()
+    {
+        await OnUiThread(() =>
+        {
+            var (viewer, peer) = CreateViewerWithPeer(TwoPageTextDoc());
+            var textChild = PageTextChild(peer);
+
+            viewer.CurrentPage = 2;
+
+            Normalized(textChild.GetName())
+                .Should().Contain("Beta page two", "navigation must re-target the accessible text")
+                .And.NotContain("Alpha");
+            return true;
+        });
+    }
+
+    [Fact]
+    public async Task PageTextPeer_NameFollowsDocumentSwap()
+    {
+        await OnUiThread(() =>
+        {
+            var (viewer, peer) = CreateViewerWithPeer(TwoPageTextDoc());
+            var textChild = PageTextChild(peer);
+
+            viewer.Document = PdfDocument.Open(RawTaggedPdfWithFigureAlt());
+
+            Normalized(textChild.GetName())
+                .Should().Contain("Gamma loaded fixture", "a document swap must swap the accessible text")
+                .And.NotContain("Alpha");
+            return true;
+        });
+    }
+
+    [Fact]
+    public async Task RenderVersionBump_RaisesNameChangeOnTextPeer()
+    {
+        await OnUiThread(() =>
+        {
+            var (viewer, peer) = CreateViewerWithPeer(TwoPageTextDoc());
+            var textChild = PageTextChild(peer);
+
+            bool nameChanged = false;
+            textChild.PropertyChanged += (_, e) =>
+            {
+                if (e.Property == AutomationElementIdentifiers.NameProperty)
+                    nameChanged = true;
+            };
+
+            // A RenderVersion bump is the content-rewrite signal (e.g. a
+            // redaction was applied); OnRenderVersionChanged notifies the
+            // automation tree synchronously.
+            viewer.RenderVersion++;
+
+            nameChanged.Should().BeTrue(
+                "screen readers must be told to re-read after the page content is rewritten");
+            return true;
+        });
+    }
+
+    // ── /Alt description peers ───────────────────────────────────────────
+
+    [Fact]
+    public async Task UntaggedDocument_HasNoAltDescriptionChildren()
+    {
+        await OnUiThread(() =>
+        {
+            var (_, peer) = CreateViewerWithPeer(TwoPageTextDoc());
+            AltTextChildren(peer).Should().BeEmpty();
+            return true;
+        });
+    }
+
+    [Fact]
+    public async Task FigureAltOnCurrentPage_IsExposedAsImageChild()
+    {
+        await OnUiThread(() =>
+        {
+            var (_, peer) = CreateViewerWithPeer(DocWithFigureAlt(altPage: 1));
+
+            var alts = AltTextChildren(peer);
+            alts.Should().HaveCount(1);
+            alts[0].GetName().Should().Be("Bar chart of quarterly revenue");
+            alts[0].GetAutomationControlType().Should().Be(AutomationControlType.Image);
+            alts[0].IsContentElement().Should().BeTrue();
+            alts[0].GetParent().Should().BeSameAs(peer);
+            return true;
+        });
+    }
+
+    [Fact]
+    public async Task FigureAltOnOtherPage_IsNotExposed_UntilNavigatedThere()
+    {
+        await OnUiThread(async () =>
+        {
+            var (viewer, peer) = CreateViewerWithPeer(DocWithFigureAlt(altPage: 2));
+
+            AltTextChildren(peer).Should().BeEmpty("the figure lives on page 2, not page 1");
+
+            // End-to-end through the production wiring: the page-change
+            // pipeline must notify the automation tree and invalidate the
+            // cached children on its own.
+            viewer.CurrentPage = 2;
+
+            var alts = await AltChildrenEventually(peer, expectedCount: 1);
+            alts.Should().HaveCount(1, "navigating to the figure's page must expose its description");
+            alts[0].GetName().Should().Be("Bar chart of quarterly revenue");
+            return true;
+        });
+    }
+
+    [Fact]
+    public async Task PageNavigation_RaisesChildrenChanged_WhenAltSetChanges()
+    {
+        await OnUiThread(() =>
+        {
+            var (viewer, peer) = CreateViewerWithPeer(DocWithFigureAlt(altPage: 2));
+            _ = peer.GetChildren(); // materialize the synthetic children
+
+            bool childrenChanged = false;
+            peer.ChildrenChanged += (_, _) => childrenChanged = true;
+
+            viewer.CurrentPage = 2;
+            peer.NotifyPageTextChanged();
+
+            childrenChanged.Should().BeTrue(
+                "AT must be told the accessible children changed when descriptions appear");
+            AltTextChildren(peer).Should().HaveCount(1);
+            return true;
+        });
+    }
+
+    [Fact]
+    public async Task FigureAlt_FromLoadedPdf_ResolvesPageThroughIndirectReference()
+    {
+        await OnUiThread(() =>
+        {
+            var (_, peer) = CreateViewerWithPeer(PdfDocument.Open(RawTaggedPdfWithFigureAlt()));
+
+            Normalized(PageTextChild(peer).GetName()).Should().Contain("Gamma loaded fixture");
+            var alts = AltTextChildren(peer);
+            alts.Should().HaveCount(1, "/Pg given as an indirect reference must resolve to the page");
+            alts[0].GetName().Should().Be("Official signature stamp");
+            return true;
+        });
+    }
+
+    [Fact]
+    public async Task StructElementWithoutOwnPg_ResolvesPageThroughMcrKid()
+    {
+        await OnUiThread(async () =>
+        {
+            var (viewer, peer) = CreateViewerWithPeer(TaggedDocWithAltViaMcr());
+
+            var alts = AltTextChildren(peer);
+            alts.Should().HaveCount(1,
+                "builder-authored elements carry /Pg only on their /MCR kids");
+            alts[0].GetName().Should().Be("Injected paragraph description");
+
+            viewer.CurrentPage = 2;
+            (await AltChildrenEventually(peer, expectedCount: 0))
+                .Should().BeEmpty("the described element belongs to page 1");
+            return true;
+        });
+    }
+}

--- a/Excise.Avalonia/Automation/PdfViewerAutomationPeer.cs
+++ b/Excise.Avalonia/Automation/PdfViewerAutomationPeer.cs
@@ -1,6 +1,7 @@
 using Avalonia.Automation;
 using Avalonia.Automation.Peers;
 using Excise.Avalonia.Controls;
+using System;
 using System.Collections.Generic;
 
 namespace Excise.Avalonia.Automation;
@@ -14,13 +15,17 @@ namespace Excise.Avalonia.Automation;
 /// none of which carry the document's text. This peer inserts a synthetic
 /// <see cref="PdfPageTextAutomationPeer"/> child — first in the children list,
 /// so it is the first thing a screen reader reaches when entering the viewer —
-/// that exposes the current page's extractable text in reading order.
+/// that exposes the current page's extractable text in reading order, followed
+/// by one <see cref="PdfAltTextAutomationPeer"/> child per tagged-PDF
+/// <c>/Alt</c> description on the current page, so figures and images with
+/// alternative text are announced too.
 /// </para>
 /// </summary>
 internal sealed class PdfViewerAutomationPeer : ControlAutomationPeer
 {
     private readonly PdfViewerControl _viewer;
     private PdfPageTextAutomationPeer? _textPeer;
+    private List<PdfAltTextAutomationPeer> _altPeers = new();
 
     public PdfViewerAutomationPeer(PdfViewerControl viewer)
         : base(viewer)
@@ -34,8 +39,10 @@ internal sealed class PdfViewerAutomationPeer : ControlAutomationPeer
     protected override IReadOnlyList<AutomationPeer>? GetChildrenCore()
     {
         _textPeer ??= new PdfPageTextAutomationPeer(_viewer);
+        SyncAltTextPeers();
 
         var result = new List<AutomationPeer> { _textPeer };
+        result.AddRange(_altPeers);
         var baseChildren = base.GetChildrenCore();
         if (baseChildren != null)
             result.AddRange(baseChildren);
@@ -43,12 +50,55 @@ internal sealed class PdfViewerAutomationPeer : ControlAutomationPeer
     }
 
     /// <summary>
+    /// Rebuild the synthetic <c>/Alt</c>-description children if the current
+    /// page's set of descriptions changed. Peer instances are kept stable
+    /// while the descriptions are unchanged so assistive technology retains
+    /// element identity across unrelated refreshes. Returns true when the
+    /// children actually changed.
+    /// </summary>
+    private bool SyncAltTextPeers()
+    {
+        var alts = _viewer.GetAccessibleAltTexts();
+
+        if (alts.Count == _altPeers.Count)
+        {
+            bool same = true;
+            for (int i = 0; i < alts.Count; i++)
+            {
+                if (!string.Equals(alts[i], _altPeers[i].Description, StringComparison.Ordinal))
+                {
+                    same = false;
+                    break;
+                }
+            }
+            if (same)
+                return false;
+        }
+
+        var peers = new List<PdfAltTextAutomationPeer>(alts.Count);
+        for (int i = 0; i < alts.Count; i++)
+            peers.Add(new PdfAltTextAutomationPeer(alts[i], i));
+        _altPeers = peers;
+        return true;
+    }
+
+    /// <summary>
     /// Called by the viewer when the current page's text content changed
     /// (page navigation, document swap, or a content rewrite such as
     /// redaction). Raises a Name property change on the synthetic text
-    /// child so screen readers pick up the new content.
+    /// child so screen readers pick up the new content, and a
+    /// children invalidation when the page's <c>/Alt</c> descriptions
+    /// changed with it. Invalidation matters: <see cref="ControlAutomationPeer"/>
+    /// caches the children list, so without <see cref="ControlAutomationPeer.InvalidateChildren"/>
+    /// (which also raises the children-changed event) a page change would keep
+    /// serving the previous page's description peers forever.
     /// </summary>
-    internal void NotifyPageTextChanged() => _textPeer?.NotifyTextChanged();
+    internal void NotifyPageTextChanged()
+    {
+        _textPeer?.NotifyTextChanged();
+        if (SyncAltTextPeers())
+            InvalidateChildren();
+    }
 }
 
 /// <summary>
@@ -116,4 +166,65 @@ internal sealed class PdfPageTextAutomationPeer : UnrealizedElementAutomationPee
 
     internal void NotifyTextChanged() =>
         RaisePropertyChangedEvent(AutomationElementIdentifiers.NameProperty, null, GetName());
+}
+
+/// <summary>
+/// Synthetic (control-less) peer that carries one tagged-PDF <c>/Alt</c>
+/// alternative description from the current page's structure tree
+/// (issue #631). Figures and images contribute nothing to the extractable
+/// text layer, so without these peers a described image is silent to
+/// screen readers even in a properly tagged document.
+///
+/// <para>
+/// The description is fixed at construction; page changes replace the peer
+/// set (see <see cref="PdfViewerAutomationPeer.NotifyPageTextChanged"/>),
+/// which raises a children-changed event so assistive technology re-reads.
+/// </para>
+/// </summary>
+internal sealed class PdfAltTextAutomationPeer : UnrealizedElementAutomationPeer
+{
+    private readonly int _index;
+    private AutomationPeer? _parent;
+
+    public PdfAltTextAutomationPeer(string description, int index)
+    {
+        Description = description;
+        _index = index;
+    }
+
+    /// <summary>The <c>/Alt</c> alternative description this peer announces.</summary>
+    public string Description { get; }
+
+    protected override string? GetNameCore() => Description;
+
+    protected override AutomationControlType GetAutomationControlTypeCore() =>
+        AutomationControlType.Image;
+
+    protected override string GetClassNameCore() => "PdfFigureAltText";
+
+    protected override string GetAutomationIdCore() => $"PdfFigureAltText{_index}";
+
+    protected override string GetLocalizedControlTypeCore() => "figure description";
+
+    protected override string? GetAcceleratorKeyCore() => null;
+
+    protected override string? GetAccessKeyCore() => null;
+
+    protected override AutomationPeer? GetLabeledByCore() => null;
+
+    protected override AutomationPeer? GetParentCore() => _parent;
+
+    // Same synthetic-node parenting contract as PdfPageTextAutomationPeer:
+    // accepting the parent set by ControlAutomationPeer's child wiring is
+    // what links this node into the tree.
+    protected override bool TrySetParent(AutomationPeer? parent)
+    {
+        _parent = parent;
+        return true;
+    }
+
+    // Unrealized peers default to invisible-to-AT; this node exists solely
+    // for assistive technology.
+    protected override bool IsContentElementCore() => true;
+    protected override bool IsControlElementCore() => true;
 }

--- a/Excise.Avalonia/Controls/PdfViewerControl.Accessibility.cs
+++ b/Excise.Avalonia/Controls/PdfViewerControl.Accessibility.cs
@@ -1,0 +1,169 @@
+using Excise.Core.Document;
+using Excise.Core.Primitives;
+using System;
+using System.Collections.Generic;
+
+namespace Excise.Avalonia.Controls;
+
+/// <summary>
+/// Accessibility support for the document content (issue #631): reading the
+/// tagged-PDF structure tree's <c>/Alt</c> alternative descriptions for the
+/// current page so figures/images — which contribute nothing to the
+/// extractable text layer — are not silent to screen readers.
+///
+/// <para>
+/// This is deliberately read-only over Excise.Core's public surface
+/// (<see cref="PdfDocument.GetStructureTree"/> plus raw-dictionary
+/// resolution). Full struct-tree reading order (re-ordering the text layer
+/// by logical structure) additionally requires mapping marked-content IDs
+/// to extracted letters, which the extraction pipeline does not surface yet
+/// — that remains a follow-up slice of #631.
+/// </para>
+/// </summary>
+public partial class PdfViewerControl
+{
+    // Cache for the current page's /Alt descriptions, keyed by the same
+    // content identity the announced-text dedupe uses: (Document,
+    // CurrentPage, RenderVersion). A RenderVersion bump matters here too —
+    // redaction scrubs /Alt from the structure tree (#636), and the
+    // accessibility tree must not keep announcing redacted descriptions.
+    private PdfDocument? _altTextDocument;
+    private int _altTextPage = -1;
+    private long _altTextRenderVersion = -1;
+    private IReadOnlyList<string>? _altTextCache;
+
+    /// <summary>
+    /// The <c>/Alt</c> alternative descriptions of tagged structure elements
+    /// (typically <c>/Figure</c>) associated with the current page, in
+    /// structure-tree order. Empty when no document is loaded, the document
+    /// is untagged, or the page has no described figures.
+    /// </summary>
+    internal IReadOnlyList<string> GetAccessibleAltTexts()
+    {
+        var doc = Document;
+        if (doc == null || CurrentPage < 1 || CurrentPage > doc.PageCount)
+            return Array.Empty<string>();
+
+        if (ReferenceEquals(_altTextDocument, doc)
+            && _altTextPage == CurrentPage
+            && _altTextRenderVersion == RenderVersion
+            && _altTextCache != null)
+            return _altTextCache;
+
+        IReadOnlyList<string> result;
+        try
+        {
+            result = CollectAltTextsForPage(doc, CurrentPage);
+        }
+        catch (Exception ex) when (ex is not OutOfMemoryException)
+        {
+            // Malformed structure trees must never take down the viewer;
+            // accessibility degrades to the text layer alone.
+            result = Array.Empty<string>();
+        }
+
+        _altTextDocument = doc;
+        _altTextPage = CurrentPage;
+        _altTextRenderVersion = RenderVersion;
+        _altTextCache = result;
+        return result;
+    }
+
+    private static IReadOnlyList<string> CollectAltTextsForPage(PdfDocument doc, int pageNumber)
+    {
+        var root = doc.GetStructureTree();
+        if (root == null)
+            return Array.Empty<string>();
+
+        // Page dictionaries resolve through the document's object cache, so
+        // reference identity maps a resolved /Pg target back to its number.
+        var pagesByDict = new Dictionary<PdfDictionary, int>();
+        for (int i = 1; i <= doc.PageCount; i++)
+            pagesByDict[doc.GetPage(i).Dictionary] = i;
+
+        var results = new List<string>();
+        Walk(doc, root, inheritedPage: null, pagesByDict, pageNumber, results, depth: 0);
+        return results.Count == 0 ? Array.Empty<string>() : results;
+    }
+
+    private const int MaxStructWalkDepth = 64; // mirrors PdfStructTreeParser.MaxDepth
+
+    private static void Walk(
+        PdfDocument doc,
+        PdfStructElement element,
+        int? inheritedPage,
+        Dictionary<PdfDictionary, int> pagesByDict,
+        int targetPage,
+        List<string> results,
+        int depth)
+    {
+        if (depth > MaxStructWalkDepth)
+            return;
+
+        int? page = ResolveElementPage(doc, element, pagesByDict) ?? inheritedPage;
+
+        if (!string.IsNullOrWhiteSpace(element.AltText))
+        {
+            // An element with no determinable page can still be safely
+            // announced when there is only one page it could belong to.
+            int? effectivePage = page ?? (doc.PageCount == 1 ? 1 : (int?)null);
+            if (effectivePage == targetPage)
+                results.Add(element.AltText!.Trim());
+        }
+
+        foreach (var child in element.Children)
+            Walk(doc, child, page, pagesByDict, targetPage, results, depth + 1);
+    }
+
+    /// <summary>
+    /// Determine which page a structure element belongs to: its own
+    /// <c>/Pg</c>, else the <c>/Pg</c> of a marked-content-reference or
+    /// object-reference kid (<c>/MCR</c>/<c>/OBJR</c> dictionaries, which
+    /// <c>PdfStructTreeParser</c> does not surface), else null so the caller
+    /// falls back to the ancestor's page.
+    /// </summary>
+    private static int? ResolveElementPage(
+        PdfDocument doc,
+        PdfStructElement element,
+        Dictionary<PdfDictionary, int> pagesByDict)
+    {
+        int? FromPg(PdfDictionary dict)
+        {
+            var pgObj = dict.GetOptional("Pg");
+            if (pgObj == null)
+                return null;
+            return doc.Resolve(pgObj) is PdfDictionary pageDict
+                && pagesByDict.TryGetValue(pageDict, out int n) ? n : null;
+        }
+
+        var own = FromPg(element.RawDictionary);
+        if (own != null)
+            return own;
+
+        // Reference-kid dictionaries (no /S of their own) carry the /Pg for
+        // content the element marks on a page.
+        var k = element.RawDictionary.GetOptional("K");
+        if (k == null)
+            return null;
+
+        var resolvedK = doc.Resolve(k);
+        if (resolvedK is PdfDictionary kidDict && kidDict.GetOptional("S") == null)
+            return FromPg(kidDict);
+
+        if (resolvedK is PdfArray kids)
+        {
+            foreach (var item in kids)
+            {
+                if (doc.Resolve(item) is PdfDictionary refDict
+                    && refDict.GetOptional("S") == null)
+                {
+                    var page = FromPg(refDict);
+                    if (page != null)
+                        return page;
+                }
+            }
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
#631 slice: expose tagged-PDF **`/Alt` alternative descriptions** to assistive technology, and add the automation peer's **first-ever test coverage**. Excise.Avalonia-only — disjoint from all other work.

## Assessment
The a11y scaffolding (page text exposed via a synthetic peer) existed but had **zero tests**. Two deeper options assessed and found blocked/done:
- **Struct-tree reading order** — blocked: `PdfStructTreeParser.ExtractPageNumber` never reads `/Pg`, MCR kid dicts are dropped, `Letter` carries no MCID → tying structure to letters needs extraction-internal changes (off-limits/in-flight). Named as the next slice.
- Page-change notifications — already wired (now test-covered).

## Change (internal-only — no public API change)
- `PdfViewerControl.Accessibility.cs` (new): collects current-page `/Alt` texts via public read-only APIs (`GetStructureTree`, `RawDictionary`, `Resolve`). Page resolution: element `/Pg` → `/Pg` on MCR/OBJR reference kids (read raw, since the parser drops them) → inherited ancestor → single-page fallback. Cached on (Document, CurrentPage, RenderVersion) so redaction rewrites (which scrub `/Alt`, #636) refresh AT; exception-hardened.
- `PdfViewerAutomationPeer.cs`: one `PdfAltTextAutomationPeer` (Image role, Name = description) per `/Alt`, after the text child. **Real bug the tests caught:** `ControlAutomationPeer` caches its children list, so without `InvalidateChildren()` on alt-set change, AT kept the previous page's descriptions forever — now fixed.

## Tests (first coverage of the peer)
11 headless tests (`Avalonia.Headless` via `HeadlessUnitTestSession`, avoiding `[AvaloniaFact]`'s #337 bug): peer roles/tree/parent wiring, page text per page, updates on nav/document-swap, Name-change on RenderVersion bump, children-changed on alt-set change, `/Alt` via direct `/Pg` + true indirect reference (byte-level tagged PDF) + MCR-kid resolution (round-tripped tagged PDF), untagged/no-doc no-ops. `AssemblyInfo.cs` serializes the suite (headless session deadlocks under parallel collections — same precedent as #363; suite is 0.2s).

## Verification (mine)
Build **0 warnings**; `Excise.Avalonia.Tests` **57/57** (11 new). Verified flake-free (multiple runs by the author).

## Next #631 slices
Struct-tree reading order (needs MCID-on-Letter from Excise.Core), `/ActualText` (needs dedup vs extractor), keyboard structure nav, PDF/UA validation surface.

Refs #631

🤖 Generated with [Claude Code](https://claude.com/claude-code)