### PR TITLE
fix(redaction): consume a removed text-op's advance in GlyphRemover keep-as-is path — #758 (R1)

### DIFF
--- a/Excise.Core.Tests/Text/Segmentation/CidRedactionEndToEndTests.cs
+++ b/Excise.Core.Tests/Text/Segmentation/CidRedactionEndToEndTests.cs
@@ -106,10 +106,12 @@ public class CidRedactionEndToEndTests
         // Layout: Tfs=12, w0=500/1000, Tc=4, Th=0.5 → per-glyph
         // tx = (6 + 4)·0.5 = 5. "KEEP" = CIDs 0x11..0x14 from x=72;
         // "SECRET" = CIDs 1..6 follows in the same block, so its 'S' pen
-        // sits at 72 + 4·5 = 92. (The SECRET run comes SECOND so removing
-        // it cannot disturb the kept run's pen position — a removed run's
-        // lost advance shifts only what FOLLOWS it in the block; that
-        // follower-drift is a separate pre-existing defect, issue #758.)
+        // sits at 72 + 4·5 = 92. (The SECRET run comes SECOND so this test
+        // isolates the #734 advance formula from follower positioning — a
+        // removed run's lost advance shifts only what FOLLOWS it in the
+        // block; that follower-drift was issue #758, fixed by the keep-as-is
+        // TJ advance compensation and pinned by
+        // RedactText_MiddleRunOfMultiRunBtBlock_FollowingKeptRunStaysPut.)
         var pdf = BuildSpacedSecretPdf();
         using var doc = PdfDocument.Open(pdf);
         var page = doc.GetPage(1);
@@ -138,6 +140,109 @@ public class CidRedactionEndToEndTests
         var kAfter = reopenedPage.Letters.First(l => l.Value == "K");
         kAfter.StartX.Should().BeApproximately(72.0, 0.5,
             "kept glyphs must stay where they were before redaction");
+    }
+
+    [Fact]
+    public void RedactText_MiddleRunOfMultiRunBtBlock_FollowingKeptRunStaysPut()
+    {
+        // #758: when the keep-as-is path removes a Tj from a multi-run BT
+        // block, the removed run's §9.4.4 pen advance must still be consumed
+        // (replayed as a numeric TJ adjustment) — otherwise every following
+        // kept run collapses back to the last explicit positioning operator.
+        //
+        // Same layout as the #734 fixture (Tfs=12, w0=500/1000, Tc=4,
+        // Th=0.5 → 5pt per glyph), but with a THIRD run after the secret:
+        // one BT block "KEEP" (from x=72) + "SECRET" (x=92) + "DONE"
+        // (x=92 + 6·5 = 122). Redacting the middle run must leave "DONE"
+        // exactly at its hand-computed spec position; pre-fix it shifted
+        // 30pt left onto the redacted gap.
+        var pdf = BuildThreeRunPdf();
+        using var doc = PdfDocument.Open(pdf);
+        var page = doc.GetPage(1);
+
+        page.Text.Should().Contain("KEEP").And.Contain("SECRET").And.Contain("DONE");
+        page.Letters.First(l => l.Value == "K").StartX.Should().BeApproximately(72.0, 1e-9);
+        page.Letters.First(l => l.Value == "S").StartX.Should().BeApproximately(92.0, 1e-9);
+        page.Letters.First(l => l.Value == "D").StartX.Should().BeApproximately(122.0, 1e-9,
+            "hand-computed §9.4.4: 72 + 10 glyphs × (w0·Tfs + Tc)·Th");
+
+        doc.RedactText("SECRET", drawBlackRect: false).Should().Be(1);
+
+        // CARRIER-AGNOSTIC: the secret must be nowhere in the SAVED BYTES,
+        // in any carrier — ASCII, UTF-16BE, or UTF-8.
+        var saved = doc.SaveToBytes();
+        (Encoding.ASCII.GetString(saved)
+         + Encoding.BigEndianUnicode.GetString(saved)
+         + Encoding.UTF8.GetString(saved))
+            .Should().NotContain("SECRET",
+                "the redacted text must be gone from every carrier in the saved file");
+
+        // Kept runs — BOTH sides of the removed run — must re-extract at
+        // their original, hand-computed spec positions.
+        var reopenedPage = PdfDocument.Open(saved).GetPage(1);
+        reopenedPage.Text.Should().Contain("KEEP").And.Contain("DONE").And.NotContain("SECRET");
+        reopenedPage.Letters.First(l => l.Value == "K").StartX.Should().BeApproximately(72.0, 0.5,
+            "a kept run BEFORE the redacted run was never at risk and must stay put");
+        reopenedPage.Letters.First(l => l.Value == "D").StartX.Should().BeApproximately(122.0, 0.5,
+            "the kept run FOLLOWING the redacted middle run must not shift left (#758)");
+    }
+
+    /// <summary>
+    /// Identity-H Type0 page drawing "KEEP" (CIDs 0x11..0x14), "SECRET"
+    /// (CIDs 1..6), then "DONE" (CIDs 0x21..0x24) in one Tj each inside a
+    /// single BT block, with 50 Tz and 4 Tc active — the #758 follower-drift
+    /// shape. All CIDs have /W width 500.
+    /// </summary>
+    private static byte[] BuildThreeRunPdf()
+    {
+        // CID → Unicode: 1..6 → S,E,C,R,E,T; 0x11..0x14 → K,E,E,P;
+        // 0x21..0x24 → D,O,N,E.
+        var cmap =
+            "/CIDInit /ProcSet findresource begin\n12 dict begin\nbegincmap\n" +
+            "1 begincodespacerange\n<0000> <FFFF>\nendcodespacerange\n" +
+            "14 beginbfchar\n" +
+            "<0001> <0053>\n<0002> <0045>\n<0003> <0043>\n<0004> <0052>\n" +
+            "<0005> <0045>\n<0006> <0054>\n" +
+            "<0011> <004B>\n<0012> <0045>\n<0013> <0045>\n<0014> <0050>\n" +
+            "<0021> <0044>\n<0022> <004F>\n<0023> <004E>\n<0024> <0045>\n" +
+            "endbfchar\nendcmap\nCMapName currentdict /CMap defineresource pop\nend\nend\n";
+
+        var content =
+            "BT /F1 12 Tf 50 Tz 4 Tc 72 700 Td " +
+            "<0011001200130014> Tj <000100020003000400050006> Tj <0021002200230024> Tj ET";
+
+        var bodies = new[]
+        {
+            "<< /Type /Catalog /Pages 2 0 R >>",
+            "<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R " +
+                "/Resources << /Font << /F1 5 0 R >> >> >>",
+            StreamBody("", content),
+            "<< /Type /Font /Subtype /Type0 /BaseFont /Test /Encoding /Identity-H " +
+                "/DescendantFonts [6 0 R] /ToUnicode 7 0 R >>",
+            "<< /Type /Font /Subtype /CIDFontType2 /BaseFont /Test " +
+                "/CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> " +
+                "/FontDescriptor 8 0 R /CIDToGIDMap /Identity /DW 1000 " +
+                "/W [ 1 6 500 17 20 500 33 36 500 ] >>",
+            StreamBody("", cmap),
+            "<< /Type /FontDescriptor /FontName /Test /Flags 4 /FontBBox [0 0 1000 1000] " +
+                "/ItalicAngle 0 /Ascent 1000 /Descent 0 /CapHeight 1000 /StemV 80 >>",
+        };
+
+        using var ms = new MemoryStream();
+        void W(string s) { var b = Encoding.Latin1.GetBytes(s); ms.Write(b, 0, b.Length); }
+        W("%PDF-1.5\n");
+        var off = new long[bodies.Length + 1];
+        for (int i = 0; i < bodies.Length; i++)
+        {
+            off[i + 1] = ms.Position;
+            W($"{i + 1} 0 obj\n{bodies[i]}\nendobj\n");
+        }
+        long xref = ms.Position;
+        W($"xref\n0 {bodies.Length + 1}\n0000000000 65535 f \n");
+        for (int i = 1; i <= bodies.Length; i++) W($"{off[i]:D10} 00000 n \n");
+        W($"trailer\n<< /Root 1 0 R /Size {bodies.Length + 1} >>\nstartxref\n{xref}\n%%EOF");
+        return ms.ToArray();
     }
 
     /// <summary>

--- a/Excise.Core/Content/ContentOperator.cs
+++ b/Excise.Core/Content/ContentOperator.cs
@@ -40,6 +40,21 @@ public class ContentOperator
     public string? TextContent { get; internal set; }
 
     /// <summary>
+    /// For text-showing operators (Tj/TJ/'/") parsed with operator metadata:
+    /// the total pen displacement this operator produced along the writing
+    /// direction, in TJ-adjustment units (thousandths of the active font
+    /// size, §9.4.3; horizontal scaling excluded because a TJ number is
+    /// itself scaled by Th at execution, so the factor cancels). Positive =
+    /// forward advance. Under the same ambient text state, <c>[-value] TJ</c>
+    /// replays the advance exactly — which is how a redaction that removes
+    /// this operator keeps later runs in the same BT block from shifting
+    /// (issue #758). Null when unknown: metadata pass disabled, operator
+    /// built synthetically, or a degenerate zero font size makes the
+    /// spacing terms inexpressible as a TJ number.
+    /// </summary>
+    internal double? TextAdvanceThousandths { get; set; }
+
+    /// <summary>
     /// For inline-image operators (<c>BI</c>), the raw binary image data
     /// that appeared between <c>ID</c> and <c>EI</c> in the source content
     /// stream. The single <see cref="Operands"/> entry holds the image

--- a/Excise.Core/Content/ContentStreamParser.cs
+++ b/Excise.Core/Content/ContentStreamParser.cs
@@ -82,6 +82,13 @@ public class ContentStreamParser
     private double _tm_a = 1, _tm_b, _tm_c, _tm_d = 1, _tm_e, _tm_f;
     private double _tlm_e, _tlm_f;
 
+    // Per-text-showing-op pen advance in TJ-adjustment units (#758) —
+    // reset before each Tj/TJ/'/" string is processed, accumulated by
+    // EmitGlyph/ApplyTjAdjustment, then stored on the operator so redaction
+    // can replay a removed op's advance as a numeric TJ adjustment.
+    private double _opAdvanceThousandths;
+    private bool _opAdvanceExpressible;
+
     // Current path for bounds calculation
     private double _pathMinX, _pathMinY, _pathMaxX, _pathMaxY;
     private bool _pathStarted;
@@ -445,9 +452,11 @@ public class ContentStreamParser
             case "TJ":
                 if (operands.Count >= 1 && operands[0] is PdfArray arr)
                 {
+                    BeginOpAdvanceTracking();
                     var (text, bounds) = ProcessTextArray(arr);
                     op.TextContent = text;
                     op.BoundingBox = bounds;
+                    EndOpAdvanceTracking(op);
                 }
                 return true;
 
@@ -595,9 +604,57 @@ public class ContentStreamParser
 
     private void SetTextOperatorResult(PdfObject textObject, ContentOperator op)
     {
+        BeginOpAdvanceTracking();
         var (text, bounds) = ProcessTextString(textObject);
         op.TextContent = text;
         op.BoundingBox = bounds;
+        EndOpAdvanceTracking(op);
+    }
+
+    /// <summary>
+    /// Start accumulating the pen advance of one text-showing operator
+    /// (#758). Called after any implicit T*/Tw/Tc side effects of '/" have
+    /// been applied — those are line-matrix/state moves, not pen advance.
+    /// </summary>
+    private void BeginOpAdvanceTracking()
+    {
+        _opAdvanceThousandths = 0;
+        _opAdvanceExpressible = true;
+    }
+
+    /// <summary>
+    /// Store the accumulated pen advance on the operator, in TJ-adjustment
+    /// units (see <see cref="ContentOperator.TextAdvanceThousandths"/>).
+    /// </summary>
+    private void EndOpAdvanceTracking(ContentOperator op)
+    {
+        op.TextAdvanceThousandths =
+            _opAdvanceExpressible ? _opAdvanceThousandths : null;
+    }
+
+    /// <summary>
+    /// Accumulate one glyph's pen displacement into the current op's advance
+    /// (#758). <paramref name="displacementThousandths"/> is the glyph-space
+    /// displacement along the writing direction (horizontal: w0; vertical:
+    /// w1y) and <paramref name="spacing"/> the active Tc(+Tw) contribution in
+    /// text-space units, converted here into the same thousandths-of-Tfs
+    /// units a TJ number uses — mirroring exactly the §9.4.4 advance the
+    /// caller applies to the text matrix, with the shared Th factor cancelled.
+    /// </summary>
+    private void AccumulateOpAdvance(double displacementThousandths, double spacing)
+    {
+        if (spacing != 0)
+        {
+            if (Math.Abs(_fontSize) < 1e-9)
+            {
+                // tx = spacing·Th with Tfs = 0 — no TJ number can reproduce
+                // it (the number is multiplied by Tfs). Mark inexpressible.
+                _opAdvanceExpressible = false;
+                return;
+            }
+            displacementThousandths += spacing * 1000.0 / _fontSize;
+        }
+        _opAdvanceThousandths += displacementThousandths;
     }
 
     #region Text Processing
@@ -715,6 +772,7 @@ public class ContentStreamParser
                 var ty = (vm.W1Y / 1000.0) * _fontSize + spacing;
                 _tm_e += ty * _tm_c;
                 _tm_f += ty * _tm_d;
+                AccumulateOpAdvance(vm.W1Y, spacing);
             }
             else
             {
@@ -725,6 +783,7 @@ public class ContentStreamParser
                 var tx = ((charWidth / 1000.0) * _fontSize + spacing) * (_horizontalScaling / 100.0);
                 _tm_e += tx * _tm_a;
                 _tm_f += tx * _tm_b;
+                AccumulateOpAdvance(charWidth, spacing);
             }
         }
 
@@ -770,6 +829,10 @@ public class ContentStreamParser
         {
             _tm_e -= (adj / 1000.0) * _fontSize * (_horizontalScaling / 100.0);
         }
+
+        // A TJ number already IS a TJ-adjustment-unit displacement: it moves
+        // the pen by −adj thousandths along the writing direction. #758
+        _opAdvanceThousandths -= adj;
     }
 
     /// <summary>

--- a/Excise.Core/Text/Segmentation/GlyphRemover.cs
+++ b/Excise.Core/Text/Segmentation/GlyphRemover.cs
@@ -192,13 +192,88 @@ public class GlyphRemover
             // survive so the kept-as-is text-ops keep their positioning.
             for (int idx = block.BtIndex; idx <= block.EtIndex; idx++)
             {
-                if (intersectingTextOpIndices.Contains(idx)) continue;
+                if (intersectingTextOpIndices.Contains(idx))
+                {
+                    // #758: a removed text-op's pen advance (and, for '/",
+                    // its line-move/spacing side effects) must still be
+                    // consumed, or every later run in this block that relies
+                    // on the accumulated §9.4.4 pen position collapses back
+                    // to the last explicit positioning operator. Emits ONLY
+                    // geometry/state operators — never text.
+                    EmitRemovedOperatorCompensation(operations, block, idx, output);
+                    continue;
+                }
                 output.Add(operations[idx]);
             }
         }
         // else: whole original block is dropped; reconstructed ops replace it.
 
         output.AddRange(reconstructed);
+    }
+
+    /// <summary>
+    /// Replace a removed text-showing operator with the non-text side effects
+    /// it had on the block (#758): the pen advance of the glyphs it drew, and
+    /// for <c>'</c>/<c>"</c> the implicit next-line move (and <c>"</c>'s
+    /// Tw/Tc settings) that later operators in the block depend on. The
+    /// advance is replayed as a numeric-only TJ adjustment — under the same
+    /// ambient Tf/Tz state (which the keep-as-is branch preserves) a TJ
+    /// number of −advance reproduces the removed op's §9.4.4 displacement
+    /// exactly, moves only the text matrix (not the line matrix), and draws
+    /// nothing. The removed text itself is NEVER re-emitted in any form.
+    /// </summary>
+    private static void EmitRemovedOperatorCompensation(
+        IReadOnlyList<ContentOperator> operations,
+        BlockInfo block,
+        int removedIndex,
+        List<ContentOperator> output)
+    {
+        var removed = operations[removedIndex];
+
+        // " sets word spacing and character spacing before showing text
+        // (§9.4.3) — text state that persists past the operator.
+        if (removed.Name == "\"" && removed.Operands.Count >= 3)
+        {
+            output.Add(new ContentOperator("Tw", new[] { removed.Operands[0] }));
+            output.Add(new ContentOperator("Tc", new[] { removed.Operands[1] }));
+        }
+
+        // ' and " both move to the next line (equivalent to T*) before
+        // showing text — a line-matrix move every subsequent operator in the
+        // block builds on.
+        if (removed.Name == "'" || removed.Name == "\"")
+            output.Add(new ContentOperator("T*"));
+
+        // Pen-advance compensation. Null means the parser couldn't express
+        // the advance (metadata pass off, synthetic op, degenerate state) —
+        // in that case fall back to today's behavior rather than guessing.
+        if (removed.TextAdvanceThousandths is not double advance) return;
+        if (Math.Abs(advance) < 1e-6) return;
+        if (!PenPositionMattersAfter(operations, block, removedIndex)) return;
+
+        output.Add(new ContentOperator("TJ", new PdfObject[]
+        {
+            new PdfArray(new PdfObject[] { new PdfReal(-advance) }),
+        }));
+    }
+
+    /// <summary>
+    /// True when some Tj/TJ after <paramref name="removedIndex"/> in the
+    /// block still depends on the accumulated pen position — i.e. appears
+    /// before any operator that resets the pen from the line matrix
+    /// (Td/TD/Tm/T*, or the implicit T* of '/").
+    /// </summary>
+    private static bool PenPositionMattersAfter(
+        IReadOnlyList<ContentOperator> operations, BlockInfo block, int removedIndex)
+    {
+        for (int i = removedIndex + 1; i <= block.EtIndex; i++)
+        {
+            var op = operations[i];
+            if (op.Name == "Tj" || op.Name == "TJ") return true;
+            if (op.Category == OperatorCategory.TextPositioning) return false;
+            if (op.Name == "'" || op.Name == "\"") return false;
+        }
+        return false;
     }
 
     private List<ContentOperator> BuildReconstructedOps(


### PR DESCRIPTION
Fixes #758: when `GlyphRemover`'s keep-as-is path removes a `Tj` (redacts text) from a **multi-run BT block**, it dropped that op's pen advance — so *following kept runs* on the same line shifted left (~30pt). Not a leak (bytes removed), but a positional-fidelity defect found during #734's RTL round-trip.

## Fix
When a text-showing op is removed, its horizontal advance is now consumed (compensating offset) so subsequent kept runs stay put; advance is computed consistently with the extractor/parser (widths + Tc/Tw·Th). Removed content stays gone — this only fixes geometry, never re-adds text.

## Verification (mine — finished after the Fable agent hit its quota; work recovered from its committed checkpoint)
| Gate | Result |
|---|---|
| Build | **0 warnings** (internal only) |
| `verify-true-redaction.sh` | intact |
| **Extraction-parity (#645)** | **98.7%** |
| Redaction | Core **190** · Rendering 44 · App 105 — includes the new test: redact a middle run of a multi-run BT line → a following kept run's position is **unchanged** vs the un-redacted doc, AND the removed text is absent from saved bytes (carrier-agnostic) |
| Full `Excise.Core.Tests` | **3665 / 0 failed** |

Closes #758

🤖 Generated with [Claude Code](https://claude.com/claude-code)