### PR TITLE
feat(a11y): expose tagged-PDF /ActualText replacement text to screen readers — #631 (R4)

### DIFF
--- a/Excise.Avalonia.Tests/PdfViewerActualTextTests.cs
+++ b/Excise.Avalonia.Tests/PdfViewerActualTextTests.cs
@@ -1,0 +1,297 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia.Automation.Peers;
+using AwesomeAssertions;
+using Excise.Avalonia.Automation;
+using Excise.Avalonia.Controls;
+using Excise.Core.Authoring;
+using Excise.Core.Document;
+using Excise.Core.Primitives;
+using Xunit;
+
+namespace Excise.Avalonia.Tests;
+
+/// <summary>
+/// Headless tests for the tagged-PDF <c>/ActualText</c> accessibility surface
+/// (#631): structure elements carrying replacement text (ISO 32000-2 §14.9.4
+/// — what a span really says when its glyphs extract wrong) are exposed as
+/// synthetic children of <see cref="PdfViewerAutomationPeer"/>, deduplicated
+/// against the page-text child so a screen reader never hears the same
+/// content twice.
+///
+/// Runs through <see cref="HeadlessSessionGuard"/> from plain [Fact]s
+/// (not [AvaloniaFact]) for the same reasons as
+/// <see cref="PdfViewerAccessibilityTests"/> (#337, #752).
+/// </summary>
+public class PdfViewerActualTextTests
+{
+    // ── harness (same shape as PdfViewerAccessibilityTests) ──────────────
+
+    private static Task<T> OnUiThread<T>(Func<T> body) =>
+        HeadlessSessionGuard.Session().Dispatch(body, CancellationToken.None);
+
+    private static Task<T> OnUiThread<T>(Func<Task<T>> body) =>
+        HeadlessSessionGuard.Session().Dispatch(body, CancellationToken.None);
+
+    private static (PdfViewerControl Viewer, PdfViewerAutomationPeer Peer) CreateViewerWithPeer(
+        PdfDocument? document)
+    {
+        var viewer = new PdfViewerControl();
+        if (document != null)
+            viewer.Document = document;
+        var peer = (PdfViewerAutomationPeer)ControlAutomationPeer.CreatePeerForElement(viewer);
+        return (viewer, peer);
+    }
+
+    private static List<AutomationPeer> ActualTextChildren(AutomationPeer peer) =>
+        peer.GetChildren().Where(c => c.GetClassName() == "PdfActualText").ToList();
+
+    /// <summary>
+    /// Wait (bounded) for the viewer's asynchronous page-change pipeline to
+    /// notify the automation tree, until the peer serves
+    /// <paramref name="expectedCount"/> /ActualText children.
+    /// </summary>
+    private static async Task<List<AutomationPeer>> ActualTextChildrenEventually(
+        AutomationPeer peer, int expectedCount)
+    {
+        for (int i = 0; i < 200; i++)
+        {
+            var actuals = ActualTextChildren(peer);
+            if (actuals.Count == expectedCount)
+                return actuals;
+            await Task.Delay(10);
+            global::Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+        }
+        return ActualTextChildren(peer);
+    }
+
+    // ── fixtures ─────────────────────────────────────────────────────────
+
+    /// <summary>Untagged two-page document with distinct per-page text.</summary>
+    private static PdfDocument TwoPageTextDoc(
+        string pageOne = "Alpha page one", string pageTwo = "Beta page two") =>
+        PdfDocument.Open(PdfDocumentBuilder.Create()
+            .Paragraph(pageOne)
+            .PageBreak()
+            .Paragraph(pageTwo)
+            .SaveToBytes());
+
+    /// <summary>
+    /// Attach a structure tree whose kids are the given (structType,
+    /// ActualText-or-Alt, page) leaves, each /Pg-anchored to its page.
+    /// </summary>
+    private static PdfDocument WithStructLeaves(
+        PdfDocument doc, params (string Type, string Key, string Text, int Page)[] leaves)
+    {
+        var kids = new PdfArray();
+        foreach (var (type, key, text, page) in leaves)
+        {
+            var elem = new PdfDictionary();
+            elem["S"] = new PdfName(type);
+            elem[key] = new PdfString(text);
+            elem["Pg"] = doc.GetPage(page).Dictionary;
+            kids.Add(elem);
+        }
+
+        var root = new PdfDictionary();
+        root["Type"] = new PdfName("StructTreeRoot");
+        root["K"] = kids;
+        doc.Catalog["StructTreeRoot"] = root;
+        return doc;
+    }
+
+    private static PdfDocument DocWithSpanActualText(string actualText, int page) =>
+        WithStructLeaves(TwoPageTextDoc(), ("Span", "ActualText", actualText, page));
+
+    // ── exposure ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task UntaggedDocument_HasNoActualTextChildren()
+    {
+        await OnUiThread(() =>
+        {
+            var (_, peer) = CreateViewerWithPeer(TwoPageTextDoc());
+            ActualTextChildren(peer).Should().BeEmpty();
+            return true;
+        });
+    }
+
+    [Fact]
+    public async Task ActualTextNotInExtractedText_IsExposedAsTextChild()
+    {
+        await OnUiThread(() =>
+        {
+            var (_, peer) = CreateViewerWithPeer(
+                DocWithSpanActualText("Bunsen-Kirchhoff prize citation", page: 1));
+
+            var actuals = ActualTextChildren(peer);
+            actuals.Should().HaveCount(1,
+                "replacement text the glyph layer does not carry must be announced");
+            actuals[0].GetName().Should().Be("Bunsen-Kirchhoff prize citation");
+            actuals[0].GetAutomationControlType().Should().Be(AutomationControlType.Text);
+            actuals[0].IsContentElement().Should().BeTrue();
+            actuals[0].IsControlElement().Should().BeTrue();
+            actuals[0].GetParent().Should().BeSameAs(peer, "an orphaned peer is invisible to AT");
+            return true;
+        });
+    }
+
+    [Fact]
+    public async Task HyphenatedGlyphs_ActualTextRejoin_IsExposed()
+    {
+        await OnUiThread(() =>
+        {
+            // The canonical /ActualText case: the line breaks as "Cross- word",
+            // the author states the real word. Extraction reads the hyphenated
+            // glyphs, so the rejoined form is not contained in the page text
+            // and must be announced.
+            var doc = WithStructLeaves(
+                TwoPageTextDoc(pageOne: "Cross- word puzzle"),
+                ("Span", "ActualText", "Crossword", 1));
+            var (_, peer) = CreateViewerWithPeer(doc);
+
+            var actuals = ActualTextChildren(peer);
+            actuals.Should().HaveCount(1);
+            actuals[0].GetName().Should().Be("Crossword");
+            return true;
+        });
+    }
+
+    // ── dedup vs the page-text child ─────────────────────────────────────
+
+    [Fact]
+    public async Task ActualTextAlreadyInExtractedText_IsSuppressed()
+    {
+        await OnUiThread(() =>
+        {
+            var (viewer, peer) = CreateViewerWithPeer(
+                DocWithSpanActualText("Alpha page", page: 1));
+
+            viewer.GetAccessiblePageText().Should().Contain("Alpha page",
+                "precondition: the glyph layer already carries this text");
+            ActualTextChildren(peer).Should().BeEmpty(
+                "content the page-text child already reads must not be announced twice");
+            return true;
+        });
+    }
+
+    [Fact]
+    public async Task DedupIsWhitespaceNormalized()
+    {
+        await OnUiThread(() =>
+        {
+            // Same words, different whitespace — still the same spoken content.
+            var (_, peer) = CreateViewerWithPeer(
+                DocWithSpanActualText("Alpha\n  page   one", page: 1));
+
+            ActualTextChildren(peer).Should().BeEmpty(
+                "whitespace differences alone must not defeat the dedup");
+            return true;
+        });
+    }
+
+    [Fact]
+    public async Task WhitespaceOnlyActualText_IsIgnored()
+    {
+        await OnUiThread(() =>
+        {
+            var (_, peer) = CreateViewerWithPeer(DocWithSpanActualText("   ", page: 1));
+            ActualTextChildren(peer).Should().BeEmpty();
+            return true;
+        });
+    }
+
+    // ── page association and change notification ─────────────────────────
+
+    [Fact]
+    public async Task ActualTextOnOtherPage_IsNotExposed_UntilNavigatedThere()
+    {
+        await OnUiThread(async () =>
+        {
+            var (viewer, peer) = CreateViewerWithPeer(
+                DocWithSpanActualText("Second-page replacement span", page: 2));
+
+            ActualTextChildren(peer).Should().BeEmpty("the span belongs to page 2, not page 1");
+
+            // End-to-end through the production wiring: the page-change
+            // pipeline must notify the automation tree and invalidate the
+            // cached children on its own.
+            viewer.CurrentPage = 2;
+
+            var actuals = await ActualTextChildrenEventually(peer, expectedCount: 1);
+            actuals.Should().HaveCount(1,
+                "navigating to the span's page must expose its replacement text");
+            actuals[0].GetName().Should().Be("Second-page replacement span");
+            return true;
+        });
+    }
+
+    [Fact]
+    public async Task PageNavigation_RaisesChildrenChanged_WhenActualTextSetChanges()
+    {
+        await OnUiThread(() =>
+        {
+            var (viewer, peer) = CreateViewerWithPeer(
+                DocWithSpanActualText("Second-page replacement span", page: 2));
+            _ = peer.GetChildren(); // materialize the synthetic children
+
+            bool childrenChanged = false;
+            peer.ChildrenChanged += (_, _) => childrenChanged = true;
+
+            viewer.CurrentPage = 2;
+            peer.NotifyPageTextChanged();
+
+            childrenChanged.Should().BeTrue(
+                "AT must be told the accessible children changed when replacements appear");
+            ActualTextChildren(peer).Should().HaveCount(1);
+            return true;
+        });
+    }
+
+    // ── tree shape ───────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ChildOrder_IsPageText_ThenAlt_ThenActualText()
+    {
+        await OnUiThread(() =>
+        {
+            var doc = WithStructLeaves(
+                TwoPageTextDoc(),
+                ("Figure", "Alt", "Chart of results", 1),
+                ("Span", "ActualText", "Ligature-corrected span", 1));
+            var (_, peer) = CreateViewerWithPeer(doc);
+
+            var classes = peer.GetChildren().Select(c => c.GetClassName()).ToList();
+            classes.IndexOf("PdfPageText").Should().Be(0,
+                "the document text stays the first thing a screen reader reaches");
+            classes.IndexOf("PdfFigureAltText").Should().BePositive();
+            classes.IndexOf("PdfActualText").Should()
+                .BeGreaterThan(classes.IndexOf("PdfFigureAltText"),
+                    "replacement spans follow the figure descriptions");
+            return true;
+        });
+    }
+
+    [Fact]
+    public async Task MultipleActualTexts_KeepStructureTreeOrder_WithStableIds()
+    {
+        await OnUiThread(() =>
+        {
+            var doc = WithStructLeaves(
+                TwoPageTextDoc(),
+                ("Span", "ActualText", "First correction", 1),
+                ("Span", "ActualText", "Second correction", 1));
+            var (_, peer) = CreateViewerWithPeer(doc);
+
+            var actuals = ActualTextChildren(peer);
+            actuals.Select(a => a.GetName()).Should()
+                .ContainInOrder("First correction", "Second correction");
+            actuals.Select(a => a.GetAutomationId()).Should()
+                .ContainInOrder("PdfActualText0", "PdfActualText1");
+            return true;
+        });
+    }
+}

--- a/Excise.Avalonia/Automation/PdfViewerAutomationPeer.cs
+++ b/Excise.Avalonia/Automation/PdfViewerAutomationPeer.cs
@@ -17,8 +17,10 @@ namespace Excise.Avalonia.Automation;
 /// so it is the first thing a screen reader reaches when entering the viewer —
 /// that exposes the current page's extractable text in reading order, followed
 /// by one <see cref="PdfAltTextAutomationPeer"/> child per tagged-PDF
-/// <c>/Alt</c> description on the current page, so figures and images with
-/// alternative text are announced too.
+/// <c>/Alt</c> description on the current page (figures and images with
+/// alternative text), and one <see cref="PdfActualTextAutomationPeer"/> child
+/// per <c>/ActualText</c> replacement text the extractable text layer does
+/// not already carry (spans where glyph extraction reads wrong).
 /// </para>
 /// </summary>
 internal sealed class PdfViewerAutomationPeer : ControlAutomationPeer
@@ -26,6 +28,7 @@ internal sealed class PdfViewerAutomationPeer : ControlAutomationPeer
     private readonly PdfViewerControl _viewer;
     private PdfPageTextAutomationPeer? _textPeer;
     private List<PdfAltTextAutomationPeer> _altPeers = new();
+    private List<PdfActualTextAutomationPeer> _actualTextPeers = new();
 
     public PdfViewerAutomationPeer(PdfViewerControl viewer)
         : base(viewer)
@@ -39,10 +42,11 @@ internal sealed class PdfViewerAutomationPeer : ControlAutomationPeer
     protected override IReadOnlyList<AutomationPeer>? GetChildrenCore()
     {
         _textPeer ??= new PdfPageTextAutomationPeer(_viewer);
-        SyncAltTextPeers();
+        SyncDescriptionPeers();
 
         var result = new List<AutomationPeer> { _textPeer };
         result.AddRange(_altPeers);
+        result.AddRange(_actualTextPeers);
         var baseChildren = base.GetChildrenCore();
         if (baseChildren != null)
             result.AddRange(baseChildren);
@@ -50,22 +54,33 @@ internal sealed class PdfViewerAutomationPeer : ControlAutomationPeer
     }
 
     /// <summary>
-    /// Rebuild the synthetic <c>/Alt</c>-description children if the current
-    /// page's set of descriptions changed. Peer instances are kept stable
-    /// while the descriptions are unchanged so assistive technology retains
-    /// element identity across unrelated refreshes. Returns true when the
-    /// children actually changed.
+    /// Rebuild the synthetic structure-tree children (<c>/Alt</c>
+    /// descriptions and <c>/ActualText</c> replacements) if the current
+    /// page's sets changed. Peer instances are kept stable while the texts
+    /// are unchanged so assistive technology retains element identity across
+    /// unrelated refreshes. Returns true when the children actually changed.
     /// </summary>
-    private bool SyncAltTextPeers()
+    private bool SyncDescriptionPeers()
     {
-        var alts = _viewer.GetAccessibleAltTexts();
+        // Non-short-circuit: both sets must be brought current.
+        return SyncPeerList(_viewer.GetAccessibleAltTexts(), ref _altPeers,
+                   static (text, i) => new PdfAltTextAutomationPeer(text, i))
+             | SyncPeerList(_viewer.GetAccessibleActualTexts(), ref _actualTextPeers,
+                   static (text, i) => new PdfActualTextAutomationPeer(text, i));
+    }
 
-        if (alts.Count == _altPeers.Count)
+    private static bool SyncPeerList<TPeer>(
+        IReadOnlyList<string> texts,
+        ref List<TPeer> peers,
+        Func<string, int, TPeer> create)
+        where TPeer : PdfStructTextAutomationPeer
+    {
+        if (texts.Count == peers.Count)
         {
             bool same = true;
-            for (int i = 0; i < alts.Count; i++)
+            for (int i = 0; i < texts.Count; i++)
             {
-                if (!string.Equals(alts[i], _altPeers[i].Description, StringComparison.Ordinal))
+                if (!string.Equals(texts[i], peers[i].Description, StringComparison.Ordinal))
                 {
                     same = false;
                     break;
@@ -75,10 +90,10 @@ internal sealed class PdfViewerAutomationPeer : ControlAutomationPeer
                 return false;
         }
 
-        var peers = new List<PdfAltTextAutomationPeer>(alts.Count);
-        for (int i = 0; i < alts.Count; i++)
-            peers.Add(new PdfAltTextAutomationPeer(alts[i], i));
-        _altPeers = peers;
+        var replacement = new List<TPeer>(texts.Count);
+        for (int i = 0; i < texts.Count; i++)
+            replacement.Add(create(texts[i], i));
+        peers = replacement;
         return true;
     }
 
@@ -87,8 +102,8 @@ internal sealed class PdfViewerAutomationPeer : ControlAutomationPeer
     /// (page navigation, document swap, or a content rewrite such as
     /// redaction). Raises a Name property change on the synthetic text
     /// child so screen readers pick up the new content, and a
-    /// children invalidation when the page's <c>/Alt</c> descriptions
-    /// changed with it. Invalidation matters: <see cref="ControlAutomationPeer"/>
+    /// children invalidation when the page's <c>/Alt</c> or <c>/ActualText</c>
+    /// sets changed with it. Invalidation matters: <see cref="ControlAutomationPeer"/>
     /// caches the children list, so without <see cref="ControlAutomationPeer.InvalidateChildren"/>
     /// (which also raises the children-changed event) a page change would keep
     /// serving the previous page's description peers forever.
@@ -96,7 +111,7 @@ internal sealed class PdfViewerAutomationPeer : ControlAutomationPeer
     internal void NotifyPageTextChanged()
     {
         _textPeer?.NotifyTextChanged();
-        if (SyncAltTextPeers())
+        if (SyncDescriptionPeers())
             InvalidateChildren();
     }
 }
@@ -169,42 +184,25 @@ internal sealed class PdfPageTextAutomationPeer : UnrealizedElementAutomationPee
 }
 
 /// <summary>
-/// Synthetic (control-less) peer that carries one tagged-PDF <c>/Alt</c>
-/// alternative description from the current page's structure tree
-/// (issue #631). Figures and images contribute nothing to the extractable
-/// text layer, so without these peers a described image is silent to
-/// screen readers even in a properly tagged document.
-///
-/// <para>
-/// The description is fixed at construction; page changes replace the peer
-/// set (see <see cref="PdfViewerAutomationPeer.NotifyPageTextChanged"/>),
-/// which raises a children-changed event so assistive technology re-reads.
-/// </para>
+/// Common base for the synthetic (control-less) peers that each carry one
+/// piece of structure-tree text from the current page (issue #631). The text
+/// is fixed at construction; page changes replace the peer set (see
+/// <see cref="PdfViewerAutomationPeer.NotifyPageTextChanged"/>), which raises
+/// a children-changed event so assistive technology re-reads.
 /// </summary>
-internal sealed class PdfAltTextAutomationPeer : UnrealizedElementAutomationPeer
+internal abstract class PdfStructTextAutomationPeer : UnrealizedElementAutomationPeer
 {
-    private readonly int _index;
     private AutomationPeer? _parent;
 
-    public PdfAltTextAutomationPeer(string description, int index)
+    protected PdfStructTextAutomationPeer(string description)
     {
         Description = description;
-        _index = index;
     }
 
-    /// <summary>The <c>/Alt</c> alternative description this peer announces.</summary>
+    /// <summary>The structure-tree text this peer announces.</summary>
     public string Description { get; }
 
     protected override string? GetNameCore() => Description;
-
-    protected override AutomationControlType GetAutomationControlTypeCore() =>
-        AutomationControlType.Image;
-
-    protected override string GetClassNameCore() => "PdfFigureAltText";
-
-    protected override string GetAutomationIdCore() => $"PdfFigureAltText{_index}";
-
-    protected override string GetLocalizedControlTypeCore() => "figure description";
 
     protected override string? GetAcceleratorKeyCore() => null;
 
@@ -223,8 +221,66 @@ internal sealed class PdfAltTextAutomationPeer : UnrealizedElementAutomationPeer
         return true;
     }
 
-    // Unrealized peers default to invisible-to-AT; this node exists solely
+    // Unrealized peers default to invisible-to-AT; these nodes exist solely
     // for assistive technology.
     protected override bool IsContentElementCore() => true;
     protected override bool IsControlElementCore() => true;
+}
+
+/// <summary>
+/// Synthetic peer that carries one tagged-PDF <c>/Alt</c> alternative
+/// description from the current page's structure tree (issue #631). Figures
+/// and images contribute nothing to the extractable text layer, so without
+/// these peers a described image is silent to screen readers even in a
+/// properly tagged document.
+/// </summary>
+internal sealed class PdfAltTextAutomationPeer : PdfStructTextAutomationPeer
+{
+    private readonly int _index;
+
+    public PdfAltTextAutomationPeer(string description, int index)
+        : base(description)
+    {
+        _index = index;
+    }
+
+    protected override AutomationControlType GetAutomationControlTypeCore() =>
+        AutomationControlType.Image;
+
+    protected override string GetClassNameCore() => "PdfFigureAltText";
+
+    protected override string GetAutomationIdCore() => $"PdfFigureAltText{_index}";
+
+    protected override string GetLocalizedControlTypeCore() => "figure description";
+}
+
+/// <summary>
+/// Synthetic peer that carries one tagged-PDF <c>/ActualText</c> replacement
+/// text from the current page's structure tree (issue #631). <c>/ActualText</c>
+/// (ISO 32000-2 §14.9.4) is the author's statement of what a content span
+/// really says when its glyphs extract wrong — hyphenation rejoins, ligature
+/// or symbol substitutions, stylized text. Only replacements the extractable
+/// text layer does not already carry are exposed (see
+/// <see cref="PdfViewerControl.GetAccessibleActualTexts"/>), so a screen
+/// reader never hears the same content twice; in-place substitution inside
+/// the page-text stream awaits MCID-to-letter mapping from Excise.Core.
+/// </summary>
+internal sealed class PdfActualTextAutomationPeer : PdfStructTextAutomationPeer
+{
+    private readonly int _index;
+
+    public PdfActualTextAutomationPeer(string description, int index)
+        : base(description)
+    {
+        _index = index;
+    }
+
+    protected override AutomationControlType GetAutomationControlTypeCore() =>
+        AutomationControlType.Text;
+
+    protected override string GetClassNameCore() => "PdfActualText";
+
+    protected override string GetAutomationIdCore() => $"PdfActualText{_index}";
+
+    protected override string GetLocalizedControlTypeCore() => "replacement text";
 }

--- a/Excise.Avalonia/Controls/PdfViewerControl.Accessibility.cs
+++ b/Excise.Avalonia/Controls/PdfViewerControl.Accessibility.cs
@@ -7,30 +7,38 @@ namespace Excise.Avalonia.Controls;
 
 /// <summary>
 /// Accessibility support for the document content (issue #631): reading the
-/// tagged-PDF structure tree's <c>/Alt</c> alternative descriptions for the
-/// current page so figures/images — which contribute nothing to the
-/// extractable text layer — are not silent to screen readers.
+/// tagged-PDF structure tree's textual carriers for the current page —
+/// <c>/Alt</c> alternative descriptions (figures/images contribute nothing to
+/// the extractable text layer) and <c>/ActualText</c> replacement text
+/// (ISO 32000-2 §14.9.4: the author-supplied text that assistive technology
+/// should read <em>instead of</em> the raw glyphs, used where glyph
+/// extraction is wrong — hyphenation rejoins, ligature or symbol
+/// substitutions, stylized text).
 ///
 /// <para>
 /// This is deliberately read-only over Excise.Core's public surface
 /// (<see cref="PdfDocument.GetStructureTree"/> plus raw-dictionary
-/// resolution). Full struct-tree reading order (re-ordering the text layer
-/// by logical structure) additionally requires mapping marked-content IDs
-/// to extracted letters, which the extraction pipeline does not surface yet
-/// — that remains a follow-up slice of #631.
+/// resolution). Splicing <c>/ActualText</c> into the page text stream
+/// in-place (true glyph substitution) and full struct-tree reading order
+/// both require mapping marked-content IDs to extracted letters, which the
+/// extraction pipeline does not surface yet — those remain follow-up slices
+/// of #631. Until then, replacement text is exposed as additional peers with
+/// a containment dedup (see <see cref="GetAccessibleActualTexts"/>) so
+/// content is not announced twice.
 /// </para>
 /// </summary>
 public partial class PdfViewerControl
 {
-    // Cache for the current page's /Alt descriptions, keyed by the same
-    // content identity the announced-text dedupe uses: (Document,
+    // Caches for the current page's structure-tree text carriers, keyed by
+    // the same content identity the announced-text dedupe uses: (Document,
     // CurrentPage, RenderVersion). A RenderVersion bump matters here too —
-    // redaction scrubs /Alt from the structure tree (#636), and the
-    // accessibility tree must not keep announcing redacted descriptions.
-    private PdfDocument? _altTextDocument;
-    private int _altTextPage = -1;
-    private long _altTextRenderVersion = -1;
-    private IReadOnlyList<string>? _altTextCache;
+    // redaction scrubs /Alt and /ActualText from the structure tree (#636),
+    // and the accessibility tree must not keep announcing redacted text.
+    private PdfDocument? _structTextDocument;
+    private int _structTextPage = -1;
+    private long _structTextRenderVersion = -1;
+    private IReadOnlyList<string> _altTextCache = Array.Empty<string>();
+    private IReadOnlyList<string> _actualTextCache = Array.Empty<string>();
 
     /// <summary>
     /// The <c>/Alt</c> alternative descriptions of tagged structure elements
@@ -40,40 +48,104 @@ public partial class PdfViewerControl
     /// </summary>
     internal IReadOnlyList<string> GetAccessibleAltTexts()
     {
-        var doc = Document;
-        if (doc == null || CurrentPage < 1 || CurrentPage > doc.PageCount)
-            return Array.Empty<string>();
-
-        if (ReferenceEquals(_altTextDocument, doc)
-            && _altTextPage == CurrentPage
-            && _altTextRenderVersion == RenderVersion
-            && _altTextCache != null)
-            return _altTextCache;
-
-        IReadOnlyList<string> result;
-        try
-        {
-            result = CollectAltTextsForPage(doc, CurrentPage);
-        }
-        catch (Exception ex) when (ex is not OutOfMemoryException)
-        {
-            // Malformed structure trees must never take down the viewer;
-            // accessibility degrades to the text layer alone.
-            result = Array.Empty<string>();
-        }
-
-        _altTextDocument = doc;
-        _altTextPage = CurrentPage;
-        _altTextRenderVersion = RenderVersion;
-        _altTextCache = result;
-        return result;
+        EnsureStructTextCaches();
+        return _altTextCache;
     }
 
-    private static IReadOnlyList<string> CollectAltTextsForPage(PdfDocument doc, int pageNumber)
+    /// <summary>
+    /// The <c>/ActualText</c> replacement texts of tagged structure elements
+    /// associated with the current page, in structure-tree order — minus any
+    /// whose content the extractable text layer already carries.
+    ///
+    /// <para>
+    /// The dedup is containment-based: a replacement text whose
+    /// whitespace-normalized content is already a substring of the page's
+    /// accessible text is dropped, because announcing it again would double
+    /// the content a screen reader hears. What survives is exactly the case
+    /// <c>/ActualText</c> exists for: spans where glyph extraction reads
+    /// wrong (<c>back- ground</c> vs <c>background</c>, ligature and symbol
+    /// substitutions), including pages where extraction fails entirely.
+    /// In-place substitution (replacing the raw glyphs inside the text
+    /// stream) requires MCID-to-letter mapping from Excise.Core — a
+    /// follow-up slice of #631.
+    /// </para>
+    /// </summary>
+    internal IReadOnlyList<string> GetAccessibleActualTexts()
+    {
+        EnsureStructTextCaches();
+        return _actualTextCache;
+    }
+
+    private void EnsureStructTextCaches()
+    {
+        var doc = Document;
+        int page = CurrentPage;
+        long version = RenderVersion;
+
+        if (ReferenceEquals(_structTextDocument, doc)
+            && _structTextPage == page
+            && _structTextRenderVersion == version)
+            return;
+
+        IReadOnlyList<string> alts = Array.Empty<string>();
+        IReadOnlyList<string> actuals = Array.Empty<string>();
+        if (doc != null && page >= 1 && page <= doc.PageCount)
+        {
+            try
+            {
+                (alts, actuals) = CollectStructTextsForPage(doc, page);
+                actuals = FilterActualTextsAlreadyInPageText(actuals);
+            }
+            catch (Exception ex) when (ex is not OutOfMemoryException)
+            {
+                // Malformed structure trees must never take down the viewer;
+                // accessibility degrades to the text layer alone.
+                alts = Array.Empty<string>();
+                actuals = Array.Empty<string>();
+            }
+        }
+
+        _structTextDocument = doc;
+        _structTextPage = page;
+        _structTextRenderVersion = version;
+        _altTextCache = alts;
+        _actualTextCache = actuals;
+    }
+
+    /// <summary>
+    /// Drop replacement texts the extractable text layer already contains
+    /// (whitespace-normalized ordinal containment). Case-sensitive on
+    /// purpose: a case difference (e.g. small-caps glyphs extracting as
+    /// upper case) is itself a correction worth announcing.
+    /// </summary>
+    private IReadOnlyList<string> FilterActualTextsAlreadyInPageText(
+        IReadOnlyList<string> actualTexts)
+    {
+        if (actualTexts.Count == 0)
+            return actualTexts;
+
+        string pageText = NormalizeWhitespace(GetAccessiblePageText());
+        if (pageText.Length == 0)
+            return actualTexts; // extraction got nothing — every replacement is news
+
+        var kept = new List<string>();
+        foreach (var text in actualTexts)
+        {
+            if (!pageText.Contains(NormalizeWhitespace(text), StringComparison.Ordinal))
+                kept.Add(text);
+        }
+        return kept.Count == 0 ? Array.Empty<string>() : kept;
+    }
+
+    private static string NormalizeWhitespace(string s) =>
+        string.Join(" ", s.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries));
+
+    private static (IReadOnlyList<string> Alts, IReadOnlyList<string> ActualTexts)
+        CollectStructTextsForPage(PdfDocument doc, int pageNumber)
     {
         var root = doc.GetStructureTree();
         if (root == null)
-            return Array.Empty<string>();
+            return (Array.Empty<string>(), Array.Empty<string>());
 
         // Page dictionaries resolve through the document's object cache, so
         // reference identity maps a resolved /Pg target back to its number.
@@ -81,9 +153,11 @@ public partial class PdfViewerControl
         for (int i = 1; i <= doc.PageCount; i++)
             pagesByDict[doc.GetPage(i).Dictionary] = i;
 
-        var results = new List<string>();
-        Walk(doc, root, inheritedPage: null, pagesByDict, pageNumber, results, depth: 0);
-        return results.Count == 0 ? Array.Empty<string>() : results;
+        var alts = new List<string>();
+        var actuals = new List<string>();
+        Walk(doc, root, inheritedPage: null, pagesByDict, pageNumber, alts, actuals, depth: 0);
+        return (alts.Count == 0 ? Array.Empty<string>() : alts,
+                actuals.Count == 0 ? Array.Empty<string>() : actuals);
     }
 
     private const int MaxStructWalkDepth = 64; // mirrors PdfStructTreeParser.MaxDepth
@@ -94,7 +168,8 @@ public partial class PdfViewerControl
         int? inheritedPage,
         Dictionary<PdfDictionary, int> pagesByDict,
         int targetPage,
-        List<string> results,
+        List<string> alts,
+        List<string> actuals,
         int depth)
     {
         if (depth > MaxStructWalkDepth)
@@ -102,17 +177,19 @@ public partial class PdfViewerControl
 
         int? page = ResolveElementPage(doc, element, pagesByDict) ?? inheritedPage;
 
-        if (!string.IsNullOrWhiteSpace(element.AltText))
+        // An element with no determinable page can still be safely announced
+        // when there is only one page it could belong to.
+        int? effectivePage = page ?? (doc.PageCount == 1 ? 1 : (int?)null);
+        if (effectivePage == targetPage)
         {
-            // An element with no determinable page can still be safely
-            // announced when there is only one page it could belong to.
-            int? effectivePage = page ?? (doc.PageCount == 1 ? 1 : (int?)null);
-            if (effectivePage == targetPage)
-                results.Add(element.AltText!.Trim());
+            if (!string.IsNullOrWhiteSpace(element.AltText))
+                alts.Add(element.AltText!.Trim());
+            if (!string.IsNullOrWhiteSpace(element.ActualText))
+                actuals.Add(element.ActualText!.Trim());
         }
 
         foreach (var child in element.Children)
-            Walk(doc, child, page, pagesByDict, targetPage, results, depth + 1);
+            Walk(doc, child, page, pagesByDict, targetPage, alts, actuals, depth + 1);
     }
 
     /// <summary>


### PR DESCRIPTION
#631 (R4 Accessibility) next slice: expose `/ActualText` (ISO 32000-2 §14.9.4) to assistive tech — the replacement-text carrier that exists exactly where the current page-text child mis-reads: **hyphenation rejoins, ligature/symbol substitutions, stylized text, and pages where glyph extraction fails entirely.** Excise.Avalonia-only; all internal (no public API change).

## Change
- `PdfViewerControl.Accessibility.cs`: the struct-tree walk now collects `/Alt` **and** `/ActualText` per page in one pass (cached on Document/CurrentPage/RenderVersion; Core already parses `PdfStructElement.ActualText` — no Core change). **Dedup story:** a replacement whose whitespace-normalized content is already an ordinal substring of the accessible page text is suppressed (content never doubled); what survives is exactly what `/ActualText` is for. Empty page text ⇒ every replacement announced.
- `PdfViewerAutomationPeer.cs`: new `PdfActualTextAutomationPeer` (Text control type, 'replacement text'); children order = page text → `/Alt` figures → `/ActualText` spans; synced + invalidated on page change. Factored a shared `PdfStructTextAutomationPeer` base (the `/Alt` peer's contract unchanged — prior tests untouched).

## Verification (mine)
| Gate | Result |
|---|---|
| Build | **0 warnings** |
| `Excise.Avalonia.Tests` | **72/72** (10 new `PdfViewerActualTextTests`: non-extracted replacement exposure, hyphenation-rejoin, suppression when glyphs already carry the text, whitespace-normalized dedup, page association + navigation, ChildrenChanged, ordering, stable IDs) |
| PublicApi | no change (all internal) |

## Stays blocked (Core-side, other milestone)
Struct-tree **logical reading order** and true in-place `/ActualText` substitution need Excise.Core to surface MCID→Letter mapping — not attemptable in Avalonia. Next #631 slices: that MCID work, keyboard/AT nav to next heading/link, PDF/UA presence surface, `/Lang` per-span exposure (Core already parses `PdfStructElement.Language`).

Refs #631

🤖 Generated with [Claude Code](https://claude.com/claude-code)