### PR TITLE
feat(a11y): tagged-PDF structure accessibility layer (#631)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,17 @@ semantic versioning.
   pdftocairo/Ghostscript differentials pinning the out-of-range fallback.
 
 ### Added
+- **Tagged-PDF structure accessibility layer** (#631) — the Avalonia viewer's
+  automation peer tree now exposes the tagged-PDF structure tree to screen
+  readers: the page's accessible text is ordered by the structure tree when a
+  tagged document supplies orderable `/ActualText` (falling back to geometric
+  reading order otherwise), structure elements are surfaced as role peers
+  (headings H1–H6, lists and list items, tables/rows/cells; figures continue
+  to come through as `/Alt` image peers), and `H` / `Shift+H` navigate to the
+  next/previous heading across page boundaries. Reading a heading's body glyphs
+  in struct order still awaits MCID-to-letter mapping from Excise.Core (a
+  follow-up slice of #631); untagged reading-order heuristics (#773) and
+  PDF/UA conformance validation (#772) are out of scope.
 - **FDF annotation import/export round-trip** (#626) — `Excise.Core.Forms.FdfSerializer`
   reads and writes the PDF-syntax `/FDF` annotation interchange format (the
   counterpart to XFDF), so annotations round-trip with tools that prefer FDF.

--- a/Excise.Avalonia.Tests/PdfViewerStructTreeA11yTests.cs
+++ b/Excise.Avalonia.Tests/PdfViewerStructTreeA11yTests.cs
@@ -1,0 +1,325 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia.Automation.Peers;
+using AwesomeAssertions;
+using Excise.Avalonia.Automation;
+using Excise.Avalonia.Controls;
+using Excise.Core.Authoring;
+using Excise.Core.Document;
+using Excise.Core.Primitives;
+using Xunit;
+
+namespace Excise.Avalonia.Tests;
+
+/// <summary>
+/// Headless tests for the tagged-PDF structure layer of the accessibility
+/// surface (#631): struct-tree reading order, the structure-role automation
+/// peers (headings, lists, tables), and structure-based keyboard navigation.
+///
+/// Companion to <see cref="PdfViewerAccessibilityTests"/> (page-text and /Alt
+/// peers). Runs through <see cref="HeadlessSessionGuard"/> from plain [Fact]s
+/// so a headless-startup failure skips rather than crashing the host (#752),
+/// and stays clear of the Avalonia.Headless.XUnit TestContext bug (#337).
+/// SkiaSharp's font manager is process-wide, so this file must not parallelize
+/// (the assembly's collection serialization is inherited).
+/// </summary>
+public class PdfViewerStructTreeA11yTests
+{
+    // ── harness ──────────────────────────────────────────────────────────
+
+    private static Task<T> OnUiThread<T>(Func<T> body) =>
+        HeadlessSessionGuard.Session().Dispatch(body, CancellationToken.None);
+
+    private static (PdfViewerControl Viewer, PdfViewerAutomationPeer Peer) CreateViewerWithPeer(
+        PdfDocument document)
+    {
+        var viewer = new PdfViewerControl { Document = document };
+        var peer = (PdfViewerAutomationPeer)ControlAutomationPeer.CreatePeerForElement(viewer);
+        return (viewer, peer);
+    }
+
+    private static AutomationPeer PageTextChild(AutomationPeer peer) =>
+        peer.GetChildren().First(c => c.GetClassName() == "PdfPageText");
+
+    private static List<PdfStructRoleAutomationPeer> RolePeers(AutomationPeer peer) =>
+        peer.GetChildren().OfType<PdfStructRoleAutomationPeer>().ToList();
+
+    private static string Normalized(string? s) =>
+        string.Join(" ", (s ?? string.Empty).Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries));
+
+    // ── fixtures ─────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// A raw single-page tagged PDF with two top-level struct elements of type
+    /// <paramref name="structType"/>, carrying <c>/ActualText</c>
+    /// <paramref name="first"/> then <paramref name="second"/> in structure
+    /// order. The content stream draws the words in the OPPOSITE (geometric)
+    /// order — "second" glyphs above "first" glyphs — so struct order and
+    /// geometric reading order diverge, which is the only way to prove reading
+    /// order really follows the structure tree.
+    /// </summary>
+    private static byte[] RawTaggedPdfTwoElements(string structType, string first, string second)
+    {
+        // Geometric top-to-bottom: the higher line reads first. Draw a marker
+        // for the second element higher, the first element lower.
+        const string content =
+            "BT /F1 12 Tf 72 720 Td (SecondGlyphs) Tj 0 -24 Td (FirstGlyphs) Tj ET";
+        var objects = new[]
+        {
+            "<< /Type /Catalog /Pages 2 0 R /StructTreeRoot 6 0 R /MarkInfo << /Marked true >> >>",
+            "<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] " +
+                "/Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>",
+            "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+            $"<< /Length {content.Length} >>\nstream\n{content}\nendstream",
+            "<< /Type /StructTreeRoot /K [7 0 R 8 0 R] >>",
+            $"<< /Type /StructElem /S /{structType} /ActualText ({first}) /Pg 3 0 R >>",
+            $"<< /Type /StructElem /S /{structType} /ActualText ({second}) /Pg 3 0 R >>",
+        };
+        return AssembleObjects(objects);
+    }
+
+    private static byte[] AssembleObjects(string[] objects)
+    {
+        var sb = new StringBuilder("%PDF-1.7\n");
+        var offsets = new long[objects.Length + 1];
+        for (int i = 0; i < objects.Length; i++)
+        {
+            offsets[i + 1] = sb.Length; // ASCII-only, so char count == byte offset
+            sb.Append($"{i + 1} 0 obj\n{objects[i]}\nendobj\n");
+        }
+        long xref = sb.Length;
+        sb.Append($"xref\n0 {objects.Length + 1}\n0000000000 65535 f \n");
+        for (int i = 1; i <= objects.Length; i++)
+            sb.Append($"{offsets[i]:0000000000} 00000 n \n");
+        sb.Append($"trailer\n<< /Size {objects.Length + 1} /Root 1 0 R >>\nstartxref\n{xref}\n%%EOF");
+        return Encoding.ASCII.GetBytes(sb.ToString());
+    }
+
+    /// <summary>
+    /// A builder-authored tagged single page with a heading, a bullet list,
+    /// and a table — real H1 / L / LI / Table / TR / TH / TD struct elements.
+    /// Their body text lives in MCID marked content (not reachable read-only),
+    /// so the role peers carry the ROLE with empty text — exactly the case the
+    /// role mapping must still expose.
+    /// </summary>
+    private static PdfDocument BuilderTaggedRichDoc() =>
+        PdfDocument.Open(PdfDocumentBuilder.Create()
+            .Tagged()
+            .Heading("Quarterly Report", 1)
+            .BulletList(new[] { "First point", "Second point" })
+            .Table(new[]
+            {
+                new[] { "Region", "Revenue" },
+                new[] { "North", "100" },
+            }, headerRow: true)
+            .SaveToBytes());
+
+    /// <summary>Two-page builder-tagged doc, one H1 heading per page.</summary>
+    private static PdfDocument BuilderTaggedTwoPageHeadings() =>
+        PdfDocument.Open(PdfDocumentBuilder.Create()
+            .Tagged()
+            .Heading("Page One Heading", 1)
+            .Paragraph("Body of page one")
+            .PageBreak()
+            .Heading("Page Two Heading", 1)
+            .Paragraph("Body of page two")
+            .SaveToBytes());
+
+    // ── reading order (requirement 1) ────────────────────────────────────
+
+    [Fact]
+    public async Task ReadingOrderText_FollowsStructTree_NotGeometricOrder()
+    {
+        await OnUiThread(() =>
+        {
+            var (viewer, peer) = CreateViewerWithPeer(
+                PdfDocument.Open(RawTaggedPdfTwoElements("P", "First", "Second")));
+
+            // The page-text peer now serves struct-ordered text.
+            Normalized(PageTextChild(peer).GetName())
+                .Should().Be("First Second",
+                    "reading order must follow the structure tree's document order");
+
+            // Proof it is not merely the geometric text relabeled: the raw
+            // glyph extraction reads the two lines top-to-bottom, the reverse.
+            Normalized(viewer.GetAccessiblePageText())
+                .Should().Contain("SecondGlyphs").And.Contain("FirstGlyphs");
+            Normalized(viewer.GetAccessibleReadingOrderText())
+                .Should().NotContain("Glyphs",
+                    "struct /ActualText carriers replace the geometric glyph text");
+            return true;
+        });
+    }
+
+    [Fact]
+    public async Task ReadingOrderText_UntaggedDocument_FallsBackToGeometric()
+    {
+        await OnUiThread(() =>
+        {
+            var doc = PdfDocument.Open(PdfDocumentBuilder.Create()
+                .Paragraph("Plain untagged content")
+                .SaveToBytes());
+            var (viewer, peer) = CreateViewerWithPeer(doc);
+
+            // No struct tree → the geometric reading-order text is used.
+            Normalized(PageTextChild(peer).GetName())
+                .Should().Contain("Plain untagged content");
+            Normalized(viewer.GetAccessibleReadingOrderText())
+                .Should().Be(Normalized(viewer.GetAccessiblePageText()));
+            return true;
+        });
+    }
+
+    // ── role peers (requirement 2) ───────────────────────────────────────
+
+    [Fact]
+    public async Task StructRolePeers_ExposeHeadingListAndTableRoles()
+    {
+        await OnUiThread(() =>
+        {
+            var (_, peer) = CreateViewerWithPeer(BuilderTaggedRichDoc());
+            var roles = RolePeers(peer);
+
+            roles.Select(r => r.Role).Should().Contain(new[]
+            {
+                AccessibleStructRole.Heading,
+                AccessibleStructRole.List,
+                AccessibleStructRole.ListItem,
+                AccessibleStructRole.Table,
+                AccessibleStructRole.TableRow,
+            }, "every mapped structural role on the page must be enumerable");
+
+            // Cells appear as header or body cells.
+            roles.Select(r => r.Role).Should().Contain(r =>
+                r == AccessibleStructRole.TableHeaderCell || r == AccessibleStructRole.TableCell);
+
+            // No figure duplicates the /Alt image peers.
+            roles.Should().NotContain(r => r.Role == AccessibleStructRole.Figure);
+            return true;
+        });
+    }
+
+    [Fact]
+    public async Task HeadingRolePeer_MapsToTextControlType_WithSpokenLevel()
+    {
+        await OnUiThread(() =>
+        {
+            var (_, peer) = CreateViewerWithPeer(BuilderTaggedRichDoc());
+
+            var heading = RolePeers(peer).First(r => r.Role == AccessibleStructRole.Heading);
+            heading.HeadingLevel.Should().Be(1);
+            heading.GetAutomationControlType().Should().Be(AutomationControlType.Text);
+            heading.GetLocalizedControlType().Should().Be("heading level 1");
+            heading.IsContentElement().Should().BeTrue();
+            heading.GetParent().Should().BeSameAs(peer, "an orphaned peer is invisible to AT");
+            return true;
+        });
+    }
+
+    [Fact]
+    public async Task ListAndTableRolePeers_MapToTheirControlTypes()
+    {
+        await OnUiThread(() =>
+        {
+            var (_, peer) = CreateViewerWithPeer(BuilderTaggedRichDoc());
+            var roles = RolePeers(peer);
+
+            roles.First(r => r.Role == AccessibleStructRole.List)
+                .GetAutomationControlType().Should().Be(AutomationControlType.List);
+            roles.First(r => r.Role == AccessibleStructRole.ListItem)
+                .GetAutomationControlType().Should().Be(AutomationControlType.ListItem);
+            roles.First(r => r.Role == AccessibleStructRole.Table)
+                .GetAutomationControlType().Should().Be(AutomationControlType.Table);
+            roles.First(r => r.Role == AccessibleStructRole.TableRow)
+                .GetAutomationControlType().Should().Be(AutomationControlType.DataItem);
+            return true;
+        });
+    }
+
+    [Fact]
+    public async Task UntaggedDocument_HasNoStructRolePeers()
+    {
+        await OnUiThread(() =>
+        {
+            var doc = PdfDocument.Open(PdfDocumentBuilder.Create()
+                .Paragraph("No structure here")
+                .SaveToBytes());
+            var (_, peer) = CreateViewerWithPeer(doc);
+            RolePeers(peer).Should().BeEmpty();
+            return true;
+        });
+    }
+
+    // ── keyboard navigation (requirement 3) ──────────────────────────────
+
+    [Fact]
+    public async Task NextHeading_LandsOnHeadingsInDocumentOrder()
+    {
+        await OnUiThread(() =>
+        {
+            var (viewer, _) = CreateViewerWithPeer(
+                PdfDocument.Open(RawTaggedPdfTwoElements("H1", "Alpha Heading", "Beta Heading")));
+
+            viewer.CurrentStructureNavigationTarget.Should().BeNull("no navigation yet");
+
+            viewer.MoveToNextStructure(backward: false, headingsOnly: true).Should().BeTrue();
+            var first = viewer.CurrentStructureNavigationTarget;
+            first.Should().NotBeNull();
+            first!.Value.Role.Should().Be(AccessibleStructRole.Heading);
+            first.Value.Text.Should().Be("Alpha Heading");
+
+            viewer.MoveToNextStructure(backward: false, headingsOnly: true).Should().BeTrue();
+            viewer.CurrentStructureNavigationTarget!.Value.Text.Should().Be("Beta Heading");
+
+            viewer.MoveToNextStructure(backward: false, headingsOnly: true)
+                .Should().BeFalse("there is no heading after the last one");
+
+            // Backward returns to the first heading.
+            viewer.MoveToNextStructure(backward: true, headingsOnly: true).Should().BeTrue();
+            viewer.CurrentStructureNavigationTarget!.Value.Text.Should().Be("Alpha Heading");
+            return true;
+        });
+    }
+
+    [Fact]
+    public async Task NextHeading_CrossesPageBoundary_AndMovesCurrentPage()
+    {
+        await OnUiThread(() =>
+        {
+            var (viewer, _) = CreateViewerWithPeer(BuilderTaggedTwoPageHeadings());
+            viewer.CurrentPage.Should().Be(1);
+
+            // First heading is on page 1.
+            viewer.MoveToNextStructure(backward: false, headingsOnly: true).Should().BeTrue();
+            viewer.CurrentStructureNavigationTarget!.Value.Page.Should().Be(1);
+            viewer.CurrentPage.Should().Be(1);
+
+            // Next heading lives on page 2 — navigation must bring it on screen.
+            viewer.MoveToNextStructure(backward: false, headingsOnly: true).Should().BeTrue();
+            viewer.CurrentStructureNavigationTarget!.Value.Page.Should().Be(2);
+            viewer.CurrentPage.Should().Be(2, "landing on a heading must show its page");
+            return true;
+        });
+    }
+
+    [Fact]
+    public async Task StructureNavigation_UntaggedDocument_IsNoOp()
+    {
+        await OnUiThread(() =>
+        {
+            var doc = PdfDocument.Open(PdfDocumentBuilder.Create()
+                .Paragraph("Nothing to navigate")
+                .SaveToBytes());
+            var (viewer, _) = CreateViewerWithPeer(doc);
+
+            viewer.MoveToNextStructure(backward: false, headingsOnly: true).Should().BeFalse();
+            viewer.CurrentStructureNavigationTarget.Should().BeNull();
+            return true;
+        });
+    }
+}

--- a/Excise.Avalonia/Automation/PdfViewerAutomationPeer.cs
+++ b/Excise.Avalonia/Automation/PdfViewerAutomationPeer.cs
@@ -29,6 +29,7 @@ internal sealed class PdfViewerAutomationPeer : ControlAutomationPeer
     private PdfPageTextAutomationPeer? _textPeer;
     private List<PdfAltTextAutomationPeer> _altPeers = new();
     private List<PdfActualTextAutomationPeer> _actualTextPeers = new();
+    private List<PdfStructRoleAutomationPeer> _rolePeers = new();
 
     public PdfViewerAutomationPeer(PdfViewerControl viewer)
         : base(viewer)
@@ -47,6 +48,7 @@ internal sealed class PdfViewerAutomationPeer : ControlAutomationPeer
         var result = new List<AutomationPeer> { _textPeer };
         result.AddRange(_altPeers);
         result.AddRange(_actualTextPeers);
+        result.AddRange(_rolePeers);
         var baseChildren = base.GetChildrenCore();
         if (baseChildren != null)
             result.AddRange(baseChildren);
@@ -62,11 +64,43 @@ internal sealed class PdfViewerAutomationPeer : ControlAutomationPeer
     /// </summary>
     private bool SyncDescriptionPeers()
     {
-        // Non-short-circuit: both sets must be brought current.
+        // Non-short-circuit: all sets must be brought current.
         return SyncPeerList(_viewer.GetAccessibleAltTexts(), ref _altPeers,
                    static (text, i) => new PdfAltTextAutomationPeer(text, i))
              | SyncPeerList(_viewer.GetAccessibleActualTexts(), ref _actualTextPeers,
-                   static (text, i) => new PdfActualTextAutomationPeer(text, i));
+                   static (text, i) => new PdfActualTextAutomationPeer(text, i))
+             | SyncRolePeers();
+    }
+
+    /// <summary>
+    /// Rebuild the structure-role children (headings, lists, tables) if the
+    /// current page's role set changed. Keyed on role + heading level + text
+    /// so a page change that swaps one heading for another of the same text
+    /// but a different level is still detected. Returns true when they changed.
+    /// </summary>
+    private bool SyncRolePeers()
+    {
+        var nodes = _viewer.GetAccessibleStructRoleNodes();
+        if (nodes.Count == _rolePeers.Count)
+        {
+            bool same = true;
+            for (int i = 0; i < nodes.Count; i++)
+            {
+                if (!_rolePeers[i].Matches(nodes[i]))
+                {
+                    same = false;
+                    break;
+                }
+            }
+            if (same)
+                return false;
+        }
+
+        var replacement = new List<PdfStructRoleAutomationPeer>(nodes.Count);
+        for (int i = 0; i < nodes.Count; i++)
+            replacement.Add(new PdfStructRoleAutomationPeer(nodes[i], i));
+        _rolePeers = replacement;
+        return true;
     }
 
     private static bool SyncPeerList<TPeer>(
@@ -145,7 +179,7 @@ internal sealed class PdfPageTextAutomationPeer : UnrealizedElementAutomationPee
         _viewer = viewer;
     }
 
-    protected override string? GetNameCore() => _viewer.GetAccessiblePageText();
+    protected override string? GetNameCore() => _viewer.GetAccessibleReadingOrderText();
 
     protected override AutomationControlType GetAutomationControlTypeCore() =>
         AutomationControlType.Text;
@@ -283,4 +317,92 @@ internal sealed class PdfActualTextAutomationPeer : PdfStructTextAutomationPeer
     protected override string GetAutomationIdCore() => $"PdfActualText{_index}";
 
     protected override string GetLocalizedControlTypeCore() => "replacement text";
+}
+
+/// <summary>
+/// Synthetic peer for one structurally significant tagged-PDF element on the
+/// current page — a heading, list, list item, table, row, or cell (issue
+/// #631). It maps the PDF structure role to the nearest Avalonia
+/// <see cref="AutomationControlType"/> and a spoken localized control type, so
+/// a screen reader can enumerate the document's structure and jump between
+/// headings. The element's text (<c>/ActualText</c> then <c>/Alt</c>) is the
+/// Name; it is empty for a tagged PDF that supplies neither, in which case the
+/// role alone is announced (the body glyphs need MCID-to-letter mapping to
+/// reach, a follow-up slice of #631).
+/// </summary>
+internal sealed class PdfStructRoleAutomationPeer : UnrealizedElementAutomationPeer
+{
+    private readonly AccessibleStructNode _node;
+    private readonly int _index;
+    private AutomationPeer? _parent;
+
+    public PdfStructRoleAutomationPeer(AccessibleStructNode node, int index)
+    {
+        _node = node;
+        _index = index;
+    }
+
+    /// <summary>True when this peer already represents the given node.</summary>
+    public bool Matches(AccessibleStructNode node) =>
+        _node.Role == node.Role
+        && _node.HeadingLevel == node.HeadingLevel
+        && string.Equals(_node.Text, node.Text, StringComparison.Ordinal);
+
+    protected override string? GetNameCore() => _node.Text;
+
+    protected override AutomationControlType GetAutomationControlTypeCore() =>
+        _node.Role switch
+        {
+            AccessibleStructRole.Heading => AutomationControlType.Text,
+            AccessibleStructRole.List => AutomationControlType.List,
+            AccessibleStructRole.ListItem => AutomationControlType.ListItem,
+            AccessibleStructRole.Table => AutomationControlType.Table,
+            AccessibleStructRole.TableRow => AutomationControlType.DataItem,
+            AccessibleStructRole.TableHeaderCell => AutomationControlType.Header,
+            AccessibleStructRole.TableCell => AutomationControlType.Text,
+            _ => AutomationControlType.Text,
+        };
+
+    protected override string GetLocalizedControlTypeCore() =>
+        _node.Role switch
+        {
+            AccessibleStructRole.Heading =>
+                _node.HeadingLevel >= 1 ? $"heading level {_node.HeadingLevel}" : "heading",
+            AccessibleStructRole.List => "list",
+            AccessibleStructRole.ListItem => "list item",
+            AccessibleStructRole.Table => "table",
+            AccessibleStructRole.TableRow => "table row",
+            AccessibleStructRole.TableHeaderCell => "table header cell",
+            AccessibleStructRole.TableCell => "table cell",
+            _ => "content",
+        };
+
+    /// <summary>The structure role this peer exposes. Used by tests.</summary>
+    public AccessibleStructRole Role => _node.Role;
+
+    /// <summary>The heading level (1–6), or 0 for non-headings. Used by tests.</summary>
+    public int HeadingLevel => _node.HeadingLevel;
+
+    protected override string GetClassNameCore() => "PdfStructRole";
+
+    protected override string GetAutomationIdCore() => $"PdfStructRole{_index}";
+
+    protected override string? GetAcceleratorKeyCore() => null;
+
+    protected override string? GetAccessKeyCore() => null;
+
+    protected override AutomationPeer? GetLabeledByCore() => null;
+
+    protected override AutomationPeer? GetParentCore() => _parent;
+
+    // Same synthetic-node parenting contract as the other peers: accepting the
+    // parent set by ControlAutomationPeer's child wiring links this node in.
+    protected override bool TrySetParent(AutomationPeer? parent)
+    {
+        _parent = parent;
+        return true;
+    }
+
+    protected override bool IsContentElementCore() => true;
+    protected override bool IsControlElementCore() => true;
 }

--- a/Excise.Avalonia/Controls/PdfViewerControl.Accessibility.cs
+++ b/Excise.Avalonia/Controls/PdfViewerControl.Accessibility.cs
@@ -40,6 +40,30 @@ public partial class PdfViewerControl
     private IReadOnlyList<string> _altTextCache = Array.Empty<string>();
     private IReadOnlyList<string> _actualTextCache = Array.Empty<string>();
 
+    // ── struct-tree reading order + role layer (#631) ────────────────────
+    // Doc-wide (not per-page) caches: keyboard structure navigation crosses
+    // page boundaries, so the ordered node list must span the whole document.
+    // Keyed by (Document, RenderVersion) — a RenderVersion bump means the
+    // structure tree may have been rewritten (redaction scrubs /Alt and
+    // /ActualText, #636), so the model must be rebuilt and stale roles dropped.
+    private PdfDocument? _structNavDocument;
+    private long _structNavRenderVersion = -1;
+    // Reading-order text carriers (elements with /ActualText) in document
+    // order, tagged with their page. This is the ONLY per-element text the
+    // read-only Excise.Core surface exposes: mapping marked-content IDs back
+    // to the extracted glyphs (so a heading's real body text could be read in
+    // struct order) needs Excise.Core to surface MCID→letter mapping, which it
+    // does not yet — a follow-up slice of #631.
+    private IReadOnlyList<(int Page, string Text)> _structReadingParts =
+        Array.Empty<(int, string)>();
+    // Structurally significant elements (headings, lists, tables) in document
+    // order, for the role automation peers and keyboard navigation.
+    private IReadOnlyList<AccessibleStructNode> _structNodes =
+        Array.Empty<AccessibleStructNode>();
+    // Index into _structNodes the last structure-navigation keystroke landed
+    // on, or -1 before any navigation.
+    private int _structNavCursor = -1;
+
     /// <summary>
     /// The <c>/Alt</c> alternative descriptions of tagged structure elements
     /// (typically <c>/Figure</c>) associated with the current page, in
@@ -243,4 +267,262 @@ public partial class PdfViewerControl
 
         return null;
     }
+
+    // ── struct-tree reading order + role model (#631) ────────────────────
+
+    /// <summary>
+    /// The current page's text in reading order, ordered by the structure
+    /// tree when the tagged PDF supplies orderable text (issue #631). Uses the
+    /// document-order sequence of <c>/ActualText</c> carriers where present;
+    /// otherwise falls back to the geometric reading-order text (see
+    /// <see cref="GetAccessiblePageText"/>). Struct order is used only when it
+    /// actually carries text: without MCID-to-letter mapping (a follow-up
+    /// slice of #631) a heading's body glyphs cannot be read in struct order,
+    /// so a tagged PDF that supplies no <c>/ActualText</c> reads geometrically.
+    /// </summary>
+    internal string GetAccessibleReadingOrderText()
+    {
+        EnsureStructNavModel();
+
+        int page = CurrentPage;
+        List<string>? parts = null;
+        foreach (var (p, text) in _structReadingParts)
+        {
+            if (p != page)
+                continue;
+            (parts ??= new List<string>()).Add(text);
+        }
+
+        return parts is { Count: > 0 }
+            ? string.Join(" ", parts)
+            : GetAccessiblePageText();
+    }
+
+    /// <summary>
+    /// The structurally significant elements (headings, lists and list items,
+    /// tables/rows/cells) on the current page in document order, each carrying
+    /// its role and any text carrier (<c>/ActualText</c> then <c>/Alt</c>).
+    /// Figures are deliberately excluded — they are already exposed as image
+    /// description peers via <see cref="GetAccessibleAltTexts"/> — so a screen
+    /// reader never hears a figure twice. Empty when the document is untagged.
+    /// </summary>
+    internal IReadOnlyList<AccessibleStructNode> GetAccessibleStructRoleNodes()
+    {
+        EnsureStructNavModel();
+
+        int page = CurrentPage;
+        List<AccessibleStructNode>? nodes = null;
+        foreach (var node in _structNodes)
+        {
+            if (node.Page != page || node.Role == AccessibleStructRole.Figure)
+                continue;
+            (nodes ??= new List<AccessibleStructNode>()).Add(node);
+        }
+
+        return (IReadOnlyList<AccessibleStructNode>?)nodes
+            ?? Array.Empty<AccessibleStructNode>();
+    }
+
+    /// <summary>
+    /// The structure element the last structure-navigation keystroke landed
+    /// on (see <see cref="MoveToNextStructure"/>), or null before any
+    /// navigation. Exposed for assistive-technology announcement and tests.
+    /// </summary>
+    internal AccessibleStructNode? CurrentStructureNavigationTarget =>
+        _structNavCursor >= 0 && _structNavCursor < _structNodes.Count
+            ? _structNodes[_structNavCursor]
+            : null;
+
+    /// <summary>
+    /// Move the structure-navigation cursor to the next (or previous) node,
+    /// optionally restricted to headings — the "next/previous heading"
+    /// screen-reader convention (issue #631). Crosses page boundaries: if the
+    /// target lives on another page the current page is changed so the landed
+    /// element is on screen. Returns true when the cursor moved.
+    /// </summary>
+    /// <param name="backward">Search toward the document start.</param>
+    /// <param name="headingsOnly">Only stop on heading elements.</param>
+    internal bool MoveToNextStructure(bool backward, bool headingsOnly)
+    {
+        EnsureStructNavModel();
+        if (_structNodes.Count == 0)
+            return false;
+
+        int step = backward ? -1 : 1;
+        for (int i = _structNavCursor + step; i >= 0 && i < _structNodes.Count; i += step)
+        {
+            var node = _structNodes[i];
+            if (node.Role == AccessibleStructRole.Figure)
+                continue; // navigable structure, not a figure description
+            if (headingsOnly && node.Role != AccessibleStructRole.Heading)
+                continue;
+
+            _structNavCursor = i;
+            if (node.Page >= 1 && node.Page <= (Document?.PageCount ?? 0)
+                && node.Page != CurrentPage)
+                CurrentPage = node.Page;
+
+            // Tell assistive technology the accessible content the user is now
+            // "on" changed, so it re-reads the role-peer set for this page.
+            (global::Avalonia.Automation.Peers.ControlAutomationPeer.FromElement(this)
+                as Excise.Avalonia.Automation.PdfViewerAutomationPeer)
+                ?.NotifyPageTextChanged();
+            return true;
+        }
+
+        return false; // already at the last (or first) matching element
+    }
+
+    private void EnsureStructNavModel()
+    {
+        var doc = Document;
+        long version = RenderVersion;
+
+        if (ReferenceEquals(_structNavDocument, doc) && _structNavRenderVersion == version)
+            return;
+
+        IReadOnlyList<(int, string)> reading = Array.Empty<(int, string)>();
+        IReadOnlyList<AccessibleStructNode> nodes = Array.Empty<AccessibleStructNode>();
+        if (doc != null && doc.PageCount > 0)
+        {
+            try
+            {
+                (reading, nodes) = CollectStructModel(doc);
+            }
+            catch (Exception ex) when (ex is not OutOfMemoryException)
+            {
+                // A malformed structure tree must never take the viewer down;
+                // structure navigation degrades to nothing.
+                reading = Array.Empty<(int, string)>();
+                nodes = Array.Empty<AccessibleStructNode>();
+            }
+        }
+
+        _structNavDocument = doc;
+        _structNavRenderVersion = version;
+        _structReadingParts = reading;
+        _structNodes = nodes;
+        _structNavCursor = -1; // a new model invalidates the navigation cursor
+    }
+
+    private static (IReadOnlyList<(int, string)> Reading,
+                    IReadOnlyList<AccessibleStructNode> Nodes)
+        CollectStructModel(PdfDocument doc)
+    {
+        var root = doc.GetStructureTree();
+        if (root == null)
+            return (Array.Empty<(int, string)>(), Array.Empty<AccessibleStructNode>());
+
+        var pagesByDict = new Dictionary<PdfDictionary, int>();
+        for (int i = 1; i <= doc.PageCount; i++)
+            pagesByDict[doc.GetPage(i).Dictionary] = i;
+
+        var reading = new List<(int, string)>();
+        var nodes = new List<AccessibleStructNode>();
+        WalkModel(doc, root, inheritedPage: null, pagesByDict, reading, nodes, depth: 0);
+        return (reading.Count == 0 ? Array.Empty<(int, string)>() : reading,
+                nodes.Count == 0 ? Array.Empty<AccessibleStructNode>() : nodes);
+    }
+
+    private static void WalkModel(
+        PdfDocument doc,
+        PdfStructElement element,
+        int? inheritedPage,
+        Dictionary<PdfDictionary, int> pagesByDict,
+        List<(int, string)> reading,
+        List<AccessibleStructNode> nodes,
+        int depth)
+    {
+        if (depth > MaxStructWalkDepth)
+            return;
+
+        int? page = ResolveElementPage(doc, element, pagesByDict) ?? inheritedPage;
+        int effectivePage = page ?? (doc.PageCount == 1 ? 1 : 0);
+
+        if (effectivePage >= 1)
+        {
+            // Reading order: /ActualText is the author's "read this instead of
+            // the glyphs" carrier, so it is the only content safe to splice
+            // into linear reading order. /Alt is a supplementary description
+            // (exposed separately as an image peer), never linear text.
+            if (!string.IsNullOrWhiteSpace(element.ActualText))
+                reading.Add((effectivePage, element.ActualText!.Trim()));
+
+            var (role, headingLevel) = ClassifyStructRole(element.Type);
+            if (role != AccessibleStructRole.Generic)
+            {
+                string text = !string.IsNullOrWhiteSpace(element.ActualText)
+                    ? element.ActualText!.Trim()
+                    : (!string.IsNullOrWhiteSpace(element.AltText)
+                        ? element.AltText!.Trim()
+                        : string.Empty);
+                nodes.Add(new AccessibleStructNode(role, headingLevel, text, effectivePage));
+            }
+        }
+
+        foreach (var child in element.Children)
+            WalkModel(doc, child, page, pagesByDict, reading, nodes, depth + 1);
+    }
+
+    /// <summary>
+    /// Map a structure element type (ISO 32000-2 §14.8.4 standard structure
+    /// types, with the leading <c>/</c> that <c>PdfStructTreeParser</c>
+    /// prepends) to an accessibility role. Bare <c>H</c> and numbered
+    /// <c>H1</c>–<c>H6</c> both map to <see cref="AccessibleStructRole.Heading"/>.
+    /// </summary>
+    private static (AccessibleStructRole Role, int HeadingLevel) ClassifyStructRole(string type)
+    {
+        string t = type.TrimStart('/');
+        if (t.Length == 0)
+            return (AccessibleStructRole.Generic, 0);
+
+        if (t == "H")
+            return (AccessibleStructRole.Heading, 0);
+        if (t.Length >= 2 && t[0] == 'H' && char.IsDigit(t[1])
+            && int.TryParse(t.AsSpan(1), out int level) && level is >= 1 and <= 6)
+            return (AccessibleStructRole.Heading, level);
+
+        return t switch
+        {
+            "L" => (AccessibleStructRole.List, 0),
+            "LI" => (AccessibleStructRole.ListItem, 0),
+            "Table" => (AccessibleStructRole.Table, 0),
+            "TR" => (AccessibleStructRole.TableRow, 0),
+            "TH" => (AccessibleStructRole.TableHeaderCell, 0),
+            "TD" => (AccessibleStructRole.TableCell, 0),
+            "Figure" => (AccessibleStructRole.Figure, 0),
+            _ => (AccessibleStructRole.Generic, 0),
+        };
+    }
+}
+
+/// <summary>
+/// A structurally significant element of a tagged PDF's structure tree, mapped
+/// to an accessibility role for the automation peer tree and structure-based
+/// keyboard navigation (issue #631).
+/// </summary>
+/// <param name="Role">The accessibility role.</param>
+/// <param name="HeadingLevel">1–6 for <c>/H1</c>–<c>/H6</c>; 0 for a bare
+/// <c>/H</c> or a non-heading role.</param>
+/// <param name="Text">The element's text carrier (<c>/ActualText</c> then
+/// <c>/Alt</c>), or empty when the tagged PDF supplies neither.</param>
+/// <param name="Page">The 1-based page the element belongs to.</param>
+internal readonly record struct AccessibleStructNode(
+    AccessibleStructRole Role,
+    int HeadingLevel,
+    string Text,
+    int Page);
+
+/// <summary>Accessibility roles mapped from PDF structure element types (#631).</summary>
+internal enum AccessibleStructRole
+{
+    Generic,
+    Heading,
+    List,
+    ListItem,
+    Table,
+    TableRow,
+    TableHeaderCell,
+    TableCell,
+    Figure,
 }

--- a/Excise.Avalonia/Controls/PdfViewerControl.axaml.cs
+++ b/Excise.Avalonia/Controls/PdfViewerControl.axaml.cs
@@ -977,6 +977,15 @@ public partial class PdfViewerControl : UserControl
                         handled = true;
                     }
                     break;
+                case Key.H:
+                    // Structure navigation (#631): H jumps to the next heading,
+                    // Shift+H to the previous — the screen-reader convention —
+                    // crossing pages as needed. No-op (unhandled) on untagged
+                    // documents so the key stays available to other handlers.
+                    handled = MoveToNextStructure(
+                        backward: e.KeyModifiers.HasFlag(KeyModifiers.Shift),
+                        headingsOnly: true);
+                    break;
             }
         }
 


### PR DESCRIPTION
## Summary

Implements the remaining core of #631 — the accessible-text **layer** over the
already-parsed tagged-PDF structure tree. Screen readers can now read a tagged
document's content in structure order, enumerate its structure, and jump
between headings. Touches only `Excise.Avalonia/**` and its tests (read-only
use of `Excise.Core` struct-tree types).

### What's new
- **Struct-tree reading order** — the page-text automation peer serves
  `/ActualText` carriers in document order when a tagged PDF supplies them,
  falling back to geometric reading order otherwise
  (`GetAccessibleReadingOrderText`).
- **Role peers** — headings (H1–H6), lists/list items, tables/rows/cells are
  surfaced as `PdfStructRoleAutomationPeer` children mapped to Avalonia
  `AutomationControlType` + spoken localized control types ("heading level 1",
  "list item", "table row", …). Figures keep coming through the existing
  `/Alt` image peers (no duplication).
- **Keyboard navigation** — `H` / `Shift+H` move to the next / previous heading
  across page boundaries (`MoveToNextStructure`), wired into `OnViewerKeyDown`.
  Typewriter/search text entry routes through a `TextBox`, which the existing
  `IsKeyboardEditingSource` guard already excludes, so the letter binding does
  not interfere with typing; on untagged docs `H` is a no-op and stays
  available to other handlers.

### Scope / deferred
- Reading a heading's **body glyphs** in struct order still needs MCID→letter
  mapping from `Excise.Core` (not surfaced read-only) — a follow-up slice of
  #631. Elements without `/ActualText` therefore expose role-only peers.
- Out of scope by request: untagged reading-order heuristics (#773), PDF/UA +
  PDF/A conformance validation (#772). "Next link" nav is not implemented —
  links are annotations, not struct elements, and the stated test criterion is
  *heading* navigation; the `headingsOnly` parameter leaves the door open.

### Tests
`Excise.Avalonia.Tests/PdfViewerStructTreeA11yTests.cs` (9 tests, headless):
- reading order follows the struct tree, proven with a fixture whose
  `/ActualText` order **diverges** from geometric glyph order;
- untagged docs fall back to geometric text and expose no role peers;
- role peers expose heading/list/table roles and their control types;
- `H`/`Shift+H` land on headings in document order, including across pages.

Full `Excise.Avalonia.Tests` suite: **81 passed, 0 failed**. Build 0 warnings.
No public API change → **no `approved.txt` regenerated** (all new members are
`internal`; `ViewerPublicApiApprovalTests` passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)