### PR TITLE
feat(text): reorder digit islands inside RTL lines to logical order — #632 (redaction-correctness)

### DIFF
--- a/Excise.Core.Tests/Text/RtlTextExtractionTests.cs
+++ b/Excise.Core.Tests/Text/RtlTextExtractionTests.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Linq;
 using System.Text;
 using AwesomeAssertions;
 using Excise.Core.Document;
@@ -98,6 +99,141 @@ public class RtlTextExtractionTests
 }
 
 /// <summary>
+/// Numbers inside RTL lines (#632, digit-island slice). Digits are bidi-WEAK:
+/// inside an RTL line they render left-to-right (least-significant digit on
+/// the left boundary of the number, "30" still reads "30") while the words
+/// around them run right-to-left. A visual-order stream therefore carries the
+/// LINE's segments in reverse logical order but each number's digits in
+/// logical order.
+///
+/// Before this slice the reorderer terminated runs at digits, so each RTL
+/// word came out logically ordered but the words' order ACROSS a number
+/// stayed visual: logical "عمر 30 سنة" extracted as "سنة 30 عمر". Any
+/// phrase needle spanning a number — name + ID number, date lines, phone
+/// numbers, exactly the redaction-relevant content of Arabic/Hebrew
+/// government documents — silently matched nothing, and RedactText
+/// reported success (CLAUDE.md limitation #1 in its RTL form).
+///
+/// Expected strings are hand-derived from the Unicode Bidirectional
+/// Algorithm (UAX #9: P2/P3 paragraph level from the first strong character;
+/// W2 EN→AN after Arabic letters; W4 single common separator between digits
+/// joins the number; I1/I2 number runs at even embedding level; L2 run
+/// reversal) — the spec is the oracle, not excise. Corroborated against
+/// mutool 1.27 (`mutool draw -F txt`) on these exact fixture bytes.
+/// </summary>
+public class RtlDigitIslandExtractionTests
+{
+    // Logical: "عمر 30 سنة" (age 30 years) — word, European number, word.
+    private static readonly int[] MixedLogical =
+        { 0x0639, 0x0645, 0x0631, 0x0020, '3', '0', 0x0020, 0x0633, 0x0646, 0x0629 };
+
+    // Visual (left→right): [ةنس] [30] [رمع] — the trailing word's glyphs
+    // leftmost and reversed, the number's digits in logical order, the
+    // leading word's glyphs rightmost and reversed.
+    private static readonly int[] MixedVisual =
+        { 0x0629, 0x0646, 0x0633, 0x0020, '3', '0', 0x0020, 0x0631, 0x0645, 0x0639 };
+
+    private static string S(int[] scalars) =>
+        string.Concat(scalars.Select(char.ConvertFromUtf32));
+
+    [Fact]
+    public void ArabicWordsAroundNumber_VisualOrderLine_ExtractsLogicalOrder()
+    {
+        var pdf = RtlPdfFixtures.SingleTjScalarStream(MixedVisual);
+        using var doc = PdfDocument.Open(pdf);
+
+        var text = new TextExtractor(doc.GetPage(1)).ExtractText();
+
+        text.Should().Be(S(MixedLogical),
+            "segments of an RTL line reverse to logical order while each number keeps its digits in place");
+    }
+
+    [Fact]
+    public void TrailingNumber_VisualOrderLine_ExtractsLogicalOrder()
+    {
+        // Logical "هاتف 123" (phone 123): the number is logically LAST, so in
+        // visual order its digits are the FIRST glyphs of the stream — a
+        // leading digit island that must join the RTL segment reversal.
+        int[] logical = { 0x0647, 0x0627, 0x062A, 0x0641, 0x0020, '1', '2', '3' };
+        int[] visual = { '1', '2', '3', 0x0020, 0x0641, 0x062A, 0x0627, 0x0647 };
+        var pdf = RtlPdfFixtures.SingleTjScalarStream(visual);
+        using var doc = PdfDocument.Open(pdf);
+
+        new TextExtractor(doc.GetPage(1)).ExtractText().Should().Be(S(logical));
+    }
+
+    [Fact]
+    public void DecimalNumber_VisualOrderLine_KeepsSeparatorInsideNumber()
+    {
+        // Logical "وزن 2.5" (weight 2.5). UBA W4: a single common separator
+        // between two digits is part of the number — "2.5" must survive as
+        // "2.5", not "5.2" or "2 . 5".
+        int[] logical = { 0x0648, 0x0632, 0x0646, 0x0020, '2', '.', '5' };
+        int[] visual = { '2', '.', '5', 0x0020, 0x0646, 0x0632, 0x0648 };
+        var pdf = RtlPdfFixtures.SingleTjScalarStream(visual);
+        using var doc = PdfDocument.Open(pdf);
+
+        new TextExtractor(doc.GetPage(1)).ExtractText().Should().Be(S(logical));
+    }
+
+    [Fact]
+    public void ArabicIndicDigits_VisualOrderLine_ExtractsLogicalOrder()
+    {
+        // Same line with Arabic-Indic digits (U+0660.., bidi class AN):
+        // logical "عمر ٣٠ سنة". AN digits also render left-to-right inside
+        // the RTL line, so the stream carries them in logical order too.
+        int[] logical = { 0x0639, 0x0645, 0x0631, 0x0020, 0x0663, 0x0660, 0x0020, 0x0633, 0x0646, 0x0629 };
+        int[] visual = { 0x0629, 0x0646, 0x0633, 0x0020, 0x0663, 0x0660, 0x0020, 0x0631, 0x0645, 0x0639 };
+        var pdf = RtlPdfFixtures.SingleTjScalarStream(visual);
+        using var doc = PdfDocument.Open(pdf);
+
+        new TextExtractor(doc.GetPage(1)).ExtractText().Should().Be(S(logical));
+    }
+
+    [Fact]
+    public void StrongLatinOnLine_DigitsStayWithTheLatinContext()
+    {
+        // Visual stream "abc 123" + reversed Arabic. With a strong-LTR
+        // character on the line the paragraph is LTR (UBA P2/P3) and W7 binds
+        // the digits to the Latin context: logical is "abc 123 سلام" — the
+        // digits must NOT travel with the Arabic word. This is the guard that
+        // digit-island joining only applies to RTL-directed lines.
+        int[] visual = { 'a', 'b', 'c', 0x0020, '1', '2', '3', 0x0020, 0x0645, 0x0627, 0x0644, 0x0633 };
+        var pdf = RtlPdfFixtures.SingleTjScalarStream(visual);
+        using var doc = PdfDocument.Open(pdf);
+
+        new TextExtractor(doc.GetPage(1)).ExtractText().Should().Be("abc 123 سلام");
+    }
+
+    [Fact]
+    public void PureNumberLine_IsNeverTouched()
+    {
+        int[] visual = { '4', '2', '.', '5', '0' };
+        var pdf = RtlPdfFixtures.SingleTjScalarStream(visual);
+        using var doc = PdfDocument.Open(pdf);
+
+        new TextExtractor(doc.GetPage(1)).ExtractText().Should().Be("42.50",
+            "a line with no strong-RTL letter must never be reordered");
+    }
+
+    [Fact]
+    public void LogicalOrderStream_DecreasingX_WithNumber_IsNotDisturbed()
+    {
+        // The other producer encoding: logical-order codes with every glyph
+        // positioned explicitly. The Arabic word descends from the right; the
+        // number sits to its left with its digits ascending locally (that is
+        // how digits render inside an RTL line). Net descending X ⇒ already
+        // logical ⇒ untouched.
+        int[] logical = { 0x0639, 0x0645, 0x0631, '3', '0' };
+        int[] xPositions = { 200, 188, 176, 140, 152 };
+        var pdf = RtlPdfFixtures.PerGlyphAtPositions(logical, xPositions);
+        using var doc = PdfDocument.Open(pdf);
+
+        new TextExtractor(doc.GetPage(1)).ExtractText().Should().Be(S(logical));
+    }
+}
+
+/// <summary>
 /// Minimal RTL fixture PDFs with a deterministic /ToUnicode CMap: character
 /// codes 0x41... ('A', 'B', ...) map to the given Unicode scalars in LOGICAL
 /// order, so the stream's byte order fully controls extraction order and the
@@ -105,6 +241,36 @@ public class RtlTextExtractionTests
 /// </summary>
 internal static class RtlPdfFixtures
 {
+    /// <summary>
+    /// One Tj whose glyphs paint the given Unicode scalars left-to-right in
+    /// exactly the given STREAM order (positive advances). Character codes
+    /// 0x41.. are assigned positionally, so the stream's byte order — and
+    /// nothing else — controls extraction order. Limited to 26 glyphs (codes
+    /// 'A'..'Z') so the content-stream literal never needs escaping.
+    /// </summary>
+    public static byte[] SingleTjScalarStream(params int[] scalarsInStreamOrder)
+    {
+        var codes = Codes(scalarsInStreamOrder.Length);
+        var content = $"BT /F1 24 Tf 100 700 Td ({new string(codes)}) Tj ET";
+        return Build(content, scalarsInStreamOrder);
+    }
+
+    /// <summary>
+    /// Logical-order scalars, one Tj per glyph, each positioned explicitly at
+    /// the given X (Y fixed at 700). Models producers that write logical-order
+    /// codes and place every glyph — including LTR-rendered digits inside an
+    /// RTL line — at its visual position.
+    /// </summary>
+    public static byte[] PerGlyphAtPositions(int[] logicalScalars, int[] xPositions)
+    {
+        var codes = Codes(logicalScalars.Length);
+        var sb = new StringBuilder("BT /F1 24 Tf");
+        for (int i = 0; i < codes.Length; i++)
+            sb.Append($" 1 0 0 1 {xPositions[i]} 700 Tm ({codes[i]}) Tj");
+        sb.Append(" ET");
+        return Build(sb.ToString(), logicalScalars);
+    }
+
     /// <summary>
     /// One Tj painting the word left-to-right with positive advances.
     /// <paramref name="visualOrder"/> true = codes reversed (leftmost glyph is

--- a/Excise.Core.Tests/Text/Segmentation/RtlRedactionTests.cs
+++ b/Excise.Core.Tests/Text/Segmentation/RtlRedactionTests.cs
@@ -99,12 +99,127 @@ public class RtlRedactionTests
     /// <summary>
     /// Carrier-agnostic view of the saved file, per the redaction test rules:
     /// ASCII (name-tree strings, raw codes, hex-encoded carriers stay visible)
-    /// concatenated with UTF-16BE (how PDF text strings carry Unicode).
+    /// concatenated with UTF-16BE (how PDF text strings carry Unicode) and
+    /// UTF-8 (metadata streams).
     /// </summary>
     private static string SearchableTextOf(byte[] saved) =>
-        Encoding.ASCII.GetString(saved) + Encoding.BigEndianUnicode.GetString(saved);
+        Encoding.ASCII.GetString(saved) +
+        Encoding.BigEndianUnicode.GetString(saved) +
+        Encoding.UTF8.GetString(saved);
 
     private static string Reverse(string s)
+    {
+        var chars = s.ToCharArray();
+        System.Array.Reverse(chars);
+        return new string(chars);
+    }
+}
+
+/// <summary>
+/// RedactText on phrases that SPAN A NUMBER inside an RTL line (#632,
+/// digit-island slice) — the ID-line / date-line / phone-number case that is
+/// the redaction-relevant content of Arabic and Hebrew government documents.
+///
+/// Before the digit-island reorder, each RTL word extracted logically but the
+/// word order ACROSS the number stayed visual ("عمر 30 سنة" extracted as
+/// "سنة 30 عمر"), so a logical-order phrase needle matched nothing and
+/// RedactText returned 0 while reporting success — the silent-failure mode
+/// this suite exists to prevent.
+///
+/// Assertions follow the redaction test rules: the saved BYTES are searched
+/// (ASCII, UTF-16BE and UTF-8) for the phrase in logical order, fully
+/// reversed visual order, per-run reversed order, and the fixture's known
+/// raw character-code carrier.
+/// </summary>
+public class RtlDigitIslandRedactionTests
+{
+    // Logical "عمر 30 سنة"; the fixture stores it in visual order (see
+    // RtlDigitIslandExtractionTests for the UBA derivation). Stream codes are
+    // 'A'..'J' assigned positionally, so the raw-code carrier of the full
+    // line is "ABCDEFGHIJ".
+    private static readonly int[] MixedVisual =
+        { 0x0629, 0x0646, 0x0633, 0x0020, '3', '0', 0x0020, 0x0631, 0x0645, 0x0639 };
+
+    private const string LogicalPhrase = "عمر 30 سنة";
+
+    [Fact]
+    public void RedactText_LogicalPhraseSpanningNumber_RemovesVisualOrderLine()
+    {
+        var pdf = RtlPdfFixtures.SingleTjScalarStream(MixedVisual);
+        using var doc = PdfDocument.Open(pdf);
+
+        // Sanity: extraction must read the phrase logically, and the raw-code
+        // carrier must be present, or the absence assertions prove nothing.
+        doc.GetPage(1).Text.Should().Contain(LogicalPhrase);
+        SearchableTextOf(doc.SaveToBytes()).Should().Contain("ABCDEFGHIJ");
+
+        var removed = doc.RedactText(LogicalPhrase);
+
+        removed.Should().BeGreaterThan(0,
+            "a logical-order phrase spanning a number must match the visual-order line; " +
+            "0 matches is the silent-failure mode this test exists to prevent");
+
+        var searchable = SearchableTextOf(doc.SaveToBytes());
+        searchable.Should().NotContain(LogicalPhrase, "the phrase must not survive in logical order");
+        searchable.Should().NotContain(ReverseString(LogicalPhrase), "nor fully reversed");
+        searchable.Should().NotContainAny("سنة", "عمر", "ةنس", "رمع");
+        searchable.Should().NotContain("ABCDEFGHIJ", "nor as its raw character codes");
+        searchable.Should().NotContain("JIHGFEDCBA");
+
+        using var reopened = PdfDocument.Open(doc.SaveToBytes());
+        reopened.GetPage(1).Text.Should().NotContainAny(LogicalPhrase, ReverseString(LogicalPhrase));
+    }
+
+    [Fact]
+    public void RedactText_NumberOnly_RemovesTheNumberAndKeepsTheWords()
+    {
+        var pdf = RtlPdfFixtures.SingleTjScalarStream(MixedVisual);
+        using var doc = PdfDocument.Open(pdf);
+
+        // The number's stream codes are 'E' ('3') and 'F' ('0').
+        SearchableTextOf(doc.SaveToBytes()).Should().Contain("DEF");
+
+        var removed = doc.RedactText("30");
+
+        removed.Should().BeGreaterThan(0);
+
+        var searchable = SearchableTextOf(doc.SaveToBytes());
+        searchable.Should().NotContain("DEF",
+            "the number's raw character codes must be gone from the saved bytes");
+
+        using var reopened = PdfDocument.Open(doc.SaveToBytes());
+        reopened.GetPage(1).Text.Should().NotContain("30");
+    }
+
+    [Fact]
+    public void RedactText_HebrewPhraseWithTrailingNumber_RemovesVisualOrderLine()
+    {
+        // Logical "טלפון 123" (phone 123): trailing number ⇒ the digits are
+        // the FIRST glyphs of the visual stream (leading digit island).
+        int[] visual = { '1', '2', '3', 0x0020, 0x05DF, 0x05D5, 0x05E4, 0x05DC, 0x05D8 };
+        const string logicalPhrase = "טלפון 123";
+        var pdf = RtlPdfFixtures.SingleTjScalarStream(visual);
+        using var doc = PdfDocument.Open(pdf);
+
+        doc.GetPage(1).Text.Should().Contain(logicalPhrase);
+
+        var removed = doc.RedactText(logicalPhrase);
+
+        removed.Should().BeGreaterThan(0);
+
+        var searchable = SearchableTextOf(doc.SaveToBytes());
+        searchable.Should().NotContain(logicalPhrase);
+        searchable.Should().NotContain(ReverseString(logicalPhrase));
+        searchable.Should().NotContain("טלפון");
+        searchable.Should().NotContain("ABCDEFGHI", "nor as its raw character codes");
+    }
+
+    private static string SearchableTextOf(byte[] saved) =>
+        Encoding.ASCII.GetString(saved) +
+        Encoding.BigEndianUnicode.GetString(saved) +
+        Encoding.UTF8.GetString(saved);
+
+    private static string ReverseString(string s)
     {
         var chars = s.ToCharArray();
         System.Array.Reverse(chars);

--- a/Excise.Core/Text/BidiReorderer.cs
+++ b/Excise.Core/Text/BidiReorderer.cs
@@ -25,19 +25,37 @@ namespace Excise.Core.Text;
 ///   DECREASE. Stream order is already correct and must not be touched.</item>
 /// </list>
 /// <para>
-/// The rule implemented here is the same geometric one mutool applies
-/// (verified against mutool 1.27 on both stream orders): find each maximal
-/// same-line run of strong-RTL letters (neutrals such as spaces and
-/// punctuation join a run only between two strong-RTL letters), and reverse
-/// the run when its X positions ascend — i.e. when stream order is visual
-/// order. Descending-X runs are already logical and pass through unchanged.
+/// The base rule: find each maximal same-line run of strong-RTL letters
+/// (neutrals such as spaces and punctuation join a run only between two
+/// members), and reverse the run when its X positions ascend — i.e. when
+/// stream order is visual order. Descending-X runs are already logical and
+/// pass through unchanged.
 /// </para>
 /// <para>
-/// This is deliberately NOT a full Unicode Bidirectional Algorithm: digits
-/// (European and Arabic-Indic — both bidi-weak) and strong-LTR letters
-/// terminate a run, so each RTL word still comes out logically ordered and
-/// searchable, but the relative placement of numbers inside a mixed-direction
-/// line is not re-derived. Full UBA remains scoped under #632.
+/// <b>Digit islands (UAX #9 weak types, #632 second slice).</b> Digits are
+/// bidi-WEAK: inside an RTL line a number renders left-to-right while the
+/// words around it run right-to-left, so a visual-order stream carries the
+/// line's segments in reverse logical order but each number's digits in
+/// logical order. On lines whose strong characters are all RTL (the UAX #9
+/// P2/P3 first-strong rule collapses to "no strong-LTR present"), digit
+/// islands — including single common/European separators between digits,
+/// rule W4 — therefore JOIN the reversible run as order-preserving blocks:
+/// the run's segments reverse, the number's digits do not. Without this,
+/// logical "عمر 30 سنة" extracted as "سنة 30 عمر" and a phrase needle
+/// spanning the number (ID lines, dates, phone numbers) silently evaded
+/// <c>RedactText</c>. When a strong-LTR character shares the line, digits
+/// bind to the LTR context (rule W7) and the pre-existing conservative rule
+/// (digits terminate runs) applies unchanged. Expected orderings are
+/// spec-derived and verified against the python-bidi UAX #9 reference
+/// implementation; NOTE mutool 1.27 is NOT an oracle for digit placement —
+/// its bidi is a per-run heuristic that leaves digit islands in stream
+/// position and reverses Arabic-Indic digit pairs.
+/// </para>
+/// <para>
+/// This is still deliberately NOT a full Unicode Bidirectional Algorithm:
+/// lines mixing strong-LTR and strong-RTL words fall back to per-run
+/// reversal, and explicit bidi controls (LRE/RLE/LRI/RLI/PDF) are not
+/// honoured. Full UBA remains scoped under #632.
 /// </para>
 /// </remarks>
 internal static class BidiReorderer
@@ -49,69 +67,153 @@ internal static class BidiReorderer
     private const double SameLineToleranceY = 5.0;
 
     /// <summary>
-    /// Reverse, in place, every maximal same-line strong-RTL run whose X
+    /// UAX #9 bidi character classes, collapsed to what the reorderer needs.
+    /// </summary>
+    private enum BidiClass : byte
+    {
+        /// <summary>Strong RTL (bidi classes R and AL).</summary>
+        StrongRtl,
+        /// <summary>Digits (bidi classes EN and AN).</summary>
+        Digit,
+        /// <summary>Whitespace, punctuation, symbols (neutral/weak).</summary>
+        Neutral,
+        /// <summary>Everything else — strong-LTR letters, CJK, unclassified.</summary>
+        Other,
+    }
+
+    /// <summary>
+    /// Reorder, in place, every maximal same-line strong-RTL run whose X
     /// positions ascend (stream order = visual order), producing logical
     /// order. Runs whose X positions descend are already logical and are
-    /// left untouched.
+    /// left untouched. On lines with no strong-LTR content, digit islands
+    /// join the run as order-preserving blocks (see class remarks).
     /// </summary>
     internal static void ReorderVisualRtlRuns(List<Letter> letters)
     {
-        int i = 0;
-        while (i < letters.Count)
+        int n = letters.Count;
+        if (n == 0) return;
+
+        var classes = new BidiClass[n];
+        for (int i = 0; i < n; i++) classes[i] = Classify(letters[i]);
+
+        // Process one line segment at a time: pairwise same-line chaining,
+        // identical to the run-extension rule this replaces.
+        int segStart = 0;
+        for (int i = 1; i <= n; i++)
         {
-            if (!IsStrongRtlLetter(letters[i]))
+            if (i == n || !IsSameLine(letters[i - 1], letters[i]))
+            {
+                ReorderLineSegment(letters, classes, segStart, i - 1);
+                segStart = i;
+            }
+        }
+    }
+
+    private static void ReorderLineSegment(
+        List<Letter> letters, BidiClass[] classes, int segStart, int segEnd)
+    {
+        bool anyRtl = false;
+        bool joinDigits = true;
+        for (int k = segStart; k <= segEnd; k++)
+        {
+            if (classes[k] == BidiClass.StrongRtl) anyRtl = true;
+            else if (classes[k] == BidiClass.Other) joinDigits = false;
+        }
+        if (!anyRtl) return;
+
+        int i = segStart;
+        while (i <= segEnd)
+        {
+            var c = classes[i];
+            bool starter = c == BidiClass.StrongRtl ||
+                           (joinDigits && c == BidiClass.Digit);
+            if (!starter)
             {
                 i++;
                 continue;
             }
 
-            // Extend the run: strong-RTL letters, plus neutrals strictly
-            // BETWEEN two strong-RTL letters (end stays on the last strong
-            // one, so trailing neutrals never join). Any other character —
-            // Latin letters, digits — terminates the run.
-            int end = i;
+            // Extend the run: strong-RTL letters (and digits, when joining),
+            // plus neutrals strictly BETWEEN two members (end stays on the
+            // last member, so trailing neutrals never join). Any other
+            // character terminates the run.
+            int start = i, end = i;
+            bool hasRtl = c == BidiClass.StrongRtl;
             int j = i + 1;
-            while (j < letters.Count && IsSameLine(letters[j - 1], letters[j]))
+            while (j <= segEnd)
             {
-                if (IsStrongRtlLetter(letters[j])) { end = j; j++; }
-                else if (IsNeutralLetter(letters[j])) { j++; }
+                var cj = classes[j];
+                if (cj == BidiClass.StrongRtl) { end = j; hasRtl = true; j++; }
+                else if (joinDigits && cj == BidiClass.Digit) { end = j; j++; }
+                else if (cj == BidiClass.Neutral) { j++; }
                 else break;
             }
 
             // Ascending X ⇒ the stream painted the run left-to-right, i.e.
-            // visual order; reversing yields logical order. Descending X ⇒
+            // visual order; reordering yields logical order. Descending X ⇒
             // already logical (glyphs positioned right-to-left explicitly).
-            if (end > i && letters[end].StartX > letters[i].StartX)
-                letters.Reverse(i, end - i + 1);
+            // Digit-only stretches (hasRtl false) are never touched.
+            if (hasRtl && end > start && letters[end].StartX > letters[start].StartX)
+            {
+                var map = BuildRunReversalMap(
+                    start, end,
+                    k => classes[k],
+                    k => IsNumberSeparatorLetter(letters[k]));
+                var copy = letters.GetRange(start, end - start + 1);
+                for (int k = start; k <= end; k++)
+                    letters[map[k - start]] = copy[k - start];
+            }
 
             i = end + 1;
         }
     }
 
     /// <summary>
-    /// Apply the same run-reversal to a plain string (no geometry available,
-    /// so ascending X — the visual-order case — is assumed). Used to bridge
-    /// between raw content-stream operator text (visual order) and the
-    /// logically-ordered page letter sequence: applying this to an operator's
-    /// decoded text reproduces what <see cref="ReorderVisualRtlRuns"/> did to
-    /// its letters.
+    /// Apply the same run reordering to a plain string (no geometry
+    /// available, so ascending X — the visual-order case — is assumed, and
+    /// the whole string is treated as one line). Used to bridge between raw
+    /// content-stream operator text (visual order) and the logically-ordered
+    /// page letter sequence: applying this to an operator's decoded text
+    /// reproduces what <see cref="ReorderVisualRtlRuns"/> did to its letters.
     /// </summary>
     internal static string ReverseRtlRunsInString(string text)
     {
         if (string.IsNullOrEmpty(text)) return text;
-        var map = BuildRtlRunPermutation(text);
-        var result = new char[text.Length];
-        for (int i = 0; i < text.Length; i++)
-            result[map[i]] = text[i];
-        return new string(result);
+        return ApplyPermutation(text, BuildRtlRunPermutation(text));
     }
 
     /// <summary>
-    /// Permutation for <see cref="ReverseRtlRunsInString"/>: element <c>i</c>
-    /// is the index the character at <c>i</c> moves to. Characters outside
-    /// RTL runs map to themselves.
+    /// Like <see cref="ReverseRtlRunsInString(string)"/> but with the
+    /// pre-digit-island rule: digits always terminate runs. The letter-side
+    /// reorder decides digit joining from the WHOLE line's content, which a
+    /// single operator's text cannot see (strong-LTR text elsewhere on the
+    /// line, split operators), so callers matching operator text should try
+    /// the primary form first and fall back to this one.
     /// </summary>
-    internal static int[] BuildRtlRunPermutation(string text)
+    internal static string ReverseRtlRunsInStringWithoutDigitJoining(string text)
+    {
+        if (string.IsNullOrEmpty(text)) return text;
+        return ApplyPermutation(text, BuildRtlRunPermutationWithoutDigitJoining(text));
+    }
+
+    /// <summary>
+    /// Permutation for <see cref="ReverseRtlRunsInString(string)"/>: element
+    /// <c>i</c> is the index the character at <c>i</c> moves to. Characters
+    /// outside RTL runs map to themselves. Digit islands join the runs as
+    /// order-preserving blocks unless the text contains strong-LTR content
+    /// (mirroring the line-level rule in <see cref="ReorderVisualRtlRuns"/>).
+    /// </summary>
+    internal static int[] BuildRtlRunPermutation(string text) =>
+        BuildStringPermutation(text, joinDigits: !ContainsOther(text));
+
+    /// <summary>
+    /// Permutation with the pre-digit-island rule (digits terminate runs);
+    /// see <see cref="ReverseRtlRunsInStringWithoutDigitJoining"/>.
+    /// </summary>
+    internal static int[] BuildRtlRunPermutationWithoutDigitJoining(string text) =>
+        BuildStringPermutation(text, joinDigits: false);
+
+    private static int[] BuildStringPermutation(string text, bool joinDigits)
     {
         var map = new int[text.Length];
         for (int k = 0; k < text.Length; k++) map[k] = k;
@@ -119,28 +221,95 @@ internal static class BidiReorderer
         int i = 0;
         while (i < text.Length)
         {
-            if (!IsStrongRtlChar(text[i]))
+            var c = Classify(text[i]);
+            bool starter = c == BidiClass.StrongRtl ||
+                           (joinDigits && c == BidiClass.Digit);
+            if (!starter)
             {
                 i++;
                 continue;
             }
 
-            int end = i;
+            int start = i, end = i;
+            bool hasRtl = c == BidiClass.StrongRtl;
             int j = i + 1;
             while (j < text.Length)
             {
-                if (IsStrongRtlChar(text[j])) { end = j; j++; }
-                else if (IsNeutralChar(text[j])) { j++; }
+                var cj = Classify(text[j]);
+                if (cj == BidiClass.StrongRtl) { end = j; hasRtl = true; j++; }
+                else if (joinDigits && cj == BidiClass.Digit) { end = j; j++; }
+                else if (cj == BidiClass.Neutral) { j++; }
                 else break;
             }
 
-            for (int k = i; k <= end; k++)
-                map[k] = i + end - k;
+            if (hasRtl && end > start)
+            {
+                var runMap = BuildRunReversalMap(
+                    start, end,
+                    k => Classify(text[k]),
+                    k => IsNumberSeparatorChar(text[k]));
+                for (int k = start; k <= end; k++)
+                    map[k] = runMap[k - start];
+            }
 
             i = end + 1;
         }
 
         return map;
+    }
+
+    /// <summary>
+    /// Destination map for one visual-order run [<paramref name="start"/>..
+    /// <paramref name="end"/>]: the run is mirrored, except that each digit
+    /// island — a maximal stretch of digits, absorbing a single number
+    /// separator flanked by digits (UAX #9 rule W4) — moves as a block with
+    /// its internal order preserved. Element <c>k - start</c> is the absolute
+    /// index the element at <c>k</c> moves to. With no digits present this is
+    /// a pure mirror, i.e. exactly the old whole-run reversal.
+    /// </summary>
+    private static int[] BuildRunReversalMap(
+        int start, int end, Func<int, BidiClass> classAt, Func<int, bool> isSeparatorAt)
+    {
+        var map = new int[end - start + 1];
+        int k = start;
+        while (k <= end)
+        {
+            if (classAt(k) == BidiClass.Digit)
+            {
+                int islandStart = k, islandEnd = k;
+                int j = k + 1;
+                while (j <= end)
+                {
+                    if (classAt(j) == BidiClass.Digit) { islandEnd = j; j++; }
+                    else if (isSeparatorAt(j) && j + 1 <= end && classAt(j + 1) == BidiClass.Digit)
+                    {
+                        islandEnd = j + 1;
+                        j += 2;
+                    }
+                    else break;
+                }
+
+                int destStart = start + end - islandEnd;
+                for (int m = islandStart; m <= islandEnd; m++)
+                    map[m - start] = destStart + (m - islandStart);
+                k = islandEnd + 1;
+            }
+            else
+            {
+                map[k - start] = start + end - k;
+                k++;
+            }
+        }
+
+        return map;
+    }
+
+    private static string ApplyPermutation(string text, int[] map)
+    {
+        var result = new char[text.Length];
+        for (int i = 0; i < text.Length; i++)
+            result[map[i]] = text[i];
+        return new string(result);
     }
 
     /// <summary>True when any character of <paramref name="text"/> is a strong-RTL character.</summary>
@@ -152,20 +321,41 @@ internal static class BidiReorderer
         return false;
     }
 
-    private static bool IsStrongRtlLetter(Letter letter)
+    private static bool ContainsOther(string text)
     {
-        if (string.IsNullOrEmpty(letter.Value)) return false;
-        foreach (var c in letter.Value)
-            if (IsStrongRtlChar(c)) return true;
+        foreach (var c in text)
+            if (Classify(c) == BidiClass.Other) return true;
         return false;
     }
 
-    private static bool IsNeutralLetter(Letter letter)
+    private static BidiClass Classify(char c)
     {
-        if (string.IsNullOrEmpty(letter.Value)) return false;
-        foreach (var c in letter.Value)
-            if (!IsNeutralChar(c)) return false;
-        return true;
+        if (IsDigitChar(c)) return BidiClass.Digit;
+        if (IsStrongRtlChar(c)) return BidiClass.StrongRtl;
+        if (IsNeutralChar(c)) return BidiClass.Neutral;
+        return BidiClass.Other;
+    }
+
+    private static BidiClass Classify(Letter letter)
+    {
+        var value = letter.Value;
+        if (string.IsNullOrEmpty(value)) return BidiClass.Other;
+
+        // Any strong-RTL scalar makes the letter strong-RTL (multi-char
+        // values come from ligature ToUnicode expansions).
+        foreach (var c in value)
+            if (IsStrongRtlChar(c)) return BidiClass.StrongRtl;
+
+        bool allDigits = true;
+        bool allNeutral = true;
+        foreach (var c in value)
+        {
+            if (!IsDigitChar(c)) allDigits = false;
+            if (!IsNeutralChar(c)) allNeutral = false;
+        }
+        if (allDigits) return BidiClass.Digit;
+        if (allNeutral) return BidiClass.Neutral;
+        return BidiClass.Other;
     }
 
     /// <summary>
@@ -184,6 +374,22 @@ internal static class BidiReorderer
         if (c >= '\uFE70' && c <= '\uFEFF') return true;  // Arabic presentation forms B
         return false;
     }
+
+    /// <summary>Digits: European (bidi EN) and Arabic-Indic (bidi AN).</summary>
+    private static bool IsDigitChar(char c) =>
+        (c >= '0' && c <= '9') ||
+        (c >= '\u0660' && c <= '\u0669') ||
+        (c >= '\u06F0' && c <= '\u06F9');
+
+    /// <summary>
+    /// UAX #9 number separators (classes CS and ES): a single one between
+    /// two digits is part of the number (rule W4) and travels with it.
+    /// </summary>
+    private static bool IsNumberSeparatorChar(char c) =>
+        c == '.' || c == ',' || c == ':' || c == '/' || c == '+' || c == '-';
+
+    private static bool IsNumberSeparatorLetter(Letter letter) =>
+        letter.Value is { Length: 1 } v && IsNumberSeparatorChar(v[0]);
 
     private static bool IsNeutralChar(char c) =>
         char.IsWhiteSpace(c) || char.IsPunctuation(c) || char.IsSymbol(c);

--- a/Excise.Core/Text/Segmentation/LetterFinder.cs
+++ b/Excise.Core/Text/Segmentation/LetterFinder.cs
@@ -84,7 +84,26 @@ public class LetterFinder
             var logicalText = BidiReorderer.ReverseRtlRunsInString(operationText);
             foundIndices = FindAllTextOccurrences(fullPageText, logicalText);
             if (foundIndices.Count > 0)
+            {
                 rtlPermutation = permutation;
+            }
+            else
+            {
+                // The primary permutation joins digit islands to RTL runs
+                // (#632); the letter-side reorder decides that from the WHOLE
+                // line, which this operator's text alone cannot see (strong-
+                // LTR in another operator on the same line, split operators).
+                // Fall back to the digits-stay-put permutation.
+                var conservative =
+                    BidiReorderer.ReverseRtlRunsInStringWithoutDigitJoining(operationText);
+                if (conservative != logicalText)
+                {
+                    foundIndices = FindAllTextOccurrences(fullPageText, conservative);
+                    if (foundIndices.Count > 0)
+                        rtlPermutation = BidiReorderer
+                            .BuildRtlRunPermutationWithoutDigitJoining(operationText);
+                }
+            }
         }
 
         if (foundIndices.Count == 0)

--- a/Excise.Core/Text/Segmentation/PdfDocumentRedactionExtensions.cs
+++ b/Excise.Core/Text/Segmentation/PdfDocumentRedactionExtensions.cs
@@ -167,10 +167,20 @@ public static class PdfDocumentRedactionExtensions
 
         // Operator text is raw content-stream order; RTL documents usually
         // store Arabic/Hebrew in VISUAL (reversed) order, so a logical-order
-        // needle must also be checked in its visual form (#632).
-        var visualNeedle = BidiReorderer.ContainsStrongRtl(searchText)
-            ? BidiReorderer.ReverseRtlRunsInString(searchText)
-            : null;
+        // needle must also be checked in its visual form (#632). Both visual
+        // forms are tried: with digit islands travelling with the RTL
+        // segments (RTL-directed line) and with digits left in place
+        // (strong-LTR elsewhere on the line) — the operator's own text
+        // cannot know which layout the page used.
+        string? visualNeedle = null;
+        string? visualNeedleDigitsApart = null;
+        if (BidiReorderer.ContainsStrongRtl(searchText))
+        {
+            visualNeedle = BidiReorderer.ReverseRtlRunsInString(searchText);
+            var alt = BidiReorderer.ReverseRtlRunsInStringWithoutDigitJoining(searchText);
+            if (alt != visualNeedle)
+                visualNeedleDigitsApart = alt;
+        }
 
         // The stream may also carry Arabic as shaped presentation forms
         // (#632), Latin ligature code points like ﬃ (#722), or decomposed
@@ -189,6 +199,8 @@ public static class PdfDocumentRedactionExtensions
                 var opText = op.TextContent ?? string.Empty;
                 if (opText.IndexOf(searchText, comparison) >= 0 ||
                     (visualNeedle != null && opText.IndexOf(visualNeedle, comparison) >= 0) ||
+                    (visualNeedleDigitsApart != null &&
+                     opText.IndexOf(visualNeedleDigitsApart, comparison) >= 0) ||
                     ContainsFolded(opText, foldedNeedle, comparison))
                 {
                     removed++;
@@ -225,8 +237,19 @@ public static class PdfDocumentRedactionExtensions
         if (MatchingNormalization.Fold(opText).IndexOf(foldedNeedle, comparison) >= 0)
             return true;
 
-        return BidiReorderer.ContainsStrongRtl(opText) &&
-               MatchingNormalization.Fold(BidiReorderer.ReverseRtlRunsInString(opText))
+        if (!BidiReorderer.ContainsStrongRtl(opText))
+            return false;
+
+        var logical = BidiReorderer.ReverseRtlRunsInString(opText);
+        if (MatchingNormalization.Fold(logical).IndexOf(foldedNeedle, comparison) >= 0)
+            return true;
+
+        // Second reading with digits left in place (see the visual-needle
+        // comment in RemoveTextShowingOperatorsContaining).
+        var logicalDigitsApart =
+            BidiReorderer.ReverseRtlRunsInStringWithoutDigitJoining(opText);
+        return logicalDigitsApart != logical &&
+               MatchingNormalization.Fold(logicalDigitsApart)
                    .IndexOf(foldedNeedle, comparison) >= 0;
     }
 


### PR DESCRIPTION
#632 slice: fix a **silent RTL redaction failure**. `BidiReorderer` already reordered single-run visual-order RTL→logical, but **digits terminated runs**, so word order *across a number* stayed visual: logical `عمر 30 سنة` extracted as `سنة 30 عمر`. A phrase needle spanning a number — **ID lines, dates, phone numbers** (the redaction-relevant content of RTL documents) — matched nothing, and `RedactText` returned 0 while reporting success (limitation #1 in its RTL form).

## Change (`Excise.Core/Text/BidiReorderer.cs`)
On lines whose strong characters are all RTL (UAX #9 P2/P3), digit islands (European + Arabic-Indic, absorbing a single separator like `2.5`) join the reversible run as **order-preserving blocks** — segments reverse, digits don't. Strong-LTR on the line ⇒ unchanged conservative rule (W7). Descending-X logical streams + digit-only lines untouched. Not full UBA (mixed LTR+RTL lines, bidi controls) — stays scoped under #632.

## Extractor/redaction-parser consistency
Both share `BidiReorderer`'s scanner (letter-side `ReorderVisualRtlRuns` ≡ string-side permutation). Since one operator can't see its whole line, `LetterFinder` + the operator-matching redaction paths (`PdfDocumentRedactionExtensions`) also fall back to the digits-stay-put permutation, so split-operator / Latin-elsewhere layouts still match.

## Oracles (not self-vouched)
Expected orderings hand-derived from **UAX #9** and verified against the **python-bidi** reference — all 6 fixtures match. **Honest finding: mutool 1.27 is NOT UBA-correct here** (leaves digit islands in stream position) — documented in code rather than claimed as corroboration. The redaction round-trip is independently verified: mutool extracts nothing from the redacted fixture.

## Verification (mine — redaction-critical battery)
| Gate | Result |
|---|---|
| Build | **0 warnings** (new members internal — no PublicApi change) |
| `verify-true-redaction.sh` | intact |
| **Extraction-parity (#645)** | 332 pages, **98.7% — unchanged** |
| **New RTL tests** | 18/18 — digit-island extraction (interior/leading/decimal/Arabic-Indic, Latin+pure-number+descending-X guards) + 3 redaction round-trips (Arabic phrase-spanning-number, number-only, Hebrew trailing-number) with **ASCII+UTF-16BE+UTF-8** saved-bytes checks; **red before the fix, green after** |
| Redaction suites | Core 192 · Rendering 44 · App 105 |
| Full `Excise.Core.Tests` | **3620 / 0 failed** |

## Follow-ups (within #632)
Full UBA for mixed strong-LTR+RTL lines; explicit bidi controls (LRE/RLE/LRI…); cross-operator reorder runs; line-level neutral (punctuation) placement.

Refs #632

🤖 Generated with [Claude Code](https://claude.com/claude-code)