### PR TITLE
ci: stabilize Excise.Avalonia.Tests on Linux (xvfb) + skip-not-crash session guard — #752

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,9 @@ jobs:
           ~/verapdf/verapdf --version
 
       - name: Install xvfb for headless UI tests
-        if: steps.changes.outputs.gui == 'true' || github.ref == 'refs/heads/develop'
+        # Unconditional (was gated on the gui paths-filter): the always-run
+        # Excise.Avalonia.Tests step below also needs xvfb since the #631
+        # HeadlessUnitTestSession accessibility tests joined it (#752).
         run: sudo apt-get install -y xvfb
 
       - name: Restore packages
@@ -197,8 +199,13 @@ jobs:
         # logic). Deliberately separate from the heavy, flaky headless
         # Excise.App.Tests suite so viewer-library changes get reliable coverage
         # on every PR. (#363, #384)
+        #
+        # xvfb-run (#752): the #631 accessibility tests drive a real
+        # HeadlessUnitTestSession app lifecycle, which crashed the test host on
+        # the displayless Linux runner (killing the whole assembly with no
+        # captured output). Same precedent as the Excise.App.Tests step below.
         run: |
-          dotnet test Excise.Avalonia.Tests --no-build -c Debug \
+          xvfb-run -a dotnet test Excise.Avalonia.Tests --no-build -c Debug \
             --logger "console;verbosity=normal"
 
       - name: Run Excise.Rendering.Tests (deterministic only)

--- a/Excise.Avalonia.Tests/HeadlessSessionGuard.cs
+++ b/Excise.Avalonia.Tests/HeadlessSessionGuard.cs
@@ -1,0 +1,87 @@
+using Avalonia.Headless;
+
+namespace Excise.Avalonia.Tests;
+
+/// <summary>
+/// Startup guard for the shared <see cref="HeadlessUnitTestSession"/> used by
+/// the automation-peer tests (#631). On CI environments where the headless
+/// Avalonia app lifecycle cannot start (observed on the displayless Linux
+/// runner, intermittently on macOS — #752), a session-start failure must fail
+/// or skip only the tests that need the session, never take down the whole
+/// test host: a crashing host kills the assembly's other, unrelated tests
+/// with no captured output, which is the worst possible outcome.
+///
+/// The guard starts the session once (lazily), verifies it can actually
+/// dispatch work with a bounded no-op probe, and converts any managed startup
+/// failure into a dynamic skip with the underlying reason. Test-body
+/// exceptions are never touched — assertions still fail loudly.
+/// </summary>
+internal static class HeadlessSessionGuard
+{
+    /// <summary>Outcome of a guarded session start: exactly one of
+    /// <paramref name="Session"/> / <paramref name="StartupFailure"/> is set.</summary>
+    internal sealed record StartResult<T>(T? Session, Exception? StartupFailure) where T : class;
+
+    private static readonly Lazy<StartResult<HeadlessUnitTestSession>> Holder = new(
+        () => TryStart(
+            () => HeadlessUnitTestSession.GetOrStartForAssembly(typeof(HeadlessTestApp).Assembly),
+            ProbeDispatch),
+        LazyThreadSafetyMode.ExecutionAndPublication);
+
+    /// <summary>
+    /// The shared assembly session, or a dynamic xunit skip (never a crash)
+    /// if it could not be started on this platform.
+    /// </summary>
+    public static HeadlessUnitTestSession Session() =>
+        SessionOrSkip(Holder.Value, nameof(HeadlessUnitTestSession));
+
+    /// <summary>
+    /// Runs <paramref name="start"/> then <paramref name="probe"/>, capturing
+    /// any exception as a recorded startup failure instead of propagating it.
+    /// Factored out (and internal) so the skip-not-crash contract is unit
+    /// testable without needing a platform where startup actually fails.
+    /// </summary>
+    internal static StartResult<T> TryStart<T>(Func<T> start, Action<T> probe) where T : class
+    {
+        try
+        {
+            var session = start();
+            probe(session);
+            return new StartResult<T>(session, null);
+        }
+        catch (Exception ex)
+        {
+            return new StartResult<T>(null, ex);
+        }
+    }
+
+    /// <summary>
+    /// Returns the started session, or throws xunit's dynamic-skip exception
+    /// (not the original startup failure) so only session-dependent tests are
+    /// skipped, with the real reason preserved in the skip message.
+    /// </summary>
+    internal static T SessionOrSkip<T>(StartResult<T> result, string what) where T : class
+    {
+        if (result.Session is null)
+        {
+            var failure = result.StartupFailure!;
+            Assert.Skip(
+                $"{what} could not start on this platform " +
+                $"({failure.GetType().Name}: {failure.Message}); " +
+                "skipping the accessibility-peer tests instead of crashing the test host (#752).");
+        }
+
+        return result.Session;
+    }
+
+    /// <summary>
+    /// Bounded no-op dispatch proving the session's UI thread is actually
+    /// serving work — a session that starts but never dispatches would
+    /// otherwise hang every test (#93-style missing-timeout trap).
+    /// </summary>
+    private static void ProbeDispatch(HeadlessUnitTestSession session)
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        session.Dispatch(() => true, cts.Token).GetAwaiter().GetResult();
+    }
+}

--- a/Excise.Avalonia.Tests/HeadlessSessionGuardTests.cs
+++ b/Excise.Avalonia.Tests/HeadlessSessionGuardTests.cs
@@ -1,0 +1,89 @@
+using AwesomeAssertions;
+
+namespace Excise.Avalonia.Tests;
+
+/// <summary>
+/// Contract tests for <see cref="HeadlessSessionGuard"/> (#752): a headless
+/// session that cannot start must surface as a per-test dynamic skip carrying
+/// the real failure reason — never as a propagated exception (which xunit
+/// reports as failure of whichever test touched the session first) and never
+/// as a test-host crash. Simulated with throwing delegates because the real
+/// failure only reproduces on a displayless CI runner.
+/// </summary>
+public class HeadlessSessionGuardTests
+{
+    [Fact]
+    public void TryStart_CapturesStartFailure_InsteadOfPropagating()
+    {
+        var result = HeadlessSessionGuard.TryStart<object>(
+            () => throw new InvalidOperationException("no display"),
+            _ => { });
+
+        result.Session.Should().BeNull();
+        result.StartupFailure.Should().BeOfType<InvalidOperationException>()
+            .Which.Message.Should().Be("no display");
+    }
+
+    [Fact]
+    public void TryStart_CapturesProbeFailure_SoAHungSessionIsNotHandedToTests()
+    {
+        var result = HeadlessSessionGuard.TryStart<object>(
+            () => new object(),
+            _ => throw new OperationCanceledException("probe dispatch timed out"));
+
+        result.Session.Should().BeNull();
+        result.StartupFailure.Should().BeOfType<OperationCanceledException>();
+    }
+
+    [Fact]
+    public void TryStart_ReturnsSession_WhenStartAndProbeSucceed()
+    {
+        var session = new object();
+        bool probed = false;
+
+        var result = HeadlessSessionGuard.TryStart(() => session, _ => probed = true);
+
+        result.Session.Should().BeSameAs(session);
+        result.StartupFailure.Should().BeNull();
+        probed.Should().BeTrue("an unprobed session could hang every dependent test");
+    }
+
+    [Fact]
+    public void SessionOrSkip_ThrowsDynamicSkip_CarryingTheStartupReason()
+    {
+        var failed = new HeadlessSessionGuard.StartResult<object>(
+            null, new InvalidOperationException("XOpenDisplay failed"));
+
+        // Plain try/catch, not Record.Exception: xunit v3's Record.Exception
+        // deliberately rethrows dynamic-skip exceptions, which would turn
+        // this test itself into a skip.
+        Exception? thrown = null;
+        try
+        {
+            HeadlessSessionGuard.SessionOrSkip(failed, "HeadlessUnitTestSession");
+        }
+        catch (Exception ex)
+        {
+            thrown = ex;
+        }
+
+        thrown.Should().NotBeNull("an unavailable session must not be returned as null");
+        // Must be xunit's dynamic-skip exception, NOT the original startup
+        // failure re-thrown (that would fail the test) and NOT a swallow.
+        thrown!.GetType().FullName.Should().Contain("Skip",
+            "session unavailability must skip the test, not fail it");
+        thrown.Message.Should().Contain("XOpenDisplay failed",
+            "the skip reason must preserve the real startup failure");
+        thrown.Message.Should().Contain("#752");
+    }
+
+    [Fact]
+    public void SessionOrSkip_ReturnsTheSession_WhenStartupSucceeded()
+    {
+        var session = new object();
+        var ok = new HeadlessSessionGuard.StartResult<object>(session, null);
+
+        HeadlessSessionGuard.SessionOrSkip(ok, "HeadlessUnitTestSession")
+            .Should().BeSameAs(session);
+    }
+}

--- a/Excise.Avalonia.Tests/PdfViewerAccessibilityTests.cs
+++ b/Excise.Avalonia.Tests/PdfViewerAccessibilityTests.cs
@@ -32,14 +32,16 @@ namespace Excise.Avalonia.Tests;
 public class PdfViewerAccessibilityTests
 {
     // ── harness ──────────────────────────────────────────────────────────
+    // Session access goes through HeadlessSessionGuard (#752): if the shared
+    // headless session cannot start on this platform, these tests skip with
+    // the startup failure as the reason instead of crashing the test host
+    // (which would take the assembly's unrelated tests down with them).
 
     private static Task<T> OnUiThread<T>(Func<T> body) =>
-        HeadlessUnitTestSession.GetOrStartForAssembly(typeof(HeadlessTestApp).Assembly)
-            .Dispatch(body, CancellationToken.None);
+        HeadlessSessionGuard.Session().Dispatch(body, CancellationToken.None);
 
     private static Task<T> OnUiThread<T>(Func<Task<T>> body) =>
-        HeadlessUnitTestSession.GetOrStartForAssembly(typeof(HeadlessTestApp).Assembly)
-            .Dispatch(body, CancellationToken.None);
+        HeadlessSessionGuard.Session().Dispatch(body, CancellationToken.None);
 
     /// <summary>
     /// Wait (bounded) for the viewer's asynchronous page-change pipeline to


### PR DESCRIPTION
Fixes the persistent Linux CI failure (and intermittent macOS crash) of `Excise.Avalonia.Tests`: the #631 accessibility tests drive a real `HeadlessUnitTestSession` app lifecycle that dies natively on the displayless Linux runner, taking the assembly's other 46 passing tests with it.

## Fix — two safe-by-construction layers
1. **ci.yml**: wrap the **Linux (ubuntu)** `Excise.Avalonia.Tests` invocation in `xvfb-run -a` — exact match to the existing `Excise.App.Tests` Linux precedent. macOS (line 439) and Windows (line 583, PowerShell) invocations stay bare (xvfb isn't available there and isn't needed). The 'Install xvfb' step's gui-paths condition was removed so xvfb is always present (Avalonia.Tests runs every PR).
2. **`HeadlessSessionGuard.cs`**: session acquisition goes through a once-only lazy start + bounded 30s no-op dispatch probe; any **managed** startup/probe failure is captured and converted to `Assert.Skip` with the real reason — only the 11 session-dependent a11y tests skip, the rest stay green. **Test-body exceptions are never caught** — the a11y assertions are exactly as strict as before.

## Why safe given no Linux repro
- xvfb wrapper: worst case it's unnecessary (harmless).
- Guard: worst case a managed session failure becomes a skip-with-reason instead of an assembly-wide crash — strictly better than today on every platform (incl. the macOS intermittent case).

## Verification (macOS — what I can run)
| Gate | Result |
|---|---|
| Build | **0 warnings** |
| `Excise.Avalonia.Tests` | **62/62** (57 original + 5 guard-contract tests, 0 skipped locally) |
| Guard contract | start-fail captured-not-propagated, probe-fail (hung session), skip-not-fail with reason, pass-through on success |
| `DocumentationClaimTests` (ci.yml touched) | **21/21** — no pinned string broke |
| ci.yml | valid YAML; `verify-doc-claims.sh` passes |

## Residual risk (honest)
Can't confirm xvfb fixes the Linux **native** crash without a Linux box — the first Linux CI run on this branch is the real verdict. If it's a native SIGSEGV even under xvfb, the step fails as today (no regression); the guard only narrows managed failures. Item 1 of #752 (the separate pre-existing `Excise.App.Tests` xvfb Linux failure) is out of scope and stays open.

Refs #752

🤖 Generated with [Claude Code](https://claude.com/claude-code)