### PR TITLE
feat(security): signature trust-chain validation + consolidated result states (#466)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,18 @@ semantic versioning.
   pdftocairo/Ghostscript differentials pinning the out-of-range fallback.
 
 ### Added
+- **Signature trust-chain validation and consolidated result states** (#466) —
+  signature verification now evaluates the signer certificate chain (OS trust
+  store by default; an explicit trust-anchor policy is injectable) in addition
+  to the existing ByteRange/CMS checks, and reports a consolidated state:
+  valid+trusted, valid-but-untrusted, invalid (modified after signing / broken
+  signature), or indeterminate (could not verify). Trust is additional to
+  cryptographic validity, never a replacement: the "trusted" state is
+  unreachable unless the signature is also cryptographically valid over the
+  correct byte range, and the summary text can only claim a trusted signer in
+  that state. Signing time is now extracted from the CMS signed attributes.
+  Certificate revocation (CRL/OCSP) remains deliberately unchecked (offline by
+  design) and is stated in the summary.
 - **Square and Circle annotation authoring** (#626, first slice of #271) —
   `AddSquareAnnotation` / `AddCircleAnnotation` write ISO 32000-2 §12.5.6.8
   shape annotations with border color (`/C`), optional interior fill (`/IC`),

--- a/Excise.App.Tests/Unit/MainWindowViewModelTests.cs
+++ b/Excise.App.Tests/Unit/MainWindowViewModelTests.cs
@@ -1047,7 +1047,10 @@ public class MainWindowViewModelTests
         summary.Should().Contain("ByteRange structure: passed");
         summary.Should().Contain("Signed byte-range digest: passed");
         summary.Should().Contain("Covers whole document: yes");
-        summary.Should().Contain("Certificate trust chain: not evaluated by the OS trust store.");
+        // Trust chain is a separate, explicit line (#466); revocation stays a
+        // stated limitation because CRL/OCSP would require network access.
+        summary.Should().Contain("Certificate trust chain: not evaluated");
+        summary.Should().Contain("certificate revocation (CRL/OCSP) is not checked");
     }
 
     [Fact]

--- a/Excise.App.Tests/Unit/SignatureTrustEvaluatorTests.cs
+++ b/Excise.App.Tests/Unit/SignatureTrustEvaluatorTests.cs
@@ -1,0 +1,106 @@
+using AwesomeAssertions;
+using Excise.App.Services;
+using Excise.App.Tests.Utilities;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+using Xunit;
+
+namespace Excise.App.Tests.Unit;
+
+/// <summary>
+/// Deterministic trust-chain tests for issue #466. Every trust anchor is
+/// generated in-process and injected via the custom trust store — no network,
+/// no dependence on the machine's OS trust store.
+/// </summary>
+public class SignatureTrustEvaluatorTests
+{
+    private static X509Certificate2 ToX509Certificate2(Org.BouncyCastle.X509.X509Certificate certificate) =>
+        X509CertificateLoader.LoadCertificate(certificate.GetEncoded());
+
+    [Fact]
+    public void Evaluate_SelfSignedCertificate_EmptyCustomTrustStore_IsUntrusted()
+    {
+        var identity = TestCertificateFactory.CreateSelfSigned();
+        var evaluator = new SignatureTrustEvaluator(Array.Empty<X509Certificate2>());
+
+        var result = evaluator.Evaluate(identity.Certificate.GetEncoded(), Array.Empty<byte[]>());
+
+        result.Status.Should().Be(SignatureTrustStatus.Untrusted);
+        result.Details.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public void Evaluate_LeafChainedToConfiguredRoot_IsTrusted()
+    {
+        var identity = TestCertificateFactory.CreateChainedToRoot();
+        var evaluator = new SignatureTrustEvaluator(
+            new List<X509Certificate2> { ToX509Certificate2(identity.TrustAnchor!) });
+
+        var result = evaluator.Evaluate(
+            identity.Certificate.GetEncoded(),
+            identity.ChainCertificates.Select(c => c.GetEncoded()).ToList());
+
+        result.Status.Should().Be(SignatureTrustStatus.Trusted);
+        result.Details.Should().Contain("PDFe Test Root CA");
+    }
+
+    [Fact]
+    public void Evaluate_LeafWithUnrelatedRootInTrustStore_IsUntrusted()
+    {
+        var identity = TestCertificateFactory.CreateChainedToRoot();
+        var unrelated = TestCertificateFactory.CreateChainedToRoot("CN=Some Other Root");
+        var evaluator = new SignatureTrustEvaluator(
+            new List<X509Certificate2> { ToX509Certificate2(unrelated.TrustAnchor!) });
+
+        var result = evaluator.Evaluate(
+            identity.Certificate.GetEncoded(),
+            identity.ChainCertificates.Select(c => c.GetEncoded()).ToList());
+
+        result.Status.Should().Be(SignatureTrustStatus.Untrusted);
+    }
+
+    [Fact]
+    public void Evaluate_SelfSignedAnchoredToItself_IsTrusted()
+    {
+        // A user can explicitly pin a self-signed certificate as its own anchor.
+        var identity = TestCertificateFactory.CreateSelfSigned();
+        var evaluator = new SignatureTrustEvaluator(
+            new List<X509Certificate2> { ToX509Certificate2(identity.Certificate) });
+
+        var result = evaluator.Evaluate(identity.Certificate.GetEncoded(), Array.Empty<byte[]>());
+
+        result.Status.Should().Be(SignatureTrustStatus.Trusted);
+    }
+
+    [Fact]
+    public void Evaluate_GarbageCertificateBytes_IsIndeterminate()
+    {
+        var evaluator = new SignatureTrustEvaluator(Array.Empty<X509Certificate2>());
+
+        var result = evaluator.Evaluate(new byte[] { 0x01, 0x02, 0x03 }, Array.Empty<byte[]>());
+
+        result.Status.Should().Be(SignatureTrustStatus.Indeterminate);
+        result.Details.Should().Contain("trust evaluation failed");
+    }
+
+    [Fact]
+    public void Evaluate_NullArguments_Throw()
+    {
+        var evaluator = new SignatureTrustEvaluator();
+
+        var nullSigner = () => evaluator.Evaluate(null!, Array.Empty<byte[]>());
+        var nullCandidates = () => evaluator.Evaluate(new byte[] { 0x30 }, null!);
+
+        nullSigner.Should().Throw<ArgumentNullException>();
+        nullCandidates.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Constructor_NullCustomAnchors_Throws()
+    {
+        var action = () => new SignatureTrustEvaluator(null!);
+        action.Should().Throw<ArgumentNullException>();
+    }
+}

--- a/Excise.App.Tests/Unit/SignatureVerificationServiceTests.cs
+++ b/Excise.App.Tests/Unit/SignatureVerificationServiceTests.cs
@@ -1,17 +1,14 @@
 using AwesomeAssertions;
 using Microsoft.Extensions.Logging;
 using Org.BouncyCastle.Cms;
-using Org.BouncyCastle.Crypto;
-using Org.BouncyCastle.Crypto.Generators;
 using Org.BouncyCastle.Crypto.Operators;
-using Org.BouncyCastle.Crypto.Parameters;
-using Org.BouncyCastle.Math;
 using Org.BouncyCastle.Security;
-using Org.BouncyCastle.X509;
-using Org.BouncyCastle.Asn1.X509;
 using Excise.App.Services;
+using Excise.App.Tests.Utilities;
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using Xunit;
 
@@ -610,6 +607,255 @@ public class SignatureVerificationServiceTests
     }
 
     // ========================================================================
+    // TRUST-CHAIN VALIDATION AND CONSOLIDATED STATES (#466)
+    // All trust anchors are generated in-process and injected via
+    // SignatureTrustEvaluator's custom trust store, so these assertions are
+    // deterministic and never depend on the machine trust store or network.
+    // ========================================================================
+
+    private static SignatureVerificationService CreateServiceWithTrustAnchors(
+        params Org.BouncyCastle.X509.X509Certificate[] anchors)
+    {
+        var anchorCertificates = new List<X509Certificate2>();
+        foreach (var anchor in anchors)
+        {
+            anchorCertificates.Add(X509CertificateLoader.LoadCertificate(anchor.GetEncoded()));
+        }
+
+        return new SignatureVerificationService(
+            new Microsoft.Extensions.Logging.Abstractions.NullLogger<SignatureVerificationService>(),
+            new SignatureTrustEvaluator(anchorCertificates));
+    }
+
+    [Fact]
+    public void VerifySignatures_ValidSelfSignedSignature_EmptyTrustStore_IsValidButUntrusted()
+    {
+        var pdfBytes = MakePdfWithValidDetachedCmsSignature(TestCertificateFactory.CreateSelfSigned());
+        var pdfPath = WriteTempPdf(pdfBytes);
+        var service = CreateServiceWithTrustAnchors(); // custom trust store with no anchors
+
+        try
+        {
+            var results = service.VerifySignatures(pdfPath);
+
+            results.Should().HaveCount(1);
+            results[0].IsValid.Should().BeTrue("the CMS signature itself is cryptographically valid");
+            results[0].ByteRangeIntegrityValid.Should().BeTrue();
+            results[0].TrustStatus.Should().Be(SignatureTrustStatus.Untrusted,
+                "a self-signed certificate must not be reported as trusted");
+            results[0].State.Should().Be(SignatureVerificationState.ValidUntrusted);
+        }
+        finally
+        {
+            File.Delete(pdfPath);
+        }
+    }
+
+    [Fact]
+    public void VerifySignatures_ValidSignatureChainedToConfiguredRoot_IsValidAndTrusted()
+    {
+        var identity = TestCertificateFactory.CreateChainedToRoot();
+        var pdfBytes = MakePdfWithValidDetachedCmsSignature(identity);
+        var pdfPath = WriteTempPdf(pdfBytes);
+        var service = CreateServiceWithTrustAnchors(identity.TrustAnchor!);
+
+        try
+        {
+            var results = service.VerifySignatures(pdfPath);
+
+            results.Should().HaveCount(1);
+            results[0].IsValid.Should().BeTrue();
+            results[0].SignedBy.Should().Contain("PDFe Test Chained Signer");
+            results[0].TrustStatus.Should().Be(SignatureTrustStatus.Trusted);
+            results[0].TrustDetails.Should().Contain("PDFe Test Root CA");
+            results[0].State.Should().Be(SignatureVerificationState.ValidTrusted);
+        }
+        finally
+        {
+            File.Delete(pdfPath);
+        }
+    }
+
+    [Fact]
+    public void VerifySignatures_ChainedSignature_RootNotInTrustStore_IsValidButUntrusted()
+    {
+        var identity = TestCertificateFactory.CreateChainedToRoot();
+        var unrelatedRoot = TestCertificateFactory.CreateChainedToRoot("CN=Unrelated Root").TrustAnchor!;
+        var pdfBytes = MakePdfWithValidDetachedCmsSignature(identity);
+        var pdfPath = WriteTempPdf(pdfBytes);
+        var service = CreateServiceWithTrustAnchors(unrelatedRoot);
+
+        try
+        {
+            var results = service.VerifySignatures(pdfPath);
+
+            results.Should().HaveCount(1);
+            results[0].IsValid.Should().BeTrue();
+            results[0].TrustStatus.Should().Be(SignatureTrustStatus.Untrusted,
+                "the chain roots in a CA that is not a configured trust anchor");
+            results[0].State.Should().Be(SignatureVerificationState.ValidUntrusted);
+        }
+        finally
+        {
+            File.Delete(pdfPath);
+        }
+    }
+
+    [Fact]
+    public void VerifySignatures_TamperedDocument_StateIsInvalid_TrustNotEvaluated()
+    {
+        var pdfBytes = MakePdfWithValidDetachedCmsSignature();
+        ReplaceAsciiMarker(pdfBytes, "ORIGINAL", "TAMPERED");
+        var pdfPath = WriteTempPdf(pdfBytes);
+        var service = CreateServiceWithTrustAnchors();
+
+        try
+        {
+            var results = service.VerifySignatures(pdfPath);
+
+            results.Should().HaveCount(1);
+            results[0].IsValid.Should().BeFalse();
+            results[0].State.Should().Be(SignatureVerificationState.Invalid,
+                "a digest mismatch is proven tampering, not an indeterminate result");
+            results[0].TrustStatus.Should().Be(SignatureTrustStatus.NotEvaluated,
+                "trust must not be evaluated (or reported) for a signature that failed verification");
+        }
+        finally
+        {
+            File.Delete(pdfPath);
+        }
+    }
+
+    [Fact]
+    public void VerifySignatures_MalformedSignatureBytes_StateIsIndeterminate()
+    {
+        var pdfBytes = MakePdfWithInvalidSignatureBytes();
+        var pdfPath = WriteTempPdf(pdfBytes);
+
+        try
+        {
+            var results = _service.VerifySignatures(pdfPath);
+
+            results.Should().HaveCount(1);
+            results[0].IsValid.Should().BeFalse();
+            results[0].State.Should().Be(SignatureVerificationState.Indeterminate,
+                "an unparseable signature is 'could not verify', not proven tampering");
+            results[0].TrustStatus.Should().Be(SignatureTrustStatus.NotEvaluated);
+        }
+        finally
+        {
+            File.Delete(pdfPath);
+        }
+    }
+
+    [Fact]
+    public void VerifySignatures_InvalidByteRangeStructure_StateIsInvalid()
+    {
+        var pdfText = MakePdfWithInvalidByteRangeGap();
+        var pdfPath = WriteTempPdf(Encoding.Latin1.GetBytes(pdfText));
+
+        try
+        {
+            var results = _service.VerifySignatures(pdfPath);
+
+            results.Should().HaveCount(1);
+            results[0].State.Should().Be(SignatureVerificationState.Invalid,
+                "a ByteRange that leaves unsigned gaps fails verification rather than being indeterminate");
+        }
+        finally
+        {
+            File.Delete(pdfPath);
+        }
+    }
+
+    [Fact]
+    public void VerifySignatures_DefaultSystemTrustEvaluator_NeverTrustsAFreshSelfSignedCertificate()
+    {
+        // Machine-independent even against the real OS store: the certificate
+        // was generated seconds ago from a random key, so no trust store can
+        // contain it. Asserts trust was evaluated and did NOT come back trusted.
+        var pdfBytes = MakePdfWithValidDetachedCmsSignature();
+        var pdfPath = WriteTempPdf(pdfBytes);
+
+        try
+        {
+            var results = _service.VerifySignatures(pdfPath);
+
+            results.Should().HaveCount(1);
+            results[0].IsValid.Should().BeTrue();
+            results[0].TrustStatus.Should().NotBe(SignatureTrustStatus.NotEvaluated,
+                "a valid signature must get a trust evaluation");
+            results[0].TrustStatus.Should().NotBe(SignatureTrustStatus.Trusted,
+                "a just-generated self-signed certificate cannot chain to any trusted root");
+            results[0].State.Should().NotBe(SignatureVerificationState.ValidTrusted);
+        }
+        finally
+        {
+            File.Delete(pdfPath);
+        }
+    }
+
+    [Fact]
+    public void VerifySignatures_ValidSignature_ExtractsSigningTimeFromSignedAttributes()
+    {
+        var pdfBytes = MakePdfWithValidDetachedCmsSignature();
+        var pdfPath = WriteTempPdf(pdfBytes);
+
+        try
+        {
+            var results = _service.VerifySignatures(pdfPath);
+
+            results.Should().HaveCount(1);
+            results[0].SigningTime.Should().NotBe(default(DateTime),
+                "BouncyCastle's default signed attributes include pkcs#9 signingTime");
+            results[0].SigningTime.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromMinutes(10));
+        }
+        finally
+        {
+            File.Delete(pdfPath);
+        }
+    }
+
+    // ------------------------------------------------------------------------
+    // Consolidated state model (pure, no I/O)
+    // ------------------------------------------------------------------------
+
+    [Fact]
+    public void State_DefaultResult_IsIndeterminate()
+    {
+        new SignatureVerificationResult().State
+            .Should().Be(SignatureVerificationState.Indeterminate);
+    }
+
+    [Theory]
+    [InlineData(SignatureTrustStatus.Trusted, SignatureVerificationState.ValidTrusted)]
+    [InlineData(SignatureTrustStatus.Untrusted, SignatureVerificationState.ValidUntrusted)]
+    [InlineData(SignatureTrustStatus.NotEvaluated, SignatureVerificationState.ValidTrustUnknown)]
+    [InlineData(SignatureTrustStatus.Indeterminate, SignatureVerificationState.ValidTrustUnknown)]
+    public void State_ValidSignature_MapsTrustStatusToState(
+        SignatureTrustStatus trustStatus, SignatureVerificationState expected)
+    {
+        var result = new SignatureVerificationResult { IsValid = true, TrustStatus = trustStatus };
+        result.State.Should().Be(expected);
+    }
+
+    [Fact]
+    public void State_TrustedStatusOnInvalidSignature_NeverReportsValidTrusted()
+    {
+        // Defensive invariant: even if a bug set TrustStatus on an invalid
+        // signature, the consolidated state must not overclaim.
+        var result = new SignatureVerificationResult
+        {
+            IsValid = false,
+            ByteRangeIntegrityChecked = true,
+            ByteRangeIntegrityValid = false,
+            TrustStatus = SignatureTrustStatus.Trusted
+        };
+
+        result.State.Should().Be(SignatureVerificationState.Invalid);
+    }
+
+    // ========================================================================
     // PDF BUILDER HELPERS
     // ========================================================================
 
@@ -970,11 +1216,14 @@ public class SignatureVerificationServiceTests
         return Encoding.Latin1.GetBytes(FillByteRange(sb.ToString()));
     }
 
-    private static byte[] MakePdfWithValidDetachedCmsSignature()
+    private static byte[] MakePdfWithValidDetachedCmsSignature() =>
+        MakePdfWithValidDetachedCmsSignature(TestCertificateFactory.CreateSelfSigned());
+
+    private static byte[] MakePdfWithValidDetachedCmsSignature(TestSigningIdentity identity)
     {
         var pdfWithByteRange = FillByteRange(MakePdfWithSignaturePlaceholder());
         var signedContent = ExtractSignedContent(Encoding.Latin1.GetBytes(pdfWithByteRange));
-        var cmsSignature = CreateDetachedCmsSignature(signedContent);
+        var cmsSignature = CreateDetachedCmsSignature(signedContent, identity);
         var signatureHex = Convert.ToHexString(cmsSignature);
         signatureHex.Length.Should().BeLessThan(SignaturePlaceholderHexLength);
 
@@ -1083,43 +1332,25 @@ public class SignatureVerificationServiceTests
         return signedContent;
     }
 
-    private static byte[] CreateDetachedCmsSignature(byte[] signedContent)
+    private static byte[] CreateDetachedCmsSignature(byte[] signedContent, TestSigningIdentity identity)
     {
         var random = new SecureRandom();
-        var keyPair = GenerateKeyPair(random);
-        var certificate = GenerateSelfSignedCertificate(keyPair, random);
 
         var signerInfoGenerator = new SignerInfoGeneratorBuilder()
-            .Build(new Asn1SignatureFactory("SHA256WITHRSA", keyPair.Private, random), certificate);
+            .Build(
+                new Asn1SignatureFactory("SHA256WITHRSA", identity.KeyPair.Private, random),
+                identity.Certificate);
 
         var generator = new CmsSignedDataGenerator();
         generator.AddSignerInfoGenerator(signerInfoGenerator);
-        generator.AddCertificate(certificate);
+        generator.AddCertificate(identity.Certificate);
+        foreach (var chainCertificate in identity.ChainCertificates)
+        {
+            generator.AddCertificate(chainCertificate);
+        }
 
         var cms = generator.Generate(new CmsProcessableByteArray(signedContent), encapsulate: false);
         return cms.GetEncoded();
-    }
-
-    private static AsymmetricCipherKeyPair GenerateKeyPair(SecureRandom random)
-    {
-        var keyGenerator = new RsaKeyPairGenerator();
-        keyGenerator.Init(new KeyGenerationParameters(random, 2048));
-        return keyGenerator.GenerateKeyPair();
-    }
-
-    private static X509Certificate GenerateSelfSignedCertificate(AsymmetricCipherKeyPair keyPair, SecureRandom random)
-    {
-        var certificateGenerator = new X509V3CertificateGenerator();
-        var subject = new X509Name("CN=PDFe Test Signer");
-        certificateGenerator.SetSerialNumber(BigInteger.ProbablePrime(128, random));
-        certificateGenerator.SetIssuerDN(subject);
-        certificateGenerator.SetSubjectDN(subject);
-        certificateGenerator.SetNotBefore(DateTime.UtcNow.AddDays(-1));
-        certificateGenerator.SetNotAfter(DateTime.UtcNow.AddDays(1));
-        certificateGenerator.SetPublicKey(keyPair.Public);
-
-        return certificateGenerator.Generate(
-            new Asn1SignatureFactory("SHA256WITHRSA", keyPair.Private, random));
     }
 
     private static string FillByteRange(string pdf)

--- a/Excise.App.Tests/Unit/SignatureVerificationSummaryFormatterTests.cs
+++ b/Excise.App.Tests/Unit/SignatureVerificationSummaryFormatterTests.cs
@@ -1,0 +1,154 @@
+using AwesomeAssertions;
+using Excise.App.Services;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Excise.App.Tests.Unit;
+
+/// <summary>
+/// UI-text tests for the signature summary (#466). The key invariant: wording
+/// that claims a trusted signer may only appear for ValidTrusted — no other
+/// state is allowed to overclaim trust.
+/// </summary>
+public class SignatureVerificationSummaryFormatterTests
+{
+    private readonly SignatureVerificationSummaryFormatter _formatter = new();
+
+    private static SignatureVerificationResult ValidResult() => new()
+    {
+        SignatureName = "Sig1",
+        IsValid = true,
+        SignedBy = "CN=Signer",
+        ByteRangeStructureChecked = true,
+        ByteRangeStructureValid = true,
+        ByteRangeIntegrityChecked = true,
+        ByteRangeIntegrityValid = true,
+        CoversWholeDocument = true
+    };
+
+    [Fact]
+    public void Format_ValidTrusted_ReportsTrustedSigner()
+    {
+        var result = ValidResult();
+        result.TrustStatus = SignatureTrustStatus.Trusted;
+        result.TrustDetails = "signer chains to trusted root: CN=Root";
+
+        var text = _formatter.Format(new[] { result });
+
+        result.State.Should().Be(SignatureVerificationState.ValidTrusted);
+        text.Should().Contain("trusted signer");
+        text.Should().Contain("Certificate trust chain: trusted");
+        text.Should().Contain("CN=Root");
+    }
+
+    [Fact]
+    public void Format_ValidUntrusted_ReportsUntrustedWithoutOverclaiming()
+    {
+        var result = ValidResult();
+        result.TrustStatus = SignatureTrustStatus.Untrusted;
+        result.TrustDetails = "self-signed certificate is not a configured trust anchor";
+
+        var text = _formatter.Format(new[] { result });
+
+        result.State.Should().Be(SignatureVerificationState.ValidUntrusted);
+        text.Should().Contain("UNTRUSTED");
+        text.Should().Contain("valid signature");
+        text.Should().NotContain("trusted signer");
+    }
+
+    [Fact]
+    public void Format_ValidTrustUnknown_SaysTrustNotDetermined()
+    {
+        var result = ValidResult();
+        result.TrustStatus = SignatureTrustStatus.Indeterminate;
+        result.TrustDetails = "trust evaluation failed: platform error";
+
+        var text = _formatter.Format(new[] { result });
+
+        result.State.Should().Be(SignatureVerificationState.ValidTrustUnknown);
+        text.Should().Contain("signer trust could not be determined");
+        text.Should().Contain("Certificate trust chain: could not be evaluated");
+        text.Should().NotContain("trusted signer");
+    }
+
+    [Fact]
+    public void Format_InvalidSignature_ReportsModificationClearly()
+    {
+        var result = new SignatureVerificationResult
+        {
+            SignatureName = "Sig1",
+            IsValid = false,
+            ByteRangeStructureChecked = true,
+            ByteRangeStructureValid = true,
+            ByteRangeIntegrityChecked = true,
+            ByteRangeIntegrityValid = false,
+            StatusMessage = "Signature verification failed or ByteRange digest mismatch"
+        };
+
+        var text = _formatter.Format(new[] { result });
+
+        result.State.Should().Be(SignatureVerificationState.Invalid);
+        text.Should().Contain("INVALID");
+        text.Should().Contain("modified after signing");
+        text.Should().Contain("Certificate trust chain: not evaluated");
+        text.Should().NotContain("trusted signer");
+    }
+
+    [Fact]
+    public void Format_IndeterminateSignature_SaysCouldNotBeVerified()
+    {
+        var result = new SignatureVerificationResult
+        {
+            SignatureName = "Sig1",
+            IsValid = false,
+            StatusMessage = "Verification failed: BouncyCastle verification failed"
+        };
+
+        var text = _formatter.Format(new[] { result });
+
+        result.State.Should().Be(SignatureVerificationState.Indeterminate);
+        text.Should().Contain("could not be verified");
+        text.Should().NotContain("trusted signer");
+    }
+
+    [Fact]
+    public void Format_TrustedSignerWording_OnlyAppearsForValidTrusted()
+    {
+        // Enumerate every reachable combination and assert the no-overclaim
+        // invariant structurally rather than per-case.
+        foreach (var isValid in new[] { true, false })
+        {
+            foreach (SignatureTrustStatus trust in Enum.GetValues<SignatureTrustStatus>())
+            {
+                var result = new SignatureVerificationResult
+                {
+                    SignatureName = "Sig",
+                    IsValid = isValid,
+                    ByteRangeStructureChecked = true,
+                    ByteRangeStructureValid = true,
+                    ByteRangeIntegrityChecked = true,
+                    ByteRangeIntegrityValid = isValid,
+                    TrustStatus = trust
+                };
+
+                var text = _formatter.Format(new[] { result });
+                var claimsTrust = text.Contains("trusted signer", StringComparison.OrdinalIgnoreCase);
+
+                claimsTrust.Should().Be(
+                    result.State == SignatureVerificationState.ValidTrusted,
+                    $"IsValid={isValid}, TrustStatus={trust} must not overclaim trust");
+            }
+        }
+    }
+
+    [Fact]
+    public void Format_AlwaysDisclosesRevocationLimitation()
+    {
+        var text = _formatter.Format(new List<SignatureVerificationResult> { ValidResult() });
+        text.Should().Contain("revocation (CRL/OCSP) is not checked");
+
+        var emptyText = _formatter.Format(new List<SignatureVerificationResult>());
+        emptyText.Should().Contain("revocation (CRL/OCSP) is not checked");
+    }
+}

--- a/Excise.App.Tests/Utilities/TestCertificateFactory.cs
+++ b/Excise.App.Tests/Utilities/TestCertificateFactory.cs
@@ -1,0 +1,97 @@
+using Org.BouncyCastle.Asn1.X509;
+using Org.BouncyCastle.Crypto;
+using Org.BouncyCastle.Crypto.Generators;
+using Org.BouncyCastle.Crypto.Operators;
+using Org.BouncyCastle.Math;
+using Org.BouncyCastle.Security;
+using Org.BouncyCastle.X509;
+using System;
+
+namespace Excise.App.Tests.Utilities;
+
+/// <summary>
+/// A signing identity for signature tests: the leaf certificate + key that
+/// signs, the extra certificates to embed in the CMS bundle, and (for chained
+/// identities) the root that a test can install as an explicit trust anchor.
+/// All material is generated in-process so trust assertions are deterministic
+/// and never depend on the machine trust store or the network (#466).
+/// </summary>
+internal sealed record TestSigningIdentity(
+    AsymmetricCipherKeyPair KeyPair,
+    X509Certificate Certificate,
+    X509Certificate[] ChainCertificates,
+    X509Certificate? TrustAnchor);
+
+internal static class TestCertificateFactory
+{
+    public static TestSigningIdentity CreateSelfSigned(string subject = "CN=PDFe Test Signer")
+    {
+        var random = new SecureRandom();
+        var keyPair = GenerateKeyPair(random);
+
+        var generator = CreateGenerator(new X509Name(subject), new X509Name(subject), keyPair.Public, random);
+        generator.AddExtension(X509Extensions.BasicConstraints, true, new BasicConstraints(false));
+        generator.AddExtension(X509Extensions.KeyUsage, true, new KeyUsage(KeyUsage.DigitalSignature));
+        var certificate = generator.Generate(
+            new Asn1SignatureFactory("SHA256WITHRSA", keyPair.Private, random));
+
+        return new TestSigningIdentity(keyPair, certificate, Array.Empty<X509Certificate>(), TrustAnchor: null);
+    }
+
+    /// <summary>
+    /// Root CA + leaf signer. The leaf signs; the root travels in
+    /// <see cref="TestSigningIdentity.ChainCertificates"/> and is exposed as
+    /// <see cref="TestSigningIdentity.TrustAnchor"/> for a custom trust store.
+    /// </summary>
+    public static TestSigningIdentity CreateChainedToRoot(
+        string rootSubject = "CN=PDFe Test Root CA",
+        string leafSubject = "CN=PDFe Test Chained Signer")
+    {
+        var random = new SecureRandom();
+
+        var rootKeyPair = GenerateKeyPair(random);
+        var rootName = new X509Name(rootSubject);
+        var rootGenerator = CreateGenerator(rootName, rootName, rootKeyPair.Public, random);
+        rootGenerator.AddExtension(X509Extensions.BasicConstraints, true, new BasicConstraints(true));
+        rootGenerator.AddExtension(X509Extensions.KeyUsage, true,
+            new KeyUsage(KeyUsage.KeyCertSign | KeyUsage.CrlSign));
+        var rootCertificate = rootGenerator.Generate(
+            new Asn1SignatureFactory("SHA256WITHRSA", rootKeyPair.Private, random));
+
+        var leafKeyPair = GenerateKeyPair(random);
+        var leafGenerator = CreateGenerator(rootName, new X509Name(leafSubject), leafKeyPair.Public, random);
+        leafGenerator.AddExtension(X509Extensions.BasicConstraints, true, new BasicConstraints(false));
+        leafGenerator.AddExtension(X509Extensions.KeyUsage, true, new KeyUsage(KeyUsage.DigitalSignature));
+        var leafCertificate = leafGenerator.Generate(
+            new Asn1SignatureFactory("SHA256WITHRSA", rootKeyPair.Private, random));
+
+        return new TestSigningIdentity(
+            leafKeyPair,
+            leafCertificate,
+            new[] { rootCertificate },
+            TrustAnchor: rootCertificate);
+    }
+
+    private static X509V3CertificateGenerator CreateGenerator(
+        X509Name issuer,
+        X509Name subject,
+        AsymmetricKeyParameter publicKey,
+        SecureRandom random)
+    {
+        var generator = new X509V3CertificateGenerator();
+        generator.SetSerialNumber(BigInteger.ProbablePrime(128, random));
+        generator.SetIssuerDN(issuer);
+        generator.SetSubjectDN(subject);
+        generator.SetNotBefore(DateTime.UtcNow.AddDays(-1));
+        generator.SetNotAfter(DateTime.UtcNow.AddDays(1));
+        generator.SetPublicKey(publicKey);
+        return generator;
+    }
+
+    private static AsymmetricCipherKeyPair GenerateKeyPair(SecureRandom random)
+    {
+        var keyGenerator = new RsaKeyPairGenerator();
+        keyGenerator.Init(new KeyGenerationParameters(random, 2048));
+        return keyGenerator.GenerateKeyPair();
+    }
+}

--- a/Excise.App/Services/SignatureTrustEvaluator.cs
+++ b/Excise.App/Services/SignatureTrustEvaluator.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+
+namespace Excise.App.Services;
+
+/// <summary>
+/// Whether the signer certificate chains to a trusted root. Kept separate from
+/// cryptographic signature validity: a signature can be cryptographically valid
+/// while the signer is untrusted, and the two must never collapse into one
+/// state. See issue #466.
+/// </summary>
+public enum SignatureTrustStatus
+{
+    /// <summary>Trust was not evaluated (e.g. the signature itself was not cryptographically valid).</summary>
+    NotEvaluated = 0,
+
+    /// <summary>The signer certificate chains to a configured trust anchor (OS trust store by default).</summary>
+    Trusted,
+
+    /// <summary>Chain building completed but the signer does not chain to any trusted root, or the chain has errors.</summary>
+    Untrusted,
+
+    /// <summary>Trust evaluation was attempted but could not produce an answer (malformed certificate, platform error).</summary>
+    Indeterminate
+}
+
+/// <summary>Outcome of a trust-chain evaluation for one signer certificate.</summary>
+public sealed class SignatureTrustResult
+{
+    public SignatureTrustStatus Status { get; init; }
+    public string Details { get; init; } = string.Empty;
+}
+
+/// <summary>
+/// Builds and evaluates the signer certificate chain for a PDF signature.
+/// By default the chain is validated against the OS/.NET system trust store;
+/// tests (and callers wanting a pinned trust policy) can inject explicit trust
+/// anchors so results are deterministic and machine-independent.
+///
+/// Revocation (CRL/OCSP) is deliberately NOT checked: it requires network
+/// access and would make verification non-deterministic. The formatter states
+/// this limitation to the user. See issue #466.
+/// </summary>
+public class SignatureTrustEvaluator
+{
+    private readonly IReadOnlyList<X509Certificate2>? _customTrustAnchors;
+
+    /// <summary>Creates an evaluator that trusts the OS/.NET system root store.</summary>
+    public SignatureTrustEvaluator()
+    {
+    }
+
+    /// <summary>
+    /// Creates an evaluator that trusts ONLY the supplied anchors
+    /// (X509ChainTrustMode.CustomRootTrust). An empty list means nothing is
+    /// trusted — useful for deterministic tests.
+    /// </summary>
+    public SignatureTrustEvaluator(IReadOnlyList<X509Certificate2> customTrustAnchors)
+    {
+        ArgumentNullException.ThrowIfNull(customTrustAnchors);
+        _customTrustAnchors = customTrustAnchors;
+    }
+
+    /// <summary>
+    /// Evaluates whether the DER-encoded signer certificate chains to a trusted
+    /// root. <paramref name="candidateChainCertificates"/> carries the other
+    /// DER-encoded certificates embedded in the CMS bundle so intermediates can
+    /// be resolved without touching the network.
+    /// </summary>
+    public virtual SignatureTrustResult Evaluate(
+        byte[] signerCertificate,
+        IReadOnlyList<byte[]> candidateChainCertificates)
+    {
+        ArgumentNullException.ThrowIfNull(signerCertificate);
+        ArgumentNullException.ThrowIfNull(candidateChainCertificates);
+
+        var extraCertificates = new List<X509Certificate2>();
+        try
+        {
+            using var signer = X509CertificateLoader.LoadCertificate(signerCertificate);
+            using var chain = new X509Chain();
+
+            // Offline and deterministic by design; the limitation is reported
+            // to the user by SignatureVerificationSummaryFormatter (#466).
+            chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
+            chain.ChainPolicy.VerificationFlags = X509VerificationFlags.NoFlag;
+
+            foreach (var der in candidateChainCertificates)
+            {
+                var candidate = X509CertificateLoader.LoadCertificate(der);
+                extraCertificates.Add(candidate);
+                chain.ChainPolicy.ExtraStore.Add(candidate);
+            }
+
+            if (_customTrustAnchors is not null)
+            {
+                chain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
+                foreach (var anchor in _customTrustAnchors)
+                {
+                    chain.ChainPolicy.CustomTrustStore.Add(anchor);
+                }
+            }
+
+            if (chain.Build(signer))
+            {
+                var root = chain.ChainElements.Count > 0
+                    ? chain.ChainElements[^1].Certificate.Subject
+                    : signer.Subject;
+                return new SignatureTrustResult
+                {
+                    Status = SignatureTrustStatus.Trusted,
+                    Details = $"signer chains to trusted root: {root}"
+                };
+            }
+
+            var statusText = string.Join("; ", chain.ChainStatus
+                .Select(s => string.IsNullOrWhiteSpace(s.StatusInformation)
+                    ? s.Status.ToString()
+                    : s.StatusInformation.Trim())
+                .Distinct());
+            return new SignatureTrustResult
+            {
+                Status = SignatureTrustStatus.Untrusted,
+                Details = string.IsNullOrWhiteSpace(statusText)
+                    ? "signer does not chain to a trusted root"
+                    : statusText
+            };
+        }
+        catch (Exception ex)
+        {
+            return new SignatureTrustResult
+            {
+                Status = SignatureTrustStatus.Indeterminate,
+                Details = $"trust evaluation failed: {ex.Message}"
+            };
+        }
+        finally
+        {
+            foreach (var candidate in extraCertificates)
+            {
+                candidate.Dispose();
+            }
+        }
+    }
+}

--- a/Excise.App/Services/SignatureVerificationService.cs
+++ b/Excise.App/Services/SignatureVerificationService.cs
@@ -10,6 +10,29 @@ using System.Linq;
 
 namespace Excise.App.Services;
 
+/// <summary>
+/// Consolidated per-signature verdict combining cryptographic validity and
+/// signer trust. Derived from the underlying check fields so the UI and tests
+/// consume the same structured state and cannot disagree (#466).
+/// </summary>
+public enum SignatureVerificationState
+{
+    /// <summary>The signature could not be parsed or verified (malformed object, missing data, engine error).</summary>
+    Indeterminate = 0,
+
+    /// <summary>Verification ran and FAILED: the signed bytes do not match the signature, or the ByteRange does not cover the document correctly. Treat as modified-after-signing or a broken signature.</summary>
+    Invalid,
+
+    /// <summary>Cryptographically valid signature, but the signer certificate does NOT chain to a trusted root.</summary>
+    ValidUntrusted,
+
+    /// <summary>Cryptographically valid signature; signer trust was not evaluated or could not be determined.</summary>
+    ValidTrustUnknown,
+
+    /// <summary>Cryptographically valid signature AND the signer chains to a trusted root.</summary>
+    ValidTrusted
+}
+
 public class SignatureVerificationResult
 {
     public string SignatureName { get; set; } = string.Empty;
@@ -23,6 +46,45 @@ public class SignatureVerificationResult
     public string ByteRangeStructureMessage { get; set; } = string.Empty;
     public bool ByteRangeIntegrityChecked { get; set; }
     public bool ByteRangeIntegrityValid { get; set; }
+
+    /// <summary>Signer certificate chain trust. Independent of, and additional to, cryptographic validity (#466).</summary>
+    public SignatureTrustStatus TrustStatus { get; set; } = SignatureTrustStatus.NotEvaluated;
+    public string TrustDetails { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Consolidated verdict. Computed from the check fields (never stored) so a
+    /// "trusted" state is impossible unless the signature is also
+    /// cryptographically valid over the correct byte range.
+    /// </summary>
+    public SignatureVerificationState State
+    {
+        get
+        {
+            if (IsValid)
+            {
+                return TrustStatus switch
+                {
+                    SignatureTrustStatus.Trusted => SignatureVerificationState.ValidTrusted,
+                    SignatureTrustStatus.Untrusted => SignatureVerificationState.ValidUntrusted,
+                    _ => SignatureVerificationState.ValidTrustUnknown
+                };
+            }
+
+            // Not valid: distinguish "verification ran and failed" (tampering /
+            // broken signature) from "could not verify at all".
+            if (ByteRangeIntegrityChecked && !ByteRangeIntegrityValid)
+            {
+                return SignatureVerificationState.Invalid;
+            }
+
+            if (ByteRangeStructureChecked && !ByteRangeStructureValid)
+            {
+                return SignatureVerificationState.Invalid;
+            }
+
+            return SignatureVerificationState.Indeterminate;
+        }
+    }
 }
 
 /// <summary>
@@ -32,11 +94,20 @@ public class SignatureVerificationResult
 public class SignatureVerificationService
 {
     private readonly ILogger<SignatureVerificationService> _logger;
+    private readonly SignatureTrustEvaluator _trustEvaluator;
 
     public SignatureVerificationService(ILogger<SignatureVerificationService> logger)
+        : this(logger, trustEvaluator: null)
+    {
+    }
+
+    public SignatureVerificationService(
+        ILogger<SignatureVerificationService> logger,
+        SignatureTrustEvaluator? trustEvaluator)
     {
         ArgumentNullException.ThrowIfNull(logger);
         _logger = logger;
+        _trustEvaluator = trustEvaluator ?? new SignatureTrustEvaluator();
     }
 
     public List<SignatureVerificationResult> VerifySignatures(string pdfPath)
@@ -237,6 +308,13 @@ public class SignatureVerificationService
                         result.ByteRangeIntegrityChecked = true;
                         result.ByteRangeIntegrityValid = true;
                         result.StatusMessage = "Signature is cryptographically valid and ByteRange digest matches";
+                        ExtractSigningTime(signer, result);
+
+                        // Trust is ADDITIONAL to validity, never a replacement:
+                        // only a cryptographically valid signature earns a trust
+                        // evaluation, and the consolidated State can only reach
+                        // ValidTrusted through both checks (#466).
+                        EvaluateTrust(cert, store, result);
                     }
                     else
                     {
@@ -262,6 +340,48 @@ public class SignatureVerificationService
         catch (Exception ex)
         {
             throw new Exception("BouncyCastle verification failed", ex);
+        }
+    }
+
+    private void EvaluateTrust(
+        X509Certificate signerCertificate,
+        Org.BouncyCastle.Utilities.Collections.IStore<X509Certificate> certificateStore,
+        SignatureVerificationResult result)
+    {
+        try
+        {
+            // Hand the evaluator every certificate embedded in the CMS bundle
+            // so intermediates resolve without any network access.
+            var candidates = certificateStore.EnumerateMatches(null)
+                .Select(c => c.GetEncoded())
+                .ToList();
+            var trust = _trustEvaluator.Evaluate(signerCertificate.GetEncoded(), candidates);
+            result.TrustStatus = trust.Status;
+            result.TrustDetails = trust.Details;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Trust-chain evaluation failed for signer {Signer}", result.SignedBy);
+            result.TrustStatus = SignatureTrustStatus.Indeterminate;
+            result.TrustDetails = $"trust evaluation failed: {ex.Message}";
+        }
+    }
+
+    private void ExtractSigningTime(SignerInformation signer, SignatureVerificationResult result)
+    {
+        try
+        {
+            var attribute = signer.SignedAttributes?[Org.BouncyCastle.Asn1.Cms.CmsAttributes.SigningTime];
+            if (attribute is { AttrValues.Count: > 0 })
+            {
+                result.SigningTime = Org.BouncyCastle.Asn1.Cms.Time
+                    .GetInstance(attribute.AttrValues[0])
+                    .ToDateTime();
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Could not extract signing time for {Signer}", result.SignedBy);
         }
     }
 

--- a/Excise.App/Services/SignatureVerificationSummaryFormatter.cs
+++ b/Excise.App/Services/SignatureVerificationSummaryFormatter.cs
@@ -18,6 +18,7 @@ public sealed class SignatureVerificationSummaryFormatter
             }
 
             summary.AppendLine($"Signature: {ValueOrUnknown(result.SignatureName)}");
+            summary.AppendLine($"Overall: {FormatOverallState(result.State)}");
             summary.AppendLine($"CMS signature check: {(result.IsValid ? "passed" : "failed")} (CMS bytes and ByteRange digest only)");
             summary.AppendLine($"Signer: {ValueOrUnknown(result.SignedBy)}");
             summary.AppendLine(result.SigningTime == default
@@ -32,6 +33,7 @@ public sealed class SignatureVerificationSummaryFormatter
             summary.AppendLine($"ByteRange structure: {FormatByteRangeStructureStatus(result)}");
             summary.AppendLine($"Signed byte-range digest: {FormatByteRangeDigestStatus(result)}");
             summary.AppendLine($"Covers whole document: {(result.CoversWholeDocument ? "yes" : "no")}");
+            summary.AppendLine($"Certificate trust chain: {FormatTrustStatus(result)}");
         }
 
         if (results.Count > 0)
@@ -39,12 +41,43 @@ public sealed class SignatureVerificationSummaryFormatter
             summary.AppendLine();
         }
 
-        summary.AppendLine("Certificate trust chain: not evaluated by the OS trust store.");
+        summary.AppendLine("Signer trust is checked against the configured certificate trust store; certificate revocation (CRL/OCSP) is not checked.");
         return summary.ToString().TrimEnd();
     }
 
     private static string ValueOrUnknown(string value) =>
         string.IsNullOrWhiteSpace(value) ? "unknown" : value;
+
+    // The strong phrase "trusted signer" is reserved for ValidTrusted: no other
+    // state may emit wording that overclaims trust (#466 acceptance criterion).
+    private static string FormatOverallState(SignatureVerificationState state) => state switch
+    {
+        SignatureVerificationState.ValidTrusted =>
+            "VALID signature from a trusted signer (cryptographically valid; signer chains to a trusted root)",
+        SignatureVerificationState.ValidUntrusted =>
+            "valid signature, but the signer is UNTRUSTED (cryptographically valid; signer does not chain to a trusted root)",
+        SignatureVerificationState.ValidTrustUnknown =>
+            "valid signature; signer trust could not be determined",
+        SignatureVerificationState.Invalid =>
+            "INVALID — the document does not match the signature (modified after signing, or the signature is broken)",
+        _ =>
+            "could not be verified (malformed or unsupported signature)"
+    };
+
+    private static string FormatTrustStatus(SignatureVerificationResult result)
+    {
+        var details = string.IsNullOrWhiteSpace(result.TrustDetails)
+            ? string.Empty
+            : $" — {result.TrustDetails}";
+
+        return result.TrustStatus switch
+        {
+            SignatureTrustStatus.Trusted => $"trusted{details}",
+            SignatureTrustStatus.Untrusted => $"UNTRUSTED{details}",
+            SignatureTrustStatus.Indeterminate => $"could not be evaluated{details}",
+            _ => "not evaluated (requires a cryptographically valid signature)"
+        };
+    }
 
     private static string FormatByteRangeStructureStatus(SignatureVerificationResult result)
     {

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Build the packages locally with `dotnet pack -c Release` (they are also attached
 - **AcroForm authoring** — drag-rect on a page to create new fields (Text / Checkbox / Choice / Signature); auto-detect underline placeholders and empty squares as fields
 - **Annotation review tools** — highlight selected text and add sticky notes as real PDF annotations
 - Reveal Hidden Text — yellow highlights for structural detections (text covered by rectangles), orange for differential-OCR recoveries (text inside rasterized images)
-- Digital signature inspection — checks ByteRange structure, verifies the detached CMS digest/signature over the signed bytes, and clearly reports current OS trust-chain validation limitations
+- Digital signature inspection — checks ByteRange structure, verifies the detached CMS digest/signature over the signed bytes, validates the signer certificate chain against the OS trust store (distinguishing valid-and-trusted from valid-but-untrusted, modified, and unverifiable signatures), and clearly reports remaining OS trust-chain validation limitations (revocation is not checked)
 - Bates numbering
 - CLI-first automation with stable JSON, batch workflows, progress NDJSON, and
   AppleScript/Shortcuts, PowerShell/Power Automate, and Linux/GNOME examples
@@ -170,9 +170,13 @@ release notes:
   that image from your OS's own viewer, which already has a real, tested
   print pipeline. Revisit only if real user demand shows up — see #621 for
   the full reasoning.
-- **Digital signatures** — excise checks ByteRange structure and verifies the
-  detached CMS signature/digest over the signed bytes, but does not evaluate the
-  signer certificate chain against the OS trust store yet (#466).
+- **Digital signatures** — excise checks ByteRange structure, verifies the
+  detached CMS signature/digest over the signed bytes, and evaluates the signer
+  certificate chain against the OS trust store, reporting a consolidated state
+  (valid+trusted / valid-but-untrusted / invalid / indeterminate). Certificate
+  revocation (CRL/OCSP) is deliberately not checked — it would require network
+  access — and timestamp/LTV (long-term validation) material is not evaluated
+  (#466).
 - **Rendering fidelity** — the current release dashboard classifies every
   contracted page as release `PASS`. Remaining non-exact rows are issue-linked
   accepted-reference matches, malformed-input/refusal classifications, or named


### PR DESCRIPTION
#466 (interop/security frontier): signature verification now evaluates **certificate trust**, not just cryptographic validity, and reports a clear consolidated state. Excise.App-only.

## Change
- **`SignatureTrustEvaluator.cs`** (new): builds the signer chain with `X509Chain` (OS trust store by default; **injectable explicit trust anchors** via `CustomRootTrust` for deterministic tests). CMS-embedded certs feed `ExtraStore` so intermediates resolve offline. `RevocationMode = NoCheck` (offline by design, disclosed in the summary).
- **`SignatureVerificationService.cs`**: result gains `TrustStatus`/`TrustDetails` and a **derived** `State`: `ValidTrusted` / `ValidUntrusted` / `ValidTrustUnknown` / `Invalid` (modified/broken) / `Indeterminate` (unverifiable). Signing time now read from CMS signed attributes.
- **`SignatureVerificationSummaryFormatter.cs`**: 'Overall:' headline + explicit trust-chain line; 'trusted signer' wording reserved for `ValidTrusted`.

## Validity semantics preserved
The `IsValid`/ByteRange/CMS logic is **byte-for-byte untouched** — trust is additive. `State` is derived (never stored), so `ValidTrusted` is structurally unreachable without a crypto-valid signature over the correct byte range (a defensive test asserts a forged `Trusted` on an invalid result still yields `Invalid`).

## Verification (mine)
| Gate | Result |
|---|---|
| Build | **0 warnings** |
| Signature + `DocumentationClaimTests` | **90/90** (README/CHANGELOG trust wording pinned) |
| Redaction (unaffected) | Core 189/0 |
| Tests | deterministic: in-process `TestCertificateFactory` (root-CA→leaf + self-signed), no network / no machine-trust-store dependence; exhaustive no-overclaim invariant over every `IsValid × TrustStatus` |

## Follow-ups (issue-worthy)
CRL/OCSP revocation, timestamp-token/LTV, a GUI affordance for user-pinned trust anchors (evaluator already supports injected anchors), post-signing modification detection beyond `CoversWholeDocument`.

Refs #466

🤖 Generated with [Claude Code](https://claude.com/claude-code)