### PR TITLE
fix(writer): deterministic fixed-precision real-number formatting — #762

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ semantic versioning.
 ## [Unreleased]
 
 ### Fixed
+- **Deterministic real-number formatting in the PDF writer** (#762) — every
+  real-number emit site (content-stream operands in `ContentStreamWriter`,
+  object serialization in `PdfObjectWriter`, `ContentOperator.ToString`) now
+  formats through a shared `PdfNumberFormatter`: invariant culture, at most
+  six decimal places, trailing zeros trimmed, never exponent notation. The
+  previous `"G"` (shortest-round-trip) format faithfully reproduced
+  accumulated float noise (`216.01600000000002`, `49.343999999999994`),
+  making saved bytes differ across platforms — and on Windows a noisy
+  coordinate's digit run coincidentally matched a redacted number, tripping
+  the carrier-agnostic saved-bytes redaction check (a byte-check false
+  positive, not a leak). Six decimals bounds any coordinate perturbation at
+  5e-7 pt — far below a rendered pixel — so redaction bounds, extraction
+  parity, and visual baselines are unchanged, while files get slightly
+  smaller and byte-identical cross-platform. The RTL saved-bytes redaction
+  tests additionally pin the trailer `/ID` (normally random bytes serialized
+  as uppercase hex) so their short A–F raw-code needles can't collide with
+  it either.
 - **CID glyph-selection matrix: deterministic handling of missing maps**
   (#515, final slice) — the renderer's CID→GID resolution for Type0 fonts now
   handles every cell of the matrix the way the reference renderers do, each

--- a/Excise.Core.Tests/Text/Segmentation/RtlRedactionTests.cs
+++ b/Excise.Core.Tests/Text/Segmentation/RtlRedactionTests.cs
@@ -29,6 +29,21 @@ public class RtlRedactionTests
     private const string ArabicWord = "سلام";
     private const string HebrewWord = "שלום";
 
+    /// <summary>
+    /// Pin the trailer /ID so SaveToBytes is deterministic. Without an
+    /// existing /ID the writer mints a random 16-byte one serialized as
+    /// UPPERCASE HEX — random A–F runs that can coincidentally contain the
+    /// short letter needles these byte-checks assert against ("DEF",
+    /// "ABCD", "DCBA"), failing the suite spuriously (~1% of runs). Same
+    /// byte-check-collision family as the float-noise coordinates of #762.
+    /// All-zero ID bytes serialize as "000…0", which contains no letters.
+    /// </summary>
+    internal static void PinDeterministicId(PdfDocument doc)
+    {
+        var zeroId = new Excise.Core.Primitives.PdfString(new byte[16], isHex: true);
+        doc.Trailer["ID"] = new Excise.Core.Primitives.PdfArray(zeroId, zeroId);
+    }
+
     private static readonly int[] ArabicScalars = { 0x0633, 0x0644, 0x0627, 0x0645 };
     private static readonly int[] HebrewScalars = { 0x05E9, 0x05DC, 0x05D5, 0x05DD };
 
@@ -37,6 +52,7 @@ public class RtlRedactionTests
     {
         var pdf = RtlPdfFixtures.SingleTj(ArabicScalars, visualOrder: true);
         using var doc = PdfDocument.Open(pdf);
+        RtlRedactionTests.PinDeterministicId(doc);
 
         // Sanity: the unredacted document must carry the word's glyph codes in
         // the saved bytes, or the "gone afterwards" assertions below prove
@@ -66,6 +82,7 @@ public class RtlRedactionTests
     {
         var pdf = RtlPdfFixtures.SingleTj(HebrewScalars, visualOrder: true);
         using var doc = PdfDocument.Open(pdf);
+        RtlRedactionTests.PinDeterministicId(doc);
 
         var removed = doc.RedactText(HebrewWord);
 
@@ -86,6 +103,7 @@ public class RtlRedactionTests
         // against the fix breaking the already-correct path.
         var pdf = RtlPdfFixtures.PerGlyphDecreasingX(ArabicScalars);
         using var doc = PdfDocument.Open(pdf);
+        RtlRedactionTests.PinDeterministicId(doc);
 
         var removed = doc.RedactText(ArabicWord);
 
@@ -147,6 +165,7 @@ public class RtlDigitIslandRedactionTests
     {
         var pdf = RtlPdfFixtures.SingleTjScalarStream(MixedVisual);
         using var doc = PdfDocument.Open(pdf);
+        RtlRedactionTests.PinDeterministicId(doc);
 
         // Sanity: extraction must read the phrase logically, and the raw-code
         // carrier must be present, or the absence assertions prove nothing.
@@ -175,6 +194,7 @@ public class RtlDigitIslandRedactionTests
     {
         var pdf = RtlPdfFixtures.SingleTjScalarStream(MixedVisual);
         using var doc = PdfDocument.Open(pdf);
+        RtlRedactionTests.PinDeterministicId(doc);
 
         // The number's stream codes are 'E' ('3') and 'F' ('0').
         SearchableTextOf(doc.SaveToBytes()).Should().Contain("DEF");
@@ -200,6 +220,7 @@ public class RtlDigitIslandRedactionTests
         const string logicalPhrase = "טלפון 123";
         var pdf = RtlPdfFixtures.SingleTjScalarStream(visual);
         using var doc = PdfDocument.Open(pdf);
+        RtlRedactionTests.PinDeterministicId(doc);
 
         doc.GetPage(1).Text.Should().Contain(logicalPhrase);
 

--- a/Excise.Core.Tests/Writing/PdfNumberFormatterTests.cs
+++ b/Excise.Core.Tests/Writing/PdfNumberFormatterTests.cs
@@ -1,0 +1,153 @@
+using System.Globalization;
+using System.Text;
+using AwesomeAssertions;
+using Excise.Core.Content;
+using Excise.Core.Primitives;
+using Excise.Core.Writing;
+using Xunit;
+
+namespace Excise.Core.Tests.Writing;
+
+/// <summary>
+/// Deterministic real-number formatting in PDF output (#762).
+///
+/// The writer used the "G" format, which emits the shortest string that
+/// round-trips the exact double bit pattern — faithfully reproducing
+/// accumulated float noise (216.01600000000002, 49.343999999999994). Those
+/// digit strings are platform-dependent, so the same document saved on
+/// Windows and macOS produced different bytes, and on Windows a noisy
+/// coordinate's digit run coincidentally matched a redacted number,
+/// tripping the carrier-agnostic saved-bytes redaction check (a false
+/// positive of the byte-check, not a leak).
+///
+/// These tests pin the fix: every real-number emit site rounds to six
+/// decimals and trims trailing zeros, so the emitted bytes are identical
+/// on every platform and carry no noise digits.
+/// </summary>
+public class PdfNumberFormatterTests
+{
+    // The exact noisy values from #762. Each is one ulp away from the clean
+    // value, so "G" prints the full noise digits while the fixed-precision
+    // format collapses them.
+    [Theory]
+    [InlineData(216.01600000000002, "216.016")]
+    [InlineData(49.343999999999994, "49.344")]
+    [InlineData(166.67200000000003, "166.672")]
+    [InlineData(-216.01600000000002, "-216.016")]
+    public void Format_FloatNoise_CollapsesToCleanValue(double value, string expected)
+    {
+        PdfNumberFormatter.Format(value).Should().Be(expected);
+    }
+
+    [Fact]
+    public void Format_ComputedNoise_IsDeterministic()
+    {
+        // The classic accumulation case: 0.1 + 0.2 is not the double nearest
+        // to 0.3, so "G" would print 0.30000000000000004.
+        PdfNumberFormatter.Format(0.1 + 0.2).Should().Be("0.3");
+
+        // Advance-style accumulation (the #734 horizontal-advance path that
+        // surfaced #762): summing glyph advances drifts off the clean value.
+        double x = 0;
+        for (int i = 0; i < 10; i++) x += 21.6016;
+        PdfNumberFormatter.Format(x).Should().Be("216.016");
+    }
+
+    [Theory]
+    [InlineData(2.5, "2.5")]
+    [InlineData(700.0, "700")]
+    [InlineData(0.0, "0")]
+    [InlineData(-2.5, "-2.5")]
+    [InlineData(1.23456789, "1.234568")]
+    [InlineData(0.001, "0.001")]
+    [InlineData(1000000.25, "1000000.25")]
+    public void Format_TypicalValues_UsesMinimalDigits(double value, string expected)
+    {
+        PdfNumberFormatter.Format(value).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(1e-8, "0")]
+    [InlineData(-1e-8, "0")]
+    [InlineData(1e-7, "0")]
+    public void Format_BelowPrecision_CollapsesToZeroWithoutSign(double value, string expected)
+    {
+        // "0.######" spells (-5e-7, 0) as "-0"; the formatter normalizes it —
+        // a signed zero would be a platform-visible artifact of noise sign.
+        PdfNumberFormatter.Format(value).Should().Be(expected);
+    }
+
+    [Fact]
+    public void Format_NeverUsesExponentNotation()
+    {
+        // Exponent notation is invalid PDF syntax; "G" produces it for
+        // large/small magnitudes, "0.######" never does.
+        PdfNumberFormatter.Format(12345678901234.5).Should().Be("12345678901234.5");
+        PdfNumberFormatter.Format(0.0000001).Should().NotContainAny("E", "e");
+    }
+
+    [Fact]
+    public void Format_IsCultureIndependent()
+    {
+        var original = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("de-DE");
+            PdfNumberFormatter.Format(216.01600000000002).Should().Be("216.016",
+                "PDF syntax requires '.' as the decimal separator regardless of thread culture");
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+    }
+
+    // ===== Emit-site integration: the operands of #762's example operators =====
+
+    [Fact]
+    public void ContentStreamWriter_NoisyTmAndRe_EmitsCleanDeterministicBytes()
+    {
+        // The exact operators from #762: a text matrix and a redaction-style
+        // rectangle whose coordinates carry accumulated float noise.
+        var tm = new ContentOperator("Tm", new PdfObject[]
+        {
+            new PdfReal(24), new PdfReal(0), new PdfReal(0), new PdfReal(24),
+            new PdfReal(216.01600000000002), new PdfReal(700)
+        });
+        var re = new ContentOperator("re", new PdfObject[]
+        {
+            new PdfReal(166.67200000000003), new PdfReal(700),
+            new PdfReal(49.343999999999994), new PdfReal(24)
+        });
+
+        var bytes = new ContentStreamWriter().Write(new ContentStream(new[] { tm, re }));
+        var text = Encoding.Latin1.GetString(bytes);
+
+        text.Should().Be("24 0 0 24 216.016 700 Tm\n166.672 700 49.344 24 re\n",
+            "content-stream coordinates must be byte-identical across platforms (#762)");
+    }
+
+    [Fact]
+    public void PdfObjectWriter_NoisyReal_SerializesClean()
+    {
+        // Object-level reals (rects, matrices, widths) go through
+        // PdfObjectWriter — the second emit path into the saved file.
+        PdfObjectWriter.Serialize(new PdfReal(49.343999999999994)).Should().Be("49.344");
+        PdfObjectWriter.Serialize(new PdfArray(new PdfObject[]
+        {
+            new PdfReal(166.67200000000003), new PdfReal(700.0),
+            new PdfReal(216.01600000000002), new PdfReal(724.0)
+        })).Should().Be("[166.672 700 216.016 724]");
+    }
+
+    [Fact]
+    public void ContentOperator_ToString_UsesSameCleanFormat()
+    {
+        var op = new ContentOperator("Td", new PdfObject[]
+        {
+            new PdfReal(216.01600000000002), new PdfReal(49.343999999999994)
+        });
+
+        op.ToString().Should().Be("216.016 49.344 Td");
+    }
+}

--- a/Excise.Core/Content/ContentOperator.cs
+++ b/Excise.Core/Content/ContentOperator.cs
@@ -455,7 +455,7 @@ public class ContentOperator
         return obj switch
         {
             PdfInteger i => i.Value.ToString(),
-            PdfReal r => r.Value.ToString("G", System.Globalization.CultureInfo.InvariantCulture),
+            PdfReal r => Writing.PdfNumberFormatter.Format(r.Value),
             PdfName n => "/" + n.Value,
             PdfString s => "(" + EscapeString(s.Value) + ")",
             PdfArray a => "[" + string.Join(" ", a.Select(FormatOperand)) + "]",

--- a/Excise.Core/Content/ContentStreamWriter.cs
+++ b/Excise.Core/Content/ContentStreamWriter.cs
@@ -117,7 +117,9 @@ public class ContentStreamWriter
                 }
                 else
                 {
-                    _sb.Append(value.ToString("G", CultureInfo.InvariantCulture));
+                    // Deterministic fixed-precision format — "G" reproduces
+                    // platform-dependent float noise in the bytes (#762).
+                    _sb.Append(Writing.PdfNumberFormatter.Format(value));
                 }
                 break;
 

--- a/Excise.Core/Writing/PdfNumberFormatter.cs
+++ b/Excise.Core/Writing/PdfNumberFormatter.cs
@@ -1,0 +1,48 @@
+using System.Globalization;
+
+namespace Excise.Core.Writing;
+
+/// <summary>
+/// Deterministic real-number formatting for PDF output. See issue #762.
+/// </summary>
+/// <remarks>
+/// <para>
+/// .NET's <c>"G"</c> format emits the shortest string that round-trips the
+/// exact <see cref="double"/> bit pattern, which faithfully reproduces
+/// accumulated floating-point noise (e.g. <c>216.01600000000002</c>,
+/// <c>49.343999999999994</c>). Because the noise digits depend on how the
+/// value was computed, the emitted bytes differ across platforms — and on
+/// Windows a coordinate's digit run coincidentally matched a redacted
+/// number, tripping the carrier-agnostic saved-bytes redaction check
+/// (a false positive, not a leak; #762).
+/// </para>
+/// <para>
+/// This formatter instead rounds to six decimal places and trims trailing
+/// zeros (<c>216.016</c>, <c>49.344</c>). Six decimals keeps any coordinate
+/// perturbation below 5e-7 pt — orders of magnitude under a rendered pixel,
+/// so redaction rectangle bounds and visual baselines are unaffected —
+/// while float noise only appears well past the sixth decimal. The format
+/// never uses exponent notation (invalid in PDF syntax) and always uses
+/// <see cref="CultureInfo.InvariantCulture"/>.
+/// </para>
+/// </remarks>
+internal static class PdfNumberFormatter
+{
+    /// <summary>
+    /// Format a PDF real number deterministically: invariant culture, at
+    /// most six decimal places, trailing zeros trimmed, no exponent
+    /// notation. Whole values format without a decimal point.
+    /// </summary>
+    internal static string Format(double value)
+    {
+        // Non-finite values are invalid PDF regardless of format; preserve
+        // the legacy "G" spelling rather than emitting "∞" from "0.######".
+        if (!double.IsFinite(value))
+            return value.ToString("G", CultureInfo.InvariantCulture);
+
+        var result = value.ToString("0.######", CultureInfo.InvariantCulture);
+
+        // "0.######" renders values in (-5e-7, 0) as "-0"; normalize.
+        return result == "-0" ? "0" : result;
+    }
+}

--- a/Excise.Core/Writing/PdfObjectWriter.cs
+++ b/Excise.Core/Writing/PdfObjectWriter.cs
@@ -71,7 +71,9 @@ public static class PdfObjectWriter
                 if (Math.Abs(value - Math.Round(value)) < 1e-10)
                     sb.Append(((long)value).ToString(CultureInfo.InvariantCulture));
                 else
-                    sb.Append(value.ToString("G", CultureInfo.InvariantCulture));
+                    // Deterministic fixed-precision format — "G" reproduces
+                    // platform-dependent float noise in the bytes (#762).
+                    sb.Append(PdfNumberFormatter.Format(value));
                 break;
 
             case PdfName n:


### PR DESCRIPTION
Fixes #762: PDF writers emitted float-noise reals (`216.01600000000002`, `49.343999999999994`) via `ToString("G")` — non-deterministic across platforms, bloated, and causing a Windows redaction-test false-positive (a coordinate's digits collided with a redacted number in the saved-bytes check).

## Fix
New `Excise.Core/Writing/PdfNumberFormatter.cs` — deterministic fixed-precision (`InvariantCulture`, trailing zeros trimmed) — applied at every real-emit site: `ContentStreamWriter` (Tm/re/cm operands), `ContentOperator`, `PdfObjectWriter`. `216.016` not `216.01600000000002`; integers stay integers. Also pinned the trailer `/ID` in the RTL saved-bytes redaction tests (random /ID could itself carry colliding digits).

## Verification (mine — redaction-critical writer, precision tuned to 0 visual churn)
| Gate | Result |
|---|---|
| Build | **0 warnings** |
| `verify-true-redaction.sh` | intact |
| **Visual regression** | PASS, **0 changed baselines** — the rounding shifts no rendered pixel (the make-or-break gate; precision chosen to guarantee it) |
| New `PdfNumberFormatter` + `RtlDigitIsland` tests | **30/30** — including the previously Windows-false-positive test, now deterministic (coordinates are `216.016`-style, no digit collision) |
| Extraction-parity (#645) | 98.7% |
| Redaction | Core 193 · Rendering 44 · App 105 |
| Full `Excise.Core.Tests` | **3677 / 0 failed** |

Deterministic output also means smaller files and reproducible PDFs across platforms.

Closes #762

🤖 Generated with [Claude Code](https://claude.com/claude-code)