### PR TITLE
feat(annotations): remaining #626 subtypes — markup, shapes, stamps, edit/reply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,43 @@ semantic versioning.
   pdftocairo/Ghostscript differentials pinning the out-of-range fallback.
 
 ### Added
+- **Remaining #626 annotation subtypes: markup, shapes, stamps, edit/reply**
+  (#626) — `PdfAnnotationAuthoring` now covers the rest of ISO 32000-2
+  §12.5.6's programmatic authoring surface, each with a baked, self-contained
+  `/AP /N` appearance stream so third-party viewers render the same pixels
+  (excise cannot be its own oracle for this — see below):
+  - **Text markup**: `AddUnderlineAnnotation`, `AddStrikeOutAnnotation`,
+    `AddSquigglyAnnotation` (§12.5.6.10) mirror `AddHighlightAnnotation`'s
+    single-quad shape but bake a stroked line/zig-zag appearance, since
+    (unlike Highlight) most viewers do not synthesize one for these subtypes.
+  - **Line/Arrow/Polygon/PolyLine** (§12.5.6.7, §12.5.6.9): `AddLineAnnotation`
+    and `AddArrowAnnotation` write `/L` plus `/LE` line-endings (`None`,
+    `OpenArrow`, `ClosedArrow`) with a matching baked triangular arrowhead;
+    `AddPolygonAnnotation` (closed, optional `/IC` fill) and
+    `AddPolyLineAnnotation` (always open, stroke-only) write `/Vertices`.
+  - **Stamp** (§12.5.6.12): `AddStampAnnotation` renders one of the 15
+    standard rubber-stamp names (`PdfAnnotationAuthoring.StandardStampNames`)
+    as a bordered, colored, bold-labeled box — excise has no bundled Acrobat
+    icon artwork, so this trades exact icon fidelity for guaranteed
+    cross-viewer pixel identity. `AddImageStampAnnotation` embeds a
+    caller-supplied raw RGB24 image as an uncompressed DeviceRGB Image
+    XObject for a custom/logo stamp, with no dependency on a JPEG/PNG codec.
+  - **Edit and delete**: `SetAnnotationContents`, `SetAnnotationColor`,
+    `SetAnnotationOpacity` mutate `/Contents`, `/C`, `/CA` on an existing
+    annotation in place (refreshing `/M`); `RemoveAnnotation` detaches an
+    annotation from a page's `/Annots` array.
+  - **Reply threads** (§12.5.6.2): `SetReplyTo` sets `/IRT` (an indirect
+    reference to the parent annotation) and `/RT` (`R` or `Group`).
+  - `XfdfSerializer`/`FdfSerializer` gained a `stamp`/`Stamp` import case
+    (previously exported but not re-importable) and now carry `/IC` through
+    generic Polygon imports (a pre-existing round-trip gap this work
+    surfaced); every new subtype round-trips position, color, `/T` author,
+    `/Contents` and `/CA` opacity through both formats.
+  - Verified with an independent-renderer gate, not excise reading its own
+    output: mutool and pdftocairo render every new appearance stream
+    (ink-region assertions on the saved file), and a third test confirms
+    excise's own `SkiaRenderer` agrees with mutool on the same pixels
+    (`Excise.Rendering.Tests/Differential/RemainingAnnotationSubtypesDifferentialTests.cs`).
 - **FDF annotation import/export round-trip** (#626) — `Excise.Core.Forms.FdfSerializer`
   reads and writes the PDF-syntax `/FDF` annotation interchange format (the
   counterpart to XFDF), so annotations round-trip with tools that prefer FDF.

--- a/Excise.Core.Tests/Document/PdfAnnotationAuthoringTests.cs
+++ b/Excise.Core.Tests/Document/PdfAnnotationAuthoringTests.cs
@@ -581,4 +581,504 @@ public class PdfAnnotationAuthoringTests
 
         action.Should().Throw<ArgumentOutOfRangeException>();
     }
+
+    // ── Underline / StrikeOut / Squiggly (#626, ISO 32000-2 §12.5.6.10) ─────
+
+    [Theory]
+    [InlineData("Underline", PdfAnnotationSubtype.Underline)]
+    [InlineData("StrikeOut", PdfAnnotationSubtype.StrikeOut)]
+    [InlineData("Squiggly", PdfAnnotationSubtype.Squiggly)]
+    public void AddTextMarkupAnnotations_WriteQuadPointsColorAndAppearance(
+        string kind, PdfAnnotationSubtype expectedSubtype)
+    {
+        using var doc = PdfDocument.CreateNew();
+        doc.Pages.AddBlank();
+        var rect = new PdfRectangle(100, 700, 300, 720);
+
+        PdfAnnotation annotation = kind switch
+        {
+            "Underline" => doc.AddUnderlineAnnotation(1, rect, "note", "EXCISE", 1, 0, 0),
+            "StrikeOut" => doc.AddStrikeOutAnnotation(1, rect, "note", "EXCISE", 1, 0, 0),
+            _           => doc.AddSquigglyAnnotation(1, rect, "note", "EXCISE", 1, 0, 0)
+        };
+
+        annotation.Subtype.Should().Be(expectedSubtype);
+        annotation.Contents.Should().Be("note");
+        annotation.Author.Should().Be("EXCISE");
+        annotation.QuadPoints.Should().NotBeNull().And.HaveCount(1);
+        annotation.Color!.Value.R.Should().BeApproximately(1, 0.001);
+        annotation.HasAppearance.Should().BeTrue(
+            $"{kind} must ship a baked /AP /N so third-party viewers render identical pixels (#626)");
+        annotation.CreationDate.Should().NotBeNull();
+
+        var raw = annotation.RawDictionary;
+        raw.GetNameOrNull("Subtype").Should().Be(kind);
+        var ap = doc.Resolve(raw.GetOptional("AP")!) as Excise.Core.Primitives.PdfDictionary;
+        var n = doc.Resolve(ap!.GetOptional("N")!) as Excise.Core.Primitives.PdfStream;
+        n.Should().NotBeNull();
+        var ops = n!.GetDecodedString();
+        ops.Should().Contain("1 0 0 RG");
+        ops.Should().Contain(" m\n");
+        ops.Should().Contain(" l\n");
+        ops.Should().Contain("S\n");
+    }
+
+    [Fact]
+    public void AddStrikeOutAnnotation_DrawsHigherThanUnderline()
+    {
+        using var doc = PdfDocument.CreateNew();
+        doc.Pages.AddBlank();
+        var rect = new PdfRectangle(100, 700, 300, 720);
+
+        var underline = doc.AddUnderlineAnnotation(1, rect);
+        var strikeOut = doc.AddStrikeOutAnnotation(1, rect);
+
+        double UnderlineY(PdfAnnotation a)
+        {
+            var ap = doc.Resolve(a.RawDictionary.GetOptional("AP")!) as Excise.Core.Primitives.PdfDictionary;
+            var n = doc.Resolve(ap!.GetOptional("N")!) as Excise.Core.Primitives.PdfStream;
+            var match = System.Text.RegularExpressions.Regex.Match(n!.GetDecodedString(), @"0 ([\d.]+) m");
+            return double.Parse(match.Groups[1].Value, System.Globalization.CultureInfo.InvariantCulture);
+        }
+
+        UnderlineY(strikeOut).Should().BeGreaterThan(UnderlineY(underline),
+            "strikeout sits through the middle of the text, well above the underline baseline position");
+    }
+
+    [Fact]
+    public void AddUnderlineAnnotation_RejectsInvalidColorAndRect()
+    {
+        using var doc = PdfDocument.CreateNew();
+        doc.Pages.AddBlank();
+
+        var badColor = () => doc.AddUnderlineAnnotation(1, new PdfRectangle(0, 0, 100, 10), red: 2);
+        badColor.Should().Throw<ArgumentOutOfRangeException>();
+
+        var badRect = () => doc.AddSquigglyAnnotation(1, new PdfRectangle(0, 0, 0, 0));
+        badRect.Should().Throw<ArgumentException>();
+    }
+
+    // ── Line / Arrow (#626, ISO 32000-2 §12.5.6.7) ───────────────────────────
+
+    [Fact]
+    public void AddLineAnnotation_WritesEndpointsColorAndAppearance()
+    {
+        using var doc = PdfDocument.CreateNew();
+        doc.Pages.AddBlank();
+
+        var annotation = doc.AddLineAnnotation(
+            1, 100, 200, 300, 250, contents: "measurement", author: "EXCISE",
+            red: 0, green: 0, blue: 1, lineWidth: 2);
+
+        annotation.Subtype.Should().Be(PdfAnnotationSubtype.Line);
+        annotation.LineEndpoints.Should().Be((100.0, 200.0, 300.0, 250.0));
+        annotation.Color!.Value.B.Should().BeApproximately(1, 0.001);
+        annotation.HasAppearance.Should().BeTrue();
+        annotation.BorderWidth.Should().Be(2);
+
+        var raw = annotation.RawDictionary;
+        var le = doc.Resolve(raw.GetOptional("LE")!) as Excise.Core.Primitives.PdfArray;
+        le.Should().NotBeNull();
+        le!.GetName(0).Should().Be("None");
+        le.GetName(1).Should().Be("None");
+
+        var ap = doc.Resolve(raw.GetOptional("AP")!) as Excise.Core.Primitives.PdfDictionary;
+        var n = doc.Resolve(ap!.GetOptional("N")!) as Excise.Core.Primitives.PdfStream;
+        var ops = n!.GetDecodedString();
+        ops.Should().Contain(" m\n");
+        ops.Should().Contain(" l\n");
+        ops.Should().Contain("S\n");
+        ops.Should().NotContain("\nB\n", "a plain Line without an arrowhead must not fill anything");
+    }
+
+    [Fact]
+    public void AddArrowAnnotation_WritesLineEndingsAndDrawsArrowhead()
+    {
+        using var doc = PdfDocument.CreateNew();
+        doc.Pages.AddBlank();
+
+        var annotation = doc.AddArrowAnnotation(
+            1, 100, 200, 300, 200, red: 1, green: 0, blue: 0,
+            endLineEnding: "ClosedArrow");
+
+        var raw = annotation.RawDictionary;
+        var le = doc.Resolve(raw.GetOptional("LE")!) as Excise.Core.Primitives.PdfArray;
+        le!.GetName(0).Should().Be("None");
+        le.GetName(1).Should().Be("ClosedArrow");
+
+        // /Rect must be padded enough to contain the arrowhead past (300,200).
+        annotation.Rect.Normalize().Right.Should().BeGreaterThan(300);
+
+        var ap = doc.Resolve(raw.GetOptional("AP")!) as Excise.Core.Primitives.PdfDictionary;
+        var n = doc.Resolve(ap!.GetOptional("N")!) as Excise.Core.Primitives.PdfStream;
+        var ops = n!.GetDecodedString();
+        ops.Should().Contain("h\nB\n", "a ClosedArrow head is a filled+stroked closed triangle");
+    }
+
+    [Fact]
+    public void AddLineAnnotation_RejectsBadArguments()
+    {
+        using var doc = PdfDocument.CreateNew();
+        doc.Pages.AddBlank();
+
+        var samePoint = () => doc.AddLineAnnotation(1, 10, 10, 10, 10);
+        samePoint.Should().Throw<ArgumentException>();
+
+        var badWidth = () => doc.AddLineAnnotation(1, 0, 0, 100, 0, lineWidth: 0);
+        badWidth.Should().Throw<ArgumentOutOfRangeException>();
+
+        var badEnding = () => doc.AddArrowAnnotation(1, 0, 0, 100, 0, endLineEnding: "Diamond");
+        badEnding.Should().Throw<ArgumentException>("Diamond is not a supported line ending (#626 scope)");
+    }
+
+    // ── Polygon / PolyLine (#626, ISO 32000-2 §12.5.6.9) ─────────────────────
+
+    [Fact]
+    public void AddPolygonAnnotation_WritesVerticesAndClosedFilledAppearance()
+    {
+        using var doc = PdfDocument.CreateNew();
+        doc.Pages.AddBlank();
+        var vertices = new (double X, double Y)[] { (100, 100), (200, 100), (150, 200) };
+
+        var annotation = doc.AddPolygonAnnotation(
+            1, vertices, contents: "triangle", red: 0, green: 0, blue: 0, borderWidth: 2,
+            interiorRed: 0, interiorGreen: 1, interiorBlue: 0);
+
+        annotation.Subtype.Should().Be(PdfAnnotationSubtype.Polygon);
+        annotation.Vertices.Should().Equal(vertices);
+        annotation.HasAppearance.Should().BeTrue();
+
+        var raw = annotation.RawDictionary;
+        var ic = doc.Resolve(raw.GetOptional("IC")!) as Excise.Core.Primitives.PdfArray;
+        ic!.GetNumber(1).Should().BeApproximately(1, 0.001);
+
+        var ap = doc.Resolve(raw.GetOptional("AP")!) as Excise.Core.Primitives.PdfDictionary;
+        var n = doc.Resolve(ap!.GetOptional("N")!) as Excise.Core.Primitives.PdfStream;
+        var ops = n!.GetDecodedString();
+        ops.Should().Contain("h\n", "polygon closes its path");
+        ops.Should().Contain("B\n", "fill+stroke with an interior color set");
+    }
+
+    [Fact]
+    public void AddPolyLineAnnotation_WritesOpenStrokedAppearance()
+    {
+        using var doc = PdfDocument.CreateNew();
+        doc.Pages.AddBlank();
+        var vertices = new (double X, double Y)[] { (100, 100), (200, 150), (300, 100) };
+
+        var annotation = doc.AddPolyLineAnnotation(1, vertices, red: 1, green: 0, blue: 0, borderWidth: 2);
+
+        annotation.Subtype.Should().Be(PdfAnnotationSubtype.PolyLine);
+        annotation.Vertices.Should().Equal(vertices);
+
+        var raw = annotation.RawDictionary;
+        raw.ContainsKey("IC").Should().BeFalse("PolyLine has no interior fill");
+
+        var ap = doc.Resolve(raw.GetOptional("AP")!) as Excise.Core.Primitives.PdfDictionary;
+        var n = doc.Resolve(ap!.GetOptional("N")!) as Excise.Core.Primitives.PdfStream;
+        var ops = n!.GetDecodedString();
+        ops.Should().NotContain("h\n", "a polyline must stay open, not closed into a polygon");
+        ops.Should().Contain("S\n");
+    }
+
+    [Fact]
+    public void AddPolygonAndPolyLine_RejectBadArguments()
+    {
+        using var doc = PdfDocument.CreateNew();
+        doc.Pages.AddBlank();
+
+        var tooFewPolygon = () => doc.AddPolygonAnnotation(
+            1, new (double, double)[] { (0, 0), (10, 10) }, interiorRed: 0, interiorGreen: 0, interiorBlue: 0);
+        tooFewPolygon.Should().Throw<ArgumentException>("a polygon needs at least 3 vertices");
+
+        var tooFewPolyLine = () => doc.AddPolyLineAnnotation(1, new (double, double)[] { (0, 0) });
+        tooFewPolyLine.Should().Throw<ArgumentException>("a polyline needs at least 2 vertices");
+
+        var invisible = () => doc.AddPolyLineAnnotation(
+            1, new (double, double)[] { (0, 0), (10, 10) }, borderWidth: 0);
+        invisible.Should().Throw<ArgumentException>();
+
+        var nanVertex = () => doc.AddPolygonAnnotation(
+            1, new (double, double)[] { (double.NaN, 0), (10, 10), (5, 20) },
+            interiorRed: 0, interiorGreen: 0, interiorBlue: 0);
+        nanVertex.Should().Throw<ArgumentException>();
+    }
+
+    // ── Stamp (#626, ISO 32000-2 §12.5.6.12) ──────────────────────────────────
+
+    [Fact]
+    public void AddStampAnnotation_WritesStandardNameAndAppearance()
+    {
+        using var doc = PdfDocument.CreateNew();
+        doc.Pages.AddBlank();
+
+        var annotation = doc.AddStampAnnotation(
+            1, new PdfRectangle(100, 600, 260, 660), "Approved", author: "EXCISE");
+
+        annotation.Subtype.Should().Be(PdfAnnotationSubtype.Stamp);
+        annotation.IconName.Should().Be("Approved");
+        annotation.Author.Should().Be("EXCISE");
+        annotation.HasAppearance.Should().BeTrue();
+        annotation.Color.Should().NotBeNull();
+
+        var raw = annotation.RawDictionary;
+        var ap = doc.Resolve(raw.GetOptional("AP")!) as Excise.Core.Primitives.PdfDictionary;
+        var n = doc.Resolve(ap!.GetOptional("N")!) as Excise.Core.Primitives.PdfStream;
+        var ops = n!.GetDecodedString();
+        ops.Should().Contain("BT");
+        ops.Should().Contain("(Approved) Tj");
+        ops.Should().Contain(" re S\n", "the stamp draws a bordered box");
+    }
+
+    [Fact]
+    public void AddStampAnnotation_RejectsNonStandardName()
+    {
+        using var doc = PdfDocument.CreateNew();
+        doc.Pages.AddBlank();
+
+        var action = () => doc.AddStampAnnotation(1, new PdfRectangle(0, 0, 100, 40), "MyCustomStamp");
+
+        action.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void StandardStampNames_AreAllAccepted()
+    {
+        using var doc = PdfDocument.CreateNew();
+        doc.Pages.AddBlank();
+
+        foreach (var name in PdfAnnotationAuthoring.StandardStampNames)
+        {
+            var annotation = doc.AddStampAnnotation(1, new PdfRectangle(0, 0, 120, 40), name);
+            annotation.IconName.Should().Be(name);
+        }
+    }
+
+    [Fact]
+    public void AddImageStampAnnotation_EmbedsImageXObjectInAppearance()
+    {
+        using var doc = PdfDocument.CreateNew();
+        doc.Pages.AddBlank();
+
+        // 2x2 solid-red RGB24 image.
+        var pixels = new byte[2 * 2 * 3];
+        for (int i = 0; i < pixels.Length; i += 3)
+        {
+            pixels[i] = 255; pixels[i + 1] = 0; pixels[i + 2] = 0;
+        }
+
+        var annotation = doc.AddImageStampAnnotation(
+            1, new PdfRectangle(100, 100, 200, 200), pixels, pixelWidth: 2, pixelHeight: 2,
+            contents: "logo");
+
+        annotation.Subtype.Should().Be(PdfAnnotationSubtype.Stamp);
+        annotation.HasAppearance.Should().BeTrue();
+
+        var raw = annotation.RawDictionary;
+        var ap = doc.Resolve(raw.GetOptional("AP")!) as Excise.Core.Primitives.PdfDictionary;
+        var n = doc.Resolve(ap!.GetOptional("N")!) as Excise.Core.Primitives.PdfStream;
+        n.Should().NotBeNull();
+        var ops = n!.GetDecodedString();
+        ops.Should().Contain("/Im0 Do");
+
+        var resources = n.GetOptional("Resources") as Excise.Core.Primitives.PdfDictionary;
+        var xobjects = doc.Resolve(resources!.GetOptional("XObject")!) as Excise.Core.Primitives.PdfDictionary;
+        var image = doc.Resolve(xobjects!.GetOptional("Im0")!) as Excise.Core.Primitives.PdfStream;
+        image.Should().NotBeNull();
+        image!.GetNameOrNull("Subtype").Should().Be("Image");
+        image.GetInt("Width", -1).Should().Be(2);
+        image.GetInt("Height", -1).Should().Be(2);
+        image.GetNameOrNull("ColorSpace").Should().Be("DeviceRGB");
+        image.DecodedData.Should().Equal(pixels);
+    }
+
+    [Fact]
+    public void AddImageStampAnnotation_RejectsMismatchedPixelBufferSize()
+    {
+        using var doc = PdfDocument.CreateNew();
+        doc.Pages.AddBlank();
+
+        var action = () => doc.AddImageStampAnnotation(
+            1, new PdfRectangle(0, 0, 100, 100), new byte[10], pixelWidth: 4, pixelHeight: 4);
+
+        action.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void StampAnnotations_SurviveSaveAndReload()
+    {
+        byte[] saved;
+        using (var doc = PdfDocument.CreateNew())
+        {
+            doc.Pages.AddBlank();
+            doc.AddStampAnnotation(1, new PdfRectangle(72, 700, 220, 750), "Draft");
+            saved = doc.SaveToBytes();
+        }
+
+        using var reopened = PdfDocument.Open(saved);
+        var stamp = reopened.GetPage(1).GetAnnotations().Should()
+            .ContainSingle(a => a.Subtype == PdfAnnotationSubtype.Stamp).Subject;
+
+        stamp.IconName.Should().Be("Draft");
+        stamp.HasAppearance.Should().BeTrue();
+    }
+
+    // ── Edit / delete existing annotations (#626) ─────────────────────────────
+
+    [Fact]
+    public void SetAnnotationContents_UpdatesContentsAndModDate()
+    {
+        using var doc = PdfDocument.CreateNew();
+        doc.Pages.AddBlank();
+        var annotation = doc.AddTextAnnotation(1, new PdfRectangle(72, 700, 108, 736), "original");
+        var originalModDate = annotation.RawDictionary.GetStringOrNull("M");
+
+        annotation.SetAnnotationContents("updated text");
+
+        annotation.RawDictionary.GetStringOrNull("Contents").Should().Be("updated text");
+        annotation.RawDictionary.GetStringOrNull("M").Should().NotBeNull();
+
+        annotation.SetAnnotationContents(null);
+        annotation.RawDictionary.ContainsKey("Contents").Should().BeFalse();
+        _ = originalModDate; // documents intent: /M is always refreshed, value not asserted (clock resolution)
+    }
+
+    [Fact]
+    public void SetAnnotationColor_UpdatesCArray()
+    {
+        using var doc = PdfDocument.CreateNew();
+        doc.Pages.AddBlank();
+        var annotation = doc.AddSquareAnnotation(1, new PdfRectangle(0, 0, 100, 100), red: 1, green: 0, blue: 0);
+
+        annotation.SetAnnotationColor(0, 1, 0);
+
+        var c = doc.Resolve(annotation.RawDictionary.GetOptional("C")!) as Excise.Core.Primitives.PdfArray;
+        c!.GetNumber(0).Should().Be(0);
+        c.GetNumber(1).Should().Be(1);
+        c.GetNumber(2).Should().Be(0);
+    }
+
+    [Fact]
+    public void SetAnnotationColor_RejectsOutOfRangeComponents()
+    {
+        using var doc = PdfDocument.CreateNew();
+        doc.Pages.AddBlank();
+        var annotation = doc.AddTextAnnotation(1, new PdfRectangle(0, 0, 20, 20), "x");
+
+        var action = () => annotation.SetAnnotationColor(1.5, 0, 0);
+        action.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void SetAnnotationOpacity_WritesCA()
+    {
+        using var doc = PdfDocument.CreateNew();
+        doc.Pages.AddBlank();
+        var annotation = doc.AddTextAnnotation(1, new PdfRectangle(0, 0, 20, 20), "x");
+
+        annotation.SetAnnotationOpacity(0.5);
+
+        annotation.RawDictionary.GetNumber("CA", -1).Should().Be(0.5);
+
+        var badOpacity = () => annotation.SetAnnotationOpacity(1.5);
+        badOpacity.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void RemoveAnnotation_DetachesFromPageAnnots()
+    {
+        using var doc = PdfDocument.CreateNew();
+        doc.Pages.AddBlank();
+        var keep = doc.AddTextAnnotation(1, new PdfRectangle(0, 0, 20, 20), "keep");
+        var remove = doc.AddTextAnnotation(1, new PdfRectangle(30, 30, 50, 50), "remove");
+
+        var removed = doc.RemoveAnnotation(1, remove);
+
+        removed.Should().BeTrue();
+        var remaining = doc.GetPage(1).GetAnnotations();
+        remaining.Should().ContainSingle();
+        remaining[0].Contents.Should().Be("keep");
+
+        // Removing again returns false — it's no longer on the page.
+        doc.RemoveAnnotation(1, remove).Should().BeFalse();
+    }
+
+    [Fact]
+    public void RemoveAnnotation_SurvivesSaveAndReload()
+    {
+        byte[] saved;
+        using (var doc = PdfDocument.CreateNew())
+        {
+            doc.Pages.AddBlank();
+            doc.AddTextAnnotation(1, new PdfRectangle(0, 0, 20, 20), "keep");
+            var remove = doc.AddTextAnnotation(1, new PdfRectangle(30, 30, 50, 50), "remove");
+            doc.RemoveAnnotation(1, remove).Should().BeTrue();
+            saved = doc.SaveToBytes();
+        }
+
+        using var reopened = PdfDocument.Open(saved);
+        var annotations = reopened.GetPage(1).GetAnnotations();
+        annotations.Should().ContainSingle();
+        annotations[0].Contents.Should().Be("keep");
+    }
+
+    // ── Reply threads (#626, ISO 32000-2 §12.5.6.2 — /IRT and /RT) ────────────
+
+    [Fact]
+    public void SetReplyTo_WritesIrtReferenceAndRt()
+    {
+        using var doc = PdfDocument.CreateNew();
+        doc.Pages.AddBlank();
+        var parent = doc.AddTextAnnotation(1, new PdfRectangle(0, 0, 20, 20), "original comment");
+        var reply = doc.AddTextAnnotation(1, new PdfRectangle(30, 0, 50, 20), "a reply");
+
+        reply.SetReplyTo(doc, parent);
+
+        var irtRef = doc.GetReferenceTo(parent.RawDictionary);
+        irtRef.Should().NotBeNull();
+        reply.RawDictionary.GetOptional("IRT").Should().Be(irtRef);
+        (doc.Resolve(reply.RawDictionary.GetOptional("IRT")!) as Excise.Core.Primitives.PdfDictionary)
+            .Should().BeSameAs(parent.RawDictionary,
+                "/IRT must resolve to the exact parent annotation dictionary");
+        reply.RawDictionary.GetNameOrNull("RT").Should().Be("R");
+    }
+
+    [Fact]
+    public void SetReplyTo_SurvivesSaveAndReload()
+    {
+        byte[] saved;
+        using (var doc = PdfDocument.CreateNew())
+        {
+            doc.Pages.AddBlank();
+            var parent = doc.AddTextAnnotation(1, new PdfRectangle(0, 0, 20, 20), "original comment");
+            var reply = doc.AddTextAnnotation(1, new PdfRectangle(30, 0, 50, 20), "a reply");
+            reply.SetReplyTo(doc, parent, "Group");
+            saved = doc.SaveToBytes();
+        }
+
+        using var reopened = PdfDocument.Open(saved);
+        var annotations = reopened.GetPage(1).GetAnnotations();
+        var reopenedParent = annotations.Single(a => a.Contents == "original comment");
+        var reopenedReply = annotations.Single(a => a.Contents == "a reply");
+
+        reopenedReply.RawDictionary.GetNameOrNull("RT").Should().Be("Group");
+        var irt = reopened.Resolve(reopenedReply.RawDictionary.GetOptional("IRT")!)
+            as Excise.Core.Primitives.PdfDictionary;
+        irt.Should().BeSameAs(reopenedParent.RawDictionary);
+    }
+
+    [Fact]
+    public void SetReplyTo_RejectsUnattachedParentAndBadReplyType()
+    {
+        using var doc = PdfDocument.CreateNew();
+        doc.Pages.AddBlank();
+        var reply = doc.AddTextAnnotation(1, new PdfRectangle(0, 0, 20, 20), "reply");
+
+        var badReplyType = () =>
+        {
+            var parent = doc.AddTextAnnotation(1, new PdfRectangle(30, 0, 50, 20), "parent");
+            reply.SetReplyTo(doc, parent, "Bogus");
+        };
+        badReplyType.Should().Throw<ArgumentException>();
+    }
 }

--- a/Excise.Core.Tests/Forms/FdfSerializerTests.cs
+++ b/Excise.Core.Tests/Forms/FdfSerializerTests.cs
@@ -657,4 +657,147 @@ public class FdfSerializerTests
         square.Color!.Value.R.Should().BeApproximately(0.2, 0.0001);
         square.BorderWidth.Should().Be(2);
     }
+
+    // ── #626 "remaining subtypes": round-trip position/color/author/contents/opacity ──
+
+    [Fact]
+    public void RoundTrip_NewlyAuthoredSubtypes_SurviveExportAndImport()
+    {
+        using var source = PdfDocument.CreateNew();
+        source.Pages.AddBlank();
+
+        source.AddUnderlineAnnotation(1, new PdfRectangle(72, 700, 220, 715),
+            contents: "underlined", author: "Alice", red: 1, green: 0, blue: 0);
+        source.AddStrikeOutAnnotation(1, new PdfRectangle(72, 650, 220, 665),
+            contents: "struck", author: "Bob", red: 0.2, green: 0.2, blue: 0.2);
+        source.AddSquigglyAnnotation(1, new PdfRectangle(72, 600, 220, 615),
+            contents: "squiggled", author: "Carol", red: 0, green: 0, blue: 1);
+        source.AddLineAnnotation(1, 72, 550, 220, 560,
+            contents: "line note", author: "Dave", red: 0, green: 0.5, blue: 0, lineWidth: 2);
+        source.AddArrowAnnotation(1, 72, 500, 220, 500,
+            contents: "arrow note", author: "Eve", red: 1, green: 0, blue: 0,
+            endLineEnding: "ClosedArrow");
+        source.AddPolygonAnnotation(1,
+            new (double X, double Y)[] { (72, 400), (150, 400), (110, 450) },
+            contents: "polygon note", author: "Frank",
+            red: 0, green: 0, blue: 0, borderWidth: 1,
+            interiorRed: 1, interiorGreen: 1, interiorBlue: 0);
+        source.AddPolyLineAnnotation(1,
+            new (double X, double Y)[] { (200, 400), (240, 440), (280, 400) },
+            contents: "polyline note", author: "Grace", red: 0.5, green: 0, blue: 0.5);
+        source.AddStampAnnotation(1, new PdfRectangle(72, 300, 200, 340), "Approved",
+            contents: "stamped", author: "Heidi");
+
+        var fdf = FdfSerializer.ExportAnnotations(source);
+
+        using var target = PdfDocument.CreateNew();
+        target.Pages.AddBlank();
+        var result = FdfSerializer.ImportAnnotations(target, fdf);
+
+        result.Skipped.Should().BeEmpty("every subtype above has export+import support");
+        result.Imported.Should().HaveCount(8);
+
+        var sourceAnnotations = source.GetPage(1).GetAnnotations();
+        var importedAnnotations = target.GetPage(1).GetAnnotations();
+        foreach (var expected in sourceAnnotations)
+        {
+            // Match by /Contents, not /Subtype — Line and Arrow both carry
+            // PdfAnnotationSubtype.Line (an Arrow *is* a Line with /LE), so
+            // subtype alone isn't unique across this fixture's eight annotations.
+            var actual = importedAnnotations.Single(a => a.Contents == expected.Contents);
+            actual.Subtype.Should().Be(expected.Subtype);
+
+            actual.Rect.Left.Should().BeApproximately(expected.Rect.Left, 0.5);
+            actual.Rect.Bottom.Should().BeApproximately(expected.Rect.Bottom, 0.5);
+            actual.Rect.Right.Should().BeApproximately(expected.Rect.Right, 0.5);
+            actual.Rect.Top.Should().BeApproximately(expected.Rect.Top, 0.5);
+            actual.Author.Should().Be(expected.Author);
+
+            if (expected.Color is { } c)
+            {
+                actual.Color.Should().NotBeNull();
+                actual.Color!.Value.R.Should().BeApproximately(c.R, 0.01);
+                actual.Color.Value.G.Should().BeApproximately(c.G, 0.01);
+                actual.Color.Value.B.Should().BeApproximately(c.B, 0.01);
+            }
+        }
+
+        var stamp = importedAnnotations.Single(a => a.Subtype == PdfAnnotationSubtype.Stamp);
+        stamp.IconName.Should().Be("Approved",
+            "a standard #626 stamp name must round-trip and re-attach through AddStampAnnotation");
+        stamp.HasAppearance.Should().BeTrue("the stamp must be re-authored (baked /AP), not a bare dictionary");
+
+        var polygon = importedAnnotations.Single(a => a.Subtype == PdfAnnotationSubtype.Polygon);
+        polygon.RawDictionary.GetArrayOrNull("IC").Should().NotBeNull("polygon interior fill must survive");
+
+        importedAnnotations.Count(a => a.Subtype == PdfAnnotationSubtype.Line).Should().Be(2);
+    }
+
+    [Fact]
+    public void RoundTrip_StampAnnotation_PreservesIconAndIsReauthored()
+    {
+        using var source = PdfDocument.CreateNew();
+        source.Pages.AddBlank();
+        source.AddStampAnnotation(1, new PdfRectangle(100, 600, 260, 650), "Confidential",
+            contents: "handle with care", author: "Reviewer");
+
+        var fdf = FdfSerializer.ExportAnnotations(source);
+        fdf.Should().Contain("/Subtype /Stamp").And.Contain("/Name /Confidential");
+
+        using var target = PdfDocument.CreateNew();
+        target.Pages.AddBlank();
+        var imported = FdfSerializer.ImportAnnotations(target, fdf).Imported.Single();
+
+        imported.Subtype.Should().Be(PdfAnnotationSubtype.Stamp);
+        imported.IconName.Should().Be("Confidential");
+        imported.Contents.Should().Be("handle with care");
+        imported.Author.Should().Be("Reviewer");
+        imported.HasAppearance.Should().BeTrue();
+    }
+
+    [Fact]
+    public void RoundTrip_NonStandardStampIcon_KeepsDataWithoutRejecting()
+    {
+        const string fdf = """
+            %FDF-1.2
+            1 0 obj
+            << /FDF << /Annots [2 0 R] >> >>
+            endobj
+            2 0 obj
+            << /Type /Annot /Subtype /Stamp /Page 0 /Rect [10 10 110 60]
+               /Name /CompanyLogo /C [0.1 0.2 0.3] /NM (custom-stamp) >>
+            endobj
+            trailer
+            << /Root 1 0 R >>
+            %%EOF
+            """;
+
+        using var doc = PdfDocument.CreateNew();
+        doc.Pages.AddBlank();
+        var result = FdfSerializer.ImportAnnotations(doc, fdf);
+
+        result.Skipped.Should().BeEmpty();
+        var stamp = result.Imported.Should().ContainSingle().Subject;
+        stamp.Subtype.Should().Be(PdfAnnotationSubtype.Stamp);
+        stamp.IconName.Should().Be("CompanyLogo");
+        stamp.HasAppearance.Should().BeFalse("a non-standard icon has no bundled #626 artwork to bake");
+    }
+
+    [Fact]
+    public void RoundTrip_Opacity_SurvivesExportAndImport()
+    {
+        using var source = PdfDocument.CreateNew();
+        source.Pages.AddBlank();
+        var annotation = source.AddSquareAnnotation(1, new PdfRectangle(10, 10, 60, 60), borderWidth: 1);
+        annotation.SetAnnotationOpacity(0.4);
+
+        var fdf = FdfSerializer.ExportAnnotations(source);
+        fdf.Should().Contain("/CA 0.4");
+
+        using var target = PdfDocument.CreateNew();
+        target.Pages.AddBlank();
+        var imported = FdfSerializer.ImportAnnotations(target, fdf).Imported.Single();
+
+        imported.RawDictionary.GetNumber("CA", -1).Should().BeApproximately(0.4, 0.001);
+    }
 }

--- a/Excise.Core.Tests/Forms/XfdfSerializerTests.cs
+++ b/Excise.Core.Tests/Forms/XfdfSerializerTests.cs
@@ -496,4 +496,156 @@ public class XfdfSerializerTests
         square.Name.Should().Be("stream-square");
         square.Color!.Value.R.Should().BeApproximately(0x33 / 255.0, 0.005);
     }
+
+    // ── #626 "remaining subtypes": round-trip position/color/author/contents/opacity ──
+
+    [Fact]
+    public void RoundTrip_NewlyAuthoredSubtypes_SurviveExportAndImport()
+    {
+        using var source = PdfDocument.CreateNew();
+        source.Pages.AddBlank();
+
+        source.AddUnderlineAnnotation(1, new PdfRectangle(72, 700, 220, 715),
+            contents: "underlined", author: "Alice", red: 1, green: 0, blue: 0);
+        source.AddStrikeOutAnnotation(1, new PdfRectangle(72, 650, 220, 665),
+            contents: "struck", author: "Bob", red: 0.2, green: 0.2, blue: 0.2);
+        source.AddSquigglyAnnotation(1, new PdfRectangle(72, 600, 220, 615),
+            contents: "squiggled", author: "Carol", red: 0, green: 0, blue: 1);
+        source.AddLineAnnotation(1, 72, 550, 220, 560,
+            contents: "line note", author: "Dave", red: 0, green: 0.5, blue: 0, lineWidth: 2);
+        source.AddArrowAnnotation(1, 72, 500, 220, 500,
+            contents: "arrow note", author: "Eve", red: 1, green: 0, blue: 0,
+            endLineEnding: "ClosedArrow");
+        source.AddPolygonAnnotation(1,
+            new (double X, double Y)[] { (72, 400), (150, 400), (110, 450) },
+            contents: "polygon note", author: "Frank",
+            red: 0, green: 0, blue: 0, borderWidth: 1,
+            interiorRed: 1, interiorGreen: 1, interiorBlue: 0);
+        source.AddPolyLineAnnotation(1,
+            new (double X, double Y)[] { (200, 400), (240, 440), (280, 400) },
+            contents: "polyline note", author: "Grace", red: 0.5, green: 0, blue: 0.5);
+        source.AddStampAnnotation(1, new PdfRectangle(72, 300, 200, 340), "Approved",
+            contents: "stamped", author: "Heidi");
+
+        var xfdf = XfdfSerializer.ExportAnnotations(source);
+
+        using var target = PdfDocument.CreateNew();
+        target.Pages.AddBlank();
+        var result = XfdfSerializer.ImportAnnotations(target, xfdf);
+
+        result.Skipped.Should().BeEmpty("every subtype above has export+import support");
+        result.Imported.Should().HaveCount(8);
+
+        var sourceAnnotations = source.GetPage(1).GetAnnotations();
+        var importedAnnotations = target.GetPage(1).GetAnnotations();
+        foreach (var expected in sourceAnnotations)
+        {
+            // Match by /Contents, not /Subtype — Line and Arrow both carry
+            // PdfAnnotationSubtype.Line (an Arrow *is* a Line with /LE), so
+            // subtype alone isn't unique across this fixture's eight annotations.
+            var actual = importedAnnotations.Single(a => a.Contents == expected.Contents);
+            actual.Subtype.Should().Be(expected.Subtype);
+
+            actual.Rect.Left.Should().BeApproximately(expected.Rect.Left, 0.5);
+            actual.Rect.Bottom.Should().BeApproximately(expected.Rect.Bottom, 0.5);
+            actual.Rect.Right.Should().BeApproximately(expected.Rect.Right, 0.5);
+            actual.Rect.Top.Should().BeApproximately(expected.Rect.Top, 0.5);
+            actual.Contents.Should().Be(expected.Contents);
+            actual.Author.Should().Be(expected.Author);
+
+            if (expected.Color is { } c)
+            {
+                actual.Color.Should().NotBeNull();
+                actual.Color!.Value.R.Should().BeApproximately(c.R, 1 / 255.0 + 0.0001);
+                actual.Color.Value.G.Should().BeApproximately(c.G, 1 / 255.0 + 0.0001);
+                actual.Color.Value.B.Should().BeApproximately(c.B, 1 / 255.0 + 0.0001);
+            }
+        }
+
+        var stamp = importedAnnotations.Single(a => a.Subtype == PdfAnnotationSubtype.Stamp);
+        stamp.IconName.Should().Be("Approved",
+            "a standard #626 stamp name must round-trip and re-attach through AddStampAnnotation");
+        stamp.HasAppearance.Should().BeTrue("the stamp must be re-authored (baked /AP), not a bare dictionary");
+
+        var polygon = importedAnnotations.Single(a => a.Subtype == PdfAnnotationSubtype.Polygon);
+        polygon.Vertices.Should().HaveCount(3);
+        polygon.RawDictionary.GetArrayOrNull("IC").Should().NotBeNull("polygon interior fill must survive");
+
+        var polyLine = importedAnnotations.Single(a => a.Subtype == PdfAnnotationSubtype.PolyLine);
+        polyLine.Vertices.Should().HaveCount(3);
+
+        // Arrow round-trips as a plain Line — XFDF has no /LE carrier in this
+        // grammar, so only endpoints/color/author/contents are asserted (by
+        // the loop above); losing the arrowhead decoration on export is a
+        // known, documented XFDF limitation, not a data-loss bug.
+        importedAnnotations.Count(a => a.Subtype == PdfAnnotationSubtype.Line).Should().Be(2);
+    }
+
+    [Fact]
+    public void RoundTrip_StampAnnotation_PreservesIconAndIsReauthored()
+    {
+        using var source = PdfDocument.CreateNew();
+        source.Pages.AddBlank();
+        source.AddStampAnnotation(1, new PdfRectangle(100, 600, 260, 650), "Confidential",
+            contents: "handle with care", author: "Reviewer");
+
+        var xfdf = XfdfSerializer.ExportAnnotations(source);
+        XDocument.Parse(xfdf).Descendants().Single(e => e.Name.LocalName == "stamp")
+            .Attribute("icon")!.Value.Should().Be("Confidential");
+
+        using var target = PdfDocument.CreateNew();
+        target.Pages.AddBlank();
+        var imported = XfdfSerializer.ImportAnnotations(target, xfdf).Imported.Single();
+
+        imported.Subtype.Should().Be(PdfAnnotationSubtype.Stamp);
+        imported.IconName.Should().Be("Confidential");
+        imported.Contents.Should().Be("handle with care");
+        imported.Author.Should().Be("Reviewer");
+        imported.HasAppearance.Should().BeTrue();
+    }
+
+    [Fact]
+    public void RoundTrip_NonStandardStampIcon_KeepsDataWithoutRejecting()
+    {
+        // A stamp element whose icon isn't one of #626's standard names
+        // (e.g. a foreign viewer's custom stamp) must not be dropped — it
+        // keeps its data without a baked appearance, same fallback the
+        // Square/Circle import path already uses for its own edge case.
+        const string xfdf = """
+            <xfdf xmlns="http://ns.adobe.com/xfdf/">
+              <annots>
+                <stamp page="0" rect="10,10,110,60" icon="CompanyLogo" color="#123456" name="custom-stamp"/>
+              </annots>
+            </xfdf>
+            """;
+
+        using var doc = PdfDocument.CreateNew();
+        doc.Pages.AddBlank();
+        var result = XfdfSerializer.ImportAnnotations(doc, xfdf);
+
+        result.Skipped.Should().BeEmpty();
+        var stamp = result.Imported.Should().ContainSingle().Subject;
+        stamp.Subtype.Should().Be(PdfAnnotationSubtype.Stamp);
+        stamp.IconName.Should().Be("CompanyLogo");
+        stamp.HasAppearance.Should().BeFalse("a non-standard icon has no bundled #626 artwork to bake");
+    }
+
+    [Fact]
+    public void RoundTrip_Opacity_SurvivesExportAndImport()
+    {
+        using var source = PdfDocument.CreateNew();
+        source.Pages.AddBlank();
+        var annotation = source.AddSquareAnnotation(1, new PdfRectangle(10, 10, 60, 60), borderWidth: 1);
+        annotation.SetAnnotationOpacity(0.4);
+
+        var xfdf = XfdfSerializer.ExportAnnotations(source);
+        XDocument.Parse(xfdf).Descendants().Single(e => e.Name.LocalName == "square")
+            .Attribute("opacity")!.Value.Should().Be("0.4");
+
+        using var target = PdfDocument.CreateNew();
+        target.Pages.AddBlank();
+        var imported = XfdfSerializer.ImportAnnotations(target, xfdf).Imported.Single();
+
+        imported.RawDictionary.GetNumber("CA", -1).Should().BeApproximately(0.4, 0.001);
+    }
 }

--- a/Excise.Core.Tests/PublicApi/Excise.Core.approved.txt
+++ b/Excise.Core.Tests/PublicApi/Excise.Core.approved.txt
@@ -479,14 +479,33 @@ namespace Excise.Core.Document
     }
     public static class PdfAnnotationAuthoring
     {
+        public static System.Collections.Generic.IReadOnlyList<string> StandardStampNames { get; }
+        public static Excise.Core.Document.PdfAnnotation AddArrowAnnotation(this Excise.Core.Document.PdfDocument document, int pageNumber, double x1, double y1, double x2, double y2, string? contents = null, string? author = null, double red = 0, double green = 0, double blue = 0, double lineWidth = 1, string startLineEnding = "None", string endLineEnding = "ClosedArrow") { }
         public static Excise.Core.Document.PdfAnnotation AddCircleAnnotation(this Excise.Core.Document.PdfDocument document, int pageNumber, Excise.Core.Document.PdfRectangle rect, string? contents = null, string? author = null, double red = 1, double green = 0, double blue = 0, double borderWidth = 1, double? interiorRed = default, double? interiorGreen = default, double? interiorBlue = default) { }
         public static Excise.Core.Document.PdfAnnotation AddFreeTextAnnotation(this Excise.Core.Document.PdfDocument document, int pageNumber, Excise.Core.Document.PdfRectangle rect, string text, string? author = null, double fontSize = 12, double textRed = 0, double textGreen = 0, double textBlue = 0, Excise.Core.Document.PdfFreeTextQuadding quadding = 0, double borderWidth = 0, double? backgroundRed = default, double? backgroundGreen = default, double? backgroundBlue = default) { }
         public static Excise.Core.Document.PdfAnnotation AddHighlightAnnotation(this Excise.Core.Document.PdfDocument document, int pageNumber, Excise.Core.Document.PdfRectangle rect, string? contents = null, string? author = null, double red = 1, double green = 1, double blue = 0) { }
+        public static Excise.Core.Document.PdfAnnotation AddImageStampAnnotation(this Excise.Core.Document.PdfDocument document, int pageNumber, Excise.Core.Document.PdfRectangle rect, byte[] rgbPixels, int pixelWidth, int pixelHeight, string? contents = null, string? author = null) { }
         public static Excise.Core.Document.PdfAnnotation AddInkAnnotation(this Excise.Core.Document.PdfDocument document, int pageNumber, [System.Runtime.CompilerServices.TupleElementNames(new string[] {
                 "X",
                 "Y"})] System.Collections.Generic.IReadOnlyList<System.Collections.Generic.IReadOnlyList<System.ValueTuple<double, double>>> strokes, string? contents = null, string? author = null, double red = 0, double green = 0, double blue = 0, double borderWidth = 2) { }
+        public static Excise.Core.Document.PdfAnnotation AddLineAnnotation(this Excise.Core.Document.PdfDocument document, int pageNumber, double x1, double y1, double x2, double y2, string? contents = null, string? author = null, double red = 0, double green = 0, double blue = 0, double lineWidth = 1) { }
+        public static Excise.Core.Document.PdfAnnotation AddPolyLineAnnotation(this Excise.Core.Document.PdfDocument document, int pageNumber, [System.Runtime.CompilerServices.TupleElementNames(new string[] {
+                "X",
+                "Y"})] System.Collections.Generic.IReadOnlyList<System.ValueTuple<double, double>> vertices, string? contents = null, string? author = null, double red = 0, double green = 0, double blue = 0, double borderWidth = 1) { }
+        public static Excise.Core.Document.PdfAnnotation AddPolygonAnnotation(this Excise.Core.Document.PdfDocument document, int pageNumber, [System.Runtime.CompilerServices.TupleElementNames(new string[] {
+                "X",
+                "Y"})] System.Collections.Generic.IReadOnlyList<System.ValueTuple<double, double>> vertices, string? contents = null, string? author = null, double red = 0, double green = 0, double blue = 0, double borderWidth = 1, double? interiorRed = default, double? interiorGreen = default, double? interiorBlue = default) { }
         public static Excise.Core.Document.PdfAnnotation AddSquareAnnotation(this Excise.Core.Document.PdfDocument document, int pageNumber, Excise.Core.Document.PdfRectangle rect, string? contents = null, string? author = null, double red = 1, double green = 0, double blue = 0, double borderWidth = 1, double? interiorRed = default, double? interiorGreen = default, double? interiorBlue = default) { }
+        public static Excise.Core.Document.PdfAnnotation AddSquigglyAnnotation(this Excise.Core.Document.PdfDocument document, int pageNumber, Excise.Core.Document.PdfRectangle rect, string? contents = null, string? author = null, double red = 1, double green = 0, double blue = 0) { }
+        public static Excise.Core.Document.PdfAnnotation AddStampAnnotation(this Excise.Core.Document.PdfDocument document, int pageNumber, Excise.Core.Document.PdfRectangle rect, string stampName, string? contents = null, string? author = null) { }
+        public static Excise.Core.Document.PdfAnnotation AddStrikeOutAnnotation(this Excise.Core.Document.PdfDocument document, int pageNumber, Excise.Core.Document.PdfRectangle rect, string? contents = null, string? author = null, double red = 1, double green = 0, double blue = 0) { }
         public static Excise.Core.Document.PdfAnnotation AddTextAnnotation(this Excise.Core.Document.PdfDocument document, int pageNumber, Excise.Core.Document.PdfRectangle rect, string contents, string? author = null, bool open = false, string iconName = "Note") { }
+        public static Excise.Core.Document.PdfAnnotation AddUnderlineAnnotation(this Excise.Core.Document.PdfDocument document, int pageNumber, Excise.Core.Document.PdfRectangle rect, string? contents = null, string? author = null, double red = 1, double green = 0, double blue = 0) { }
+        public static bool RemoveAnnotation(this Excise.Core.Document.PdfDocument document, int pageNumber, Excise.Core.Document.PdfAnnotation annotation) { }
+        public static void SetAnnotationColor(this Excise.Core.Document.PdfAnnotation annotation, double red, double green, double blue) { }
+        public static void SetAnnotationContents(this Excise.Core.Document.PdfAnnotation annotation, string? contents) { }
+        public static void SetAnnotationOpacity(this Excise.Core.Document.PdfAnnotation annotation, double opacity) { }
+        public static void SetReplyTo(this Excise.Core.Document.PdfAnnotation reply, Excise.Core.Document.PdfDocument document, Excise.Core.Document.PdfAnnotation parent, string replyType = "R") { }
     }
     [System.Flags]
     public enum PdfAnnotationFlags

--- a/Excise.Core/Document/PdfAnnotationAuthoring.cs
+++ b/Excise.Core/Document/PdfAnnotationAuthoring.cs
@@ -624,6 +624,897 @@ public static class PdfAnnotationAuthoring
         return sb.ToString();
     }
 
+    // ── Text markup: Underline / StrikeOut / Squiggly (#626, ISO 32000-2 §12.5.6.10) ──
+
+    /// <summary>
+    /// Add an Underline text-markup annotation — a straight line drawn under
+    /// the marked text (ISO 32000-2:2020 §12.5.6.10, Table 179). Mirrors
+    /// <see cref="AddHighlightAnnotation"/>'s shape: a single axis-aligned
+    /// <paramref name="rect"/> becomes one /QuadPoints quad. Unlike Highlight
+    /// (which most viewers synthesize an appearance for), Underline carries a
+    /// baked <c>/AP /N</c> stroke so every viewer draws the same line (#626).
+    /// </summary>
+    public static PdfAnnotation AddUnderlineAnnotation(
+        this PdfDocument document,
+        int pageNumber,
+        PdfRectangle rect,
+        string? contents = null,
+        string? author = null,
+        double red = 1,
+        double green = 0,
+        double blue = 0)
+        => AddTextMarkupAnnotation(document, pageNumber, rect, "Underline", contents, author, red, green, blue);
+
+    /// <summary>
+    /// Add a StrikeOut text-markup annotation — a line through the middle of
+    /// the marked text (ISO 32000-2:2020 §12.5.6.10, Table 179). See
+    /// <see cref="AddUnderlineAnnotation"/> for shared parameter semantics.
+    /// </summary>
+    public static PdfAnnotation AddStrikeOutAnnotation(
+        this PdfDocument document,
+        int pageNumber,
+        PdfRectangle rect,
+        string? contents = null,
+        string? author = null,
+        double red = 1,
+        double green = 0,
+        double blue = 0)
+        => AddTextMarkupAnnotation(document, pageNumber, rect, "StrikeOut", contents, author, red, green, blue);
+
+    /// <summary>
+    /// Add a Squiggly text-markup annotation — a wavy underline (ISO
+    /// 32000-2:2020 §12.5.6.10, Table 179). See
+    /// <see cref="AddUnderlineAnnotation"/> for shared parameter semantics.
+    /// </summary>
+    public static PdfAnnotation AddSquigglyAnnotation(
+        this PdfDocument document,
+        int pageNumber,
+        PdfRectangle rect,
+        string? contents = null,
+        string? author = null,
+        double red = 1,
+        double green = 0,
+        double blue = 0)
+        => AddTextMarkupAnnotation(document, pageNumber, rect, "Squiggly", contents, author, red, green, blue);
+
+    private static PdfAnnotation AddTextMarkupAnnotation(
+        PdfDocument document,
+        int pageNumber,
+        PdfRectangle rect,
+        string subtype,
+        string? contents,
+        string? author,
+        double red,
+        double green,
+        double blue)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+        ValidateRect(rect);
+        ValidateColor(red, nameof(red));
+        ValidateColor(green, nameof(green));
+        ValidateColor(blue, nameof(blue));
+
+        var normalized = rect.Normalize();
+        var annot = NewAnnotationDict(subtype, normalized);
+
+        if (!string.IsNullOrWhiteSpace(contents))
+            annot.SetString("Contents", contents);
+        if (!string.IsNullOrWhiteSpace(author))
+            annot.SetString("T", author);
+
+        // Markup annotations carry /CreationDate (§12.5.6.2 Table 172).
+        annot.SetString("CreationDate", PdfDate(DateTimeOffset.UtcNow));
+
+        annot["C"] = new PdfArray(new PdfReal(red), new PdfReal(green), new PdfReal(blue));
+
+        annot["QuadPoints"] = new PdfArray(
+            new PdfReal(normalized.Left), new PdfReal(normalized.Top),
+            new PdfReal(normalized.Right), new PdfReal(normalized.Top),
+            new PdfReal(normalized.Left), new PdfReal(normalized.Bottom),
+            new PdfReal(normalized.Right), new PdfReal(normalized.Bottom));
+
+        // Baked normal appearance so third-party viewers draw the same pixels.
+        var apStream = BuildTextMarkupAppearanceStream(normalized, subtype, (red, green, blue));
+        var ap = new PdfDictionary();
+        ap["N"] = document.AddIndirectObject(apStream);
+        annot["AP"] = ap;
+
+        return AttachAnnotation(document, pageNumber, annot);
+    }
+
+    /// <summary>
+    /// Build the <c>/AP /N</c> Form XObject for an Underline/StrikeOut/Squiggly
+    /// markup annotation. Draws a single stroked line (Underline/StrikeOut) or
+    /// a zig-zag (Squiggly) across the local BBox width, positioned per
+    /// conventional placement: underline near the baseline (~12% up from the
+    /// bottom), strikeout through the visual middle (~45% up), squiggly at the
+    /// underline height.
+    /// </summary>
+    private static PdfStream BuildTextMarkupAppearanceStream(
+        PdfRectangle rect, string subtype, (double R, double G, double B) color)
+    {
+        double w = rect.Width;
+        double h = rect.Height;
+        double lineWidth = Math.Max(0.5, h * 0.06);
+
+        var sb = new StringBuilder();
+        sb.Append($"{Num(color.R)} {Num(color.G)} {Num(color.B)} RG\n");
+        sb.Append($"{Num(lineWidth)} w\n");
+
+        if (subtype == "Squiggly")
+        {
+            double baseline = h * 0.12;
+            double amplitude = Math.Max(1, h * 0.06);
+            double period = Math.Max(2, h * 0.18);
+            sb.Append($"0 {Num(baseline)} m\n");
+            bool up = true;
+            int emitted = 0;
+            for (double x = period; x <= w + period && emitted < 200; x += period, emitted++)
+            {
+                double y = baseline + (up ? amplitude : -amplitude);
+                sb.Append($"{Num(Math.Min(x, w))} {Num(y)} l\n");
+                up = !up;
+            }
+            if (emitted == 0)
+                sb.Append($"{Num(w)} {Num(baseline)} l\n");
+            sb.Append("S\n");
+        }
+        else
+        {
+            double y = subtype == "StrikeOut" ? h * 0.45 : h * 0.12;
+            sb.Append($"0 {Num(y)} m\n{Num(w)} {Num(y)} l\nS\n");
+        }
+
+        var stream = new PdfStream(Encoding.ASCII.GetBytes(sb.ToString()));
+        stream.SetName("Type", "XObject");
+        stream.SetName("Subtype", "Form");
+        stream.SetInt("FormType", 1);
+        stream["BBox"] = PdfArray.FromRectangle(0, 0, w, h);
+        stream["Resources"] = new PdfDictionary();
+        return stream;
+    }
+
+    // ── Line / Arrow (#626, ISO 32000-2 §12.5.6.7) ───────────────────────────
+
+    /// <summary>
+    /// Add a Line annotation — a straight line between two points (ISO
+    /// 32000-2:2020 §12.5.6.7, Table 178).
+    /// </summary>
+    /// <remarks>
+    /// Carries <c>/L</c> (the two absolute-page-space endpoints) and a baked
+    /// <c>/AP /N</c> stroke so every viewer draws the same line (#626).
+    /// <c>/Rect</c> is the line's bounding box, padded by half the stroke
+    /// width so the stroke isn't clipped.
+    /// </remarks>
+    public static PdfAnnotation AddLineAnnotation(
+        this PdfDocument document,
+        int pageNumber,
+        double x1, double y1, double x2, double y2,
+        string? contents = null,
+        string? author = null,
+        double red = 0,
+        double green = 0,
+        double blue = 0,
+        double lineWidth = 1)
+        => AddLineOrArrowAnnotation(
+            document, pageNumber, x1, y1, x2, y2, contents, author,
+            red, green, blue, lineWidth, startLineEnding: "None", endLineEnding: "None");
+
+    /// <summary>
+    /// Add an Arrow annotation — a Line annotation whose <c>/LE</c> entry
+    /// gives one or both ends an arrowhead (ISO 32000-2:2020 §12.5.6.7,
+    /// Table 178, <c>/LE</c> line-ending styles per Table 179). The default
+    /// draws a closed arrowhead at the end point only — the common "points at
+    /// X" review mark.
+    /// </summary>
+    /// <param name="startLineEnding">Line-ending style at (x1,y1): "None",
+    /// "OpenArrow" or "ClosedArrow".</param>
+    /// <param name="endLineEnding">Line-ending style at (x2,y2): "None",
+    /// "OpenArrow" or "ClosedArrow".</param>
+    public static PdfAnnotation AddArrowAnnotation(
+        this PdfDocument document,
+        int pageNumber,
+        double x1, double y1, double x2, double y2,
+        string? contents = null,
+        string? author = null,
+        double red = 0,
+        double green = 0,
+        double blue = 0,
+        double lineWidth = 1,
+        string startLineEnding = "None",
+        string endLineEnding = "ClosedArrow")
+        => AddLineOrArrowAnnotation(
+            document, pageNumber, x1, y1, x2, y2, contents, author,
+            red, green, blue, lineWidth, startLineEnding, endLineEnding);
+
+    private static readonly HashSet<string> SupportedLineEndings =
+        new(StringComparer.Ordinal) { "None", "OpenArrow", "ClosedArrow" };
+
+    private static PdfAnnotation AddLineOrArrowAnnotation(
+        PdfDocument document,
+        int pageNumber,
+        double x1, double y1, double x2, double y2,
+        string? contents,
+        string? author,
+        double red, double green, double blue,
+        double lineWidth,
+        string startLineEnding,
+        string endLineEnding)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+        if (double.IsNaN(x1) || double.IsInfinity(x1) || double.IsNaN(y1) || double.IsInfinity(y1) ||
+            double.IsNaN(x2) || double.IsInfinity(x2) || double.IsNaN(y2) || double.IsInfinity(y2))
+            throw new ArgumentException("Line endpoints must be finite numbers.");
+        if (x1 == x2 && y1 == y2)
+            throw new ArgumentException("A line annotation needs two distinct endpoints.");
+
+        ValidateColor(red, nameof(red));
+        ValidateColor(green, nameof(green));
+        ValidateColor(blue, nameof(blue));
+        if (double.IsNaN(lineWidth) || double.IsInfinity(lineWidth) || lineWidth <= 0)
+            throw new ArgumentOutOfRangeException(nameof(lineWidth),
+                "Line width must be a finite, positive number of points.");
+        if (!SupportedLineEndings.Contains(startLineEnding))
+            throw new ArgumentException(
+                $"Unsupported start line ending \"{startLineEnding}\". Supported: " +
+                string.Join(", ", SupportedLineEndings) + ".",
+                nameof(startLineEnding));
+        if (!SupportedLineEndings.Contains(endLineEnding))
+            throw new ArgumentException(
+                $"Unsupported end line ending \"{endLineEnding}\". Supported: " +
+                string.Join(", ", SupportedLineEndings) + ".",
+                nameof(endLineEnding));
+
+        // Arrowheads extend past the endpoint; pad the rect enough to contain them.
+        double headSize = Math.Max(6, lineWidth * 4);
+        bool hasHead = startLineEnding != "None" || endLineEnding != "None";
+        double pad = lineWidth / 2 + (hasHead ? headSize : 0);
+        var rect = new PdfRectangle(
+            Math.Min(x1, x2) - pad, Math.Min(y1, y2) - pad,
+            Math.Max(x1, x2) + pad, Math.Max(y1, y2) + pad);
+
+        var annot = NewAnnotationDict("Line", rect);
+
+        if (!string.IsNullOrWhiteSpace(contents))
+            annot.SetString("Contents", contents);
+        if (!string.IsNullOrWhiteSpace(author))
+            annot.SetString("T", author);
+        annot.SetString("CreationDate", PdfDate(DateTimeOffset.UtcNow));
+
+        annot["L"] = new PdfArray(new PdfReal(x1), new PdfReal(y1), new PdfReal(x2), new PdfReal(y2));
+        annot["C"] = new PdfArray(new PdfReal(red), new PdfReal(green), new PdfReal(blue));
+        annot["LE"] = new PdfArray(new PdfName(startLineEnding), new PdfName(endLineEnding));
+
+        var bs = new PdfDictionary();
+        bs.SetName("Type", "Border");
+        bs.SetNumber("W", lineWidth);
+        bs.SetName("S", "S");
+        annot["BS"] = bs;
+
+        // Baked normal appearance so third-party viewers draw the same pixels.
+        var apStream = BuildLineAppearanceStream(
+            rect, x1, y1, x2, y2, (red, green, blue), lineWidth, startLineEnding, endLineEnding, headSize);
+        var ap = new PdfDictionary();
+        ap["N"] = document.AddIndirectObject(apStream);
+        annot["AP"] = ap;
+
+        return AttachAnnotation(document, pageNumber, annot);
+    }
+
+    /// <summary>
+    /// Build the <c>/AP /N</c> Form XObject for a Line/Arrow annotation. The
+    /// stream draws in a local space whose <c>/BBox</c> is <c>[0 0 w h]</c>
+    /// (points translated by the /Rect origin), strokes the line itself, then
+    /// appends a triangular arrowhead at each end whose <c>/LE</c> style is
+    /// not "None".
+    /// </summary>
+    private static PdfStream BuildLineAppearanceStream(
+        PdfRectangle rect,
+        double x1, double y1, double x2, double y2,
+        (double R, double G, double B) color,
+        double lineWidth,
+        string startLineEnding,
+        string endLineEnding,
+        double headSize)
+    {
+        double ox = rect.Left, oy = rect.Bottom;
+        double lx1 = x1 - ox, ly1 = y1 - oy, lx2 = x2 - ox, ly2 = y2 - oy;
+
+        var sb = new StringBuilder();
+        sb.Append($"{Num(color.R)} {Num(color.G)} {Num(color.B)} RG\n");
+        sb.Append($"{Num(color.R)} {Num(color.G)} {Num(color.B)} rg\n");
+        sb.Append($"{Num(lineWidth)} w\n1 J\n");
+        sb.Append($"{Num(lx1)} {Num(ly1)} m\n{Num(lx2)} {Num(ly2)} l\nS\n");
+
+        double dx = lx2 - lx1, dy = ly2 - ly1;
+        double len = Math.Sqrt(dx * dx + dy * dy);
+        double ux = len > 0 ? dx / len : 1, uy = len > 0 ? dy / len : 0;
+
+        if (endLineEnding != "None")
+            AppendArrowHead(sb, lx2, ly2, ux, uy, endLineEnding, headSize);
+        if (startLineEnding != "None")
+            AppendArrowHead(sb, lx1, ly1, -ux, -uy, startLineEnding, headSize);
+
+        var stream = new PdfStream(Encoding.ASCII.GetBytes(sb.ToString()));
+        stream.SetName("Type", "XObject");
+        stream.SetName("Subtype", "Form");
+        stream.SetInt("FormType", 1);
+        stream["BBox"] = PdfArray.FromRectangle(0, 0, rect.Width, rect.Height);
+        stream["Resources"] = new PdfDictionary();
+        return stream;
+    }
+
+    /// <summary>
+    /// Append a triangular arrowhead at (tipX,tipY) pointing along the unit
+    /// direction (dirX,dirY) — the line's own direction for an end-of-line
+    /// head, or its negation for a start-of-line head. "ClosedArrow" fills
+    /// the triangle; "OpenArrow" strokes just the two wings (open at the
+    /// base, per the ISO 32000-2 Table 179 line-ending gallery).
+    /// </summary>
+    private static void AppendArrowHead(
+        StringBuilder sb, double tipX, double tipY, double dirX, double dirY, string style, double size)
+    {
+        double px = -dirY, py = dirX; // perpendicular to the direction
+        double wingSpread = size * 0.4;
+
+        double baseX = tipX - dirX * size, baseY = tipY - dirY * size;
+        double leftX = baseX + px * wingSpread, leftY = baseY + py * wingSpread;
+        double rightX = baseX - px * wingSpread, rightY = baseY - py * wingSpread;
+
+        if (style == "ClosedArrow")
+        {
+            sb.Append($"{Num(tipX)} {Num(tipY)} m\n");
+            sb.Append($"{Num(leftX)} {Num(leftY)} l\n");
+            sb.Append($"{Num(rightX)} {Num(rightY)} l\n");
+            sb.Append("h\nB\n");
+        }
+        else // OpenArrow
+        {
+            sb.Append($"{Num(leftX)} {Num(leftY)} m\n");
+            sb.Append($"{Num(tipX)} {Num(tipY)} l\n");
+            sb.Append($"{Num(rightX)} {Num(rightY)} l\nS\n");
+        }
+    }
+
+    // ── Polygon / PolyLine (#626, ISO 32000-2 §12.5.6.9) ─────────────────────
+
+    /// <summary>
+    /// Add a Polygon annotation — a closed multi-sided shape (ISO
+    /// 32000-2:2020 §12.5.6.9, Table 178). See <see cref="AddSquareAnnotation"/>
+    /// for the shared border/interior-fill parameter semantics.
+    /// </summary>
+    public static PdfAnnotation AddPolygonAnnotation(
+        this PdfDocument document,
+        int pageNumber,
+        IReadOnlyList<(double X, double Y)> vertices,
+        string? contents = null,
+        string? author = null,
+        double red = 0,
+        double green = 0,
+        double blue = 0,
+        double borderWidth = 1,
+        double? interiorRed = null,
+        double? interiorGreen = null,
+        double? interiorBlue = null)
+        => AddPolyAnnotation(
+            document, pageNumber, vertices, isClosed: true, contents, author,
+            red, green, blue, borderWidth, interiorRed, interiorGreen, interiorBlue);
+
+    /// <summary>
+    /// Add a PolyLine annotation — an open multi-segment line (ISO
+    /// 32000-2:2020 §12.5.6.9, Table 178). Unlike Polygon, PolyLine has no
+    /// interior fill — it is always stroke-only.
+    /// </summary>
+    public static PdfAnnotation AddPolyLineAnnotation(
+        this PdfDocument document,
+        int pageNumber,
+        IReadOnlyList<(double X, double Y)> vertices,
+        string? contents = null,
+        string? author = null,
+        double red = 0,
+        double green = 0,
+        double blue = 0,
+        double borderWidth = 1)
+        => AddPolyAnnotation(
+            document, pageNumber, vertices, isClosed: false, contents, author,
+            red, green, blue, borderWidth, null, null, null);
+
+    private static PdfAnnotation AddPolyAnnotation(
+        PdfDocument document,
+        int pageNumber,
+        IReadOnlyList<(double X, double Y)> vertices,
+        bool isClosed,
+        string? contents,
+        string? author,
+        double red, double green, double blue,
+        double borderWidth,
+        double? interiorRed, double? interiorGreen, double? interiorBlue)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+        ArgumentNullException.ThrowIfNull(vertices);
+
+        int minVertices = isClosed ? 3 : 2;
+        if (vertices.Count < minVertices)
+            throw new ArgumentException(
+                $"A {(isClosed ? "Polygon" : "PolyLine")} annotation needs at least {minVertices} vertices.",
+                nameof(vertices));
+        foreach (var (x, y) in vertices)
+            if (double.IsNaN(x) || double.IsInfinity(x) || double.IsNaN(y) || double.IsInfinity(y))
+                throw new ArgumentException("Vertex coordinates must be finite numbers.", nameof(vertices));
+
+        ValidateColor(red, nameof(red));
+        ValidateColor(green, nameof(green));
+        ValidateColor(blue, nameof(blue));
+        if (double.IsNaN(borderWidth) || double.IsInfinity(borderWidth) || borderWidth < 0)
+            throw new ArgumentOutOfRangeException(nameof(borderWidth),
+                "Border width must be a finite, non-negative number of points.");
+
+        var interiorSet = new[] { interiorRed, interiorGreen, interiorBlue }.Count(c => c.HasValue);
+        if (interiorSet is not (0 or 3))
+            throw new ArgumentException(
+                "Interior color requires all three of interiorRed, interiorGreen " +
+                "and interiorBlue, or none.", nameof(interiorRed));
+
+        (double R, double G, double B)? interior = null;
+        if (interiorSet == 3)
+        {
+            ValidateColor(interiorRed!.Value, nameof(interiorRed));
+            ValidateColor(interiorGreen!.Value, nameof(interiorGreen));
+            ValidateColor(interiorBlue!.Value, nameof(interiorBlue));
+            interior = (interiorRed.Value, interiorGreen.Value, interiorBlue.Value);
+        }
+
+        if (borderWidth == 0 && interior == null)
+            throw new ArgumentException(
+                $"A {(isClosed ? "polygon" : "polyline")} with zero border width and no interior " +
+                "color would be invisible. Give it a border, a fill, or both.",
+                nameof(borderWidth));
+
+        double minX = double.MaxValue, minY = double.MaxValue;
+        double maxX = double.MinValue, maxY = double.MinValue;
+        foreach (var (x, y) in vertices)
+        {
+            minX = Math.Min(minX, x); maxX = Math.Max(maxX, x);
+            minY = Math.Min(minY, y); maxY = Math.Max(maxY, y);
+        }
+        double pad = borderWidth / 2;
+        var rect = new PdfRectangle(minX - pad, minY - pad, maxX + pad, maxY + pad);
+
+        var annot = NewAnnotationDict(isClosed ? "Polygon" : "PolyLine", rect);
+
+        if (!string.IsNullOrWhiteSpace(contents))
+            annot.SetString("Contents", contents);
+        if (!string.IsNullOrWhiteSpace(author))
+            annot.SetString("T", author);
+        annot.SetString("CreationDate", PdfDate(DateTimeOffset.UtcNow));
+
+        var verticesArr = new PdfArray();
+        foreach (var (x, y) in vertices)
+        {
+            verticesArr.Add(x);
+            verticesArr.Add(y);
+        }
+        annot["Vertices"] = verticesArr;
+
+        annot["C"] = new PdfArray(new PdfReal(red), new PdfReal(green), new PdfReal(blue));
+        if (interior is { } ic)
+            annot["IC"] = new PdfArray(new PdfReal(ic.R), new PdfReal(ic.G), new PdfReal(ic.B));
+
+        var bs = new PdfDictionary();
+        bs.SetName("Type", "Border");
+        bs.SetNumber("W", borderWidth);
+        bs.SetName("S", "S");
+        annot["BS"] = bs;
+
+        // Baked normal appearance so third-party viewers draw the same pixels.
+        var apStream = BuildPolyAppearanceStream(rect, vertices, isClosed, (red, green, blue), interior, borderWidth);
+        var ap = new PdfDictionary();
+        ap["N"] = document.AddIndirectObject(apStream);
+        annot["AP"] = ap;
+
+        return AttachAnnotation(document, pageNumber, annot);
+    }
+
+    /// <summary>
+    /// Build the <c>/AP /N</c> Form XObject for a Polygon/PolyLine annotation
+    /// — a single path visiting every vertex in order, closed with <c>h</c>
+    /// for Polygon, left open for PolyLine.
+    /// </summary>
+    private static PdfStream BuildPolyAppearanceStream(
+        PdfRectangle rect,
+        IReadOnlyList<(double X, double Y)> vertices,
+        bool isClosed,
+        (double R, double G, double B) stroke,
+        (double R, double G, double B)? interior,
+        double borderWidth)
+    {
+        double ox = rect.Left, oy = rect.Bottom;
+        var sb = new StringBuilder();
+        if (interior is { } ic)
+            sb.Append($"{Num(ic.R)} {Num(ic.G)} {Num(ic.B)} rg\n");
+        if (borderWidth > 0)
+        {
+            sb.Append($"{Num(stroke.R)} {Num(stroke.G)} {Num(stroke.B)} RG\n");
+            sb.Append($"{Num(borderWidth)} w\n1 j\n");
+        }
+
+        sb.Append($"{Num(vertices[0].X - ox)} {Num(vertices[0].Y - oy)} m\n");
+        for (int i = 1; i < vertices.Count; i++)
+            sb.Append($"{Num(vertices[i].X - ox)} {Num(vertices[i].Y - oy)} l\n");
+        if (isClosed)
+            sb.Append("h\n");
+
+        sb.Append(interior != null
+            ? (borderWidth > 0 ? "B\n" : "f\n")
+            : "S\n");
+
+        var stream = new PdfStream(Encoding.ASCII.GetBytes(sb.ToString()));
+        stream.SetName("Type", "XObject");
+        stream.SetName("Subtype", "Form");
+        stream.SetInt("FormType", 1);
+        stream["BBox"] = PdfArray.FromRectangle(0, 0, rect.Width, rect.Height);
+        stream["Resources"] = new PdfDictionary();
+        return stream;
+    }
+
+    // ── Stamp (#626, ISO 32000-2 §12.5.6.12) ─────────────────────────────────
+
+    /// <summary>
+    /// The standard rubber-stamp names defined in ISO 32000-2:2020 §12.5.6.12
+    /// (Table 181) that <see cref="AddStampAnnotation"/> accepts for
+    /// <c>stampName</c>.
+    /// </summary>
+    public static IReadOnlyList<string> StandardStampNames { get; } =
+    [
+        "Approved", "Experimental", "NotApproved", "AsIs", "Expired",
+        "NotForPublicRelease", "Confidential", "Sold", "Departmental",
+        "TopSecret", "Draft", "ForComment", "Final", "ForPublicRelease",
+        "InformationOnly"
+    ];
+
+    private static readonly HashSet<string> StandardStampNameSet =
+        new(StandardStampNames, StringComparer.Ordinal);
+
+    private static readonly HashSet<string> NegativeStampNames = new(StringComparer.Ordinal)
+        { "NotApproved", "Expired", "NotForPublicRelease", "Confidential", "TopSecret", "Draft" };
+
+    private static readonly HashSet<string> PositiveStampNames = new(StringComparer.Ordinal)
+        { "Approved", "Final", "Sold", "ForPublicRelease" };
+
+    /// <summary>
+    /// Add a Stamp annotation using one of the standard rubber-stamp names
+    /// (ISO 32000-2:2020 §12.5.6.12, Table 181).
+    /// </summary>
+    /// <remarks>
+    /// excise has no bundled stamp icon artwork, so the baked <c>/AP /N</c>
+    /// appearance draws a bordered box with the stamp name as bold, centered
+    /// text in a color matching common reviewer convention (red for
+    /// negative/urgent stamps such as "Confidential"/"Draft"/"Expired", green
+    /// for positive ones such as "Approved"/"Final", blue otherwise) — not
+    /// Acrobat's own icon artwork, but every ISO-conforming viewer renders the
+    /// exact same pixels, which is the property #626 cares about. For a
+    /// company logo or other custom artwork use
+    /// <see cref="AddImageStampAnnotation"/> instead.
+    /// </remarks>
+    /// <param name="stampName">One of <see cref="StandardStampNames"/>.</param>
+    public static PdfAnnotation AddStampAnnotation(
+        this PdfDocument document,
+        int pageNumber,
+        PdfRectangle rect,
+        string stampName,
+        string? contents = null,
+        string? author = null)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+        ValidateRect(rect);
+        if (string.IsNullOrWhiteSpace(stampName) || !StandardStampNameSet.Contains(stampName))
+            throw new ArgumentException(
+                $"\"{stampName}\" is not a standard stamp name. Supported: " +
+                string.Join(", ", StandardStampNames) + ".",
+                nameof(stampName));
+
+        var normalized = rect.Normalize();
+        var annot = NewAnnotationDict("Stamp", normalized);
+        annot.SetName("Name", stampName);
+
+        if (!string.IsNullOrWhiteSpace(contents))
+            annot.SetString("Contents", contents);
+        if (!string.IsNullOrWhiteSpace(author))
+            annot.SetString("T", author);
+        annot.SetString("CreationDate", PdfDate(DateTimeOffset.UtcNow));
+
+        var color = StampColor(stampName);
+        annot["C"] = new PdfArray(new PdfReal(color.R), new PdfReal(color.G), new PdfReal(color.B));
+
+        var apStream = BuildStampAppearanceStream(document, normalized, stampName, color);
+        var ap = new PdfDictionary();
+        ap["N"] = document.AddIndirectObject(apStream);
+        annot["AP"] = ap;
+
+        return AttachAnnotation(document, pageNumber, annot);
+    }
+
+    private static (double R, double G, double B) StampColor(string stampName) =>
+        NegativeStampNames.Contains(stampName) ? (0.8, 0, 0) :
+        PositiveStampNames.Contains(stampName) ? (0, 0.55, 0) :
+        (0, 0.3, 0.7);
+
+    /// <summary>
+    /// Build the <c>/AP /N</c> Form XObject for a standard-name Stamp: a
+    /// stroked border plus the stamp name as bold Helvetica, sized to fit the
+    /// box (bounded by both width and height) and centered.
+    /// </summary>
+    private static PdfStream BuildStampAppearanceStream(
+        PdfDocument document, PdfRectangle rect, string label, (double R, double G, double B) color)
+    {
+        double w = rect.Width, h = rect.Height;
+        double borderWidth = Math.Max(1, Math.Min(w, h) * 0.04);
+        double inset = borderWidth / 2;
+
+        var sb = new StringBuilder();
+        sb.Append($"{Num(color.R)} {Num(color.G)} {Num(color.B)} RG\n");
+        sb.Append($"{Num(borderWidth)} w\n");
+        sb.Append($"{Num(inset)} {Num(inset)} {Num(w - 2 * inset)} {Num(h - 2 * inset)} re S\n");
+
+        var unitFont = PdfFont.HelveticaBold(1);
+        double widthAt1 = Math.Max(0.001, unitFont.MeasureWidth(label));
+        double fontSizeByWidth = (w * 0.85) / widthAt1;
+        double fontSizeByHeight = h * 0.4;
+        double fontSize = Math.Max(4, Math.Min(fontSizeByWidth, fontSizeByHeight));
+        var sized = PdfFont.HelveticaBold(fontSize);
+        double textWidth = sized.MeasureWidth(label);
+        double x = Math.Max(0, (w - textWidth) / 2);
+        double y = h / 2 - fontSize * 0.35;
+
+        sb.Append("BT\n");
+        sb.Append($"/HelvB {Num(fontSize)} Tf\n");
+        sb.Append($"{Num(color.R)} {Num(color.G)} {Num(color.B)} rg\n");
+        sb.Append($"{Num(x)} {Num(y)} Td\n");
+        sb.Append('(').Append(EscapePdfTextString(label)).Append(") Tj\n");
+        sb.Append("ET\n");
+
+        var stream = new PdfStream(Encoding.ASCII.GetBytes(sb.ToString()));
+        stream.SetName("Type", "XObject");
+        stream.SetName("Subtype", "Form");
+        stream.SetInt("FormType", 1);
+        stream["BBox"] = PdfArray.FromRectangle(0, 0, w, h);
+
+        var helvBold = new PdfDictionary();
+        helvBold.SetName("Type", "Font");
+        helvBold.SetName("Subtype", "Type1");
+        helvBold.SetName("BaseFont", "Helvetica-Bold");
+        helvBold.SetName("Encoding", "WinAnsiEncoding");
+
+        var fonts = new PdfDictionary();
+        fonts["HelvB"] = document.AddIndirectObject(helvBold);
+        var resources = new PdfDictionary();
+        resources["Font"] = fonts;
+        stream["Resources"] = resources;
+
+        return stream;
+    }
+
+    /// <summary>
+    /// Add a Stamp annotation whose appearance is a caller-supplied raster
+    /// image (e.g. a company logo) rather than one of the standard names
+    /// (ISO 32000-2:2020 §12.5.6.12).
+    /// </summary>
+    /// <remarks>
+    /// The image is embedded as an uncompressed DeviceRGB Image XObject
+    /// referenced from the baked <c>/AP /N</c> Form XObject, so every
+    /// ISO-conforming viewer draws the exact same pixels (#626) — deliberately
+    /// no dependency on an external image codec (JPEG/PNG decoding); callers
+    /// that already have decoded pixels (e.g. from SkiaSharp in the GUI layer)
+    /// can pass them straight through.
+    /// </remarks>
+    /// <param name="document">Target document.</param>
+    /// <param name="pageNumber">1-based page number.</param>
+    /// <param name="rect">Annotation rectangle in PDF points (Y-up); the
+    /// image is stretched to fill it.</param>
+    /// <param name="rgbPixels">Top-down, row-major RGB24 pixel data: exactly
+    /// <c>pixelWidth * pixelHeight * 3</c> bytes, 3 bytes (R,G,B) per pixel,
+    /// no padding between rows.</param>
+    /// <param name="pixelWidth">Image width in pixels.</param>
+    /// <param name="pixelHeight">Image height in pixels.</param>
+    public static PdfAnnotation AddImageStampAnnotation(
+        this PdfDocument document,
+        int pageNumber,
+        PdfRectangle rect,
+        byte[] rgbPixels,
+        int pixelWidth,
+        int pixelHeight,
+        string? contents = null,
+        string? author = null)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+        ArgumentNullException.ThrowIfNull(rgbPixels);
+        ValidateRect(rect);
+
+        if (pixelWidth <= 0 || pixelHeight <= 0)
+            throw new ArgumentException("Image dimensions must be positive.", nameof(pixelWidth));
+        long expected = (long)pixelWidth * pixelHeight * 3;
+        if (rgbPixels.LongLength != expected)
+            throw new ArgumentException(
+                $"rgbPixels must be exactly pixelWidth*pixelHeight*3 bytes ({expected}), " +
+                $"got {rgbPixels.LongLength}.",
+                nameof(rgbPixels));
+
+        var normalized = rect.Normalize();
+        var annot = NewAnnotationDict("Stamp", normalized);
+
+        if (!string.IsNullOrWhiteSpace(contents))
+            annot.SetString("Contents", contents);
+        if (!string.IsNullOrWhiteSpace(author))
+            annot.SetString("T", author);
+        annot.SetString("CreationDate", PdfDate(DateTimeOffset.UtcNow));
+
+        var apStream = BuildImageStampAppearanceStream(document, normalized, rgbPixels, pixelWidth, pixelHeight);
+        var ap = new PdfDictionary();
+        ap["N"] = document.AddIndirectObject(apStream);
+        annot["AP"] = ap;
+
+        return AttachAnnotation(document, pageNumber, annot);
+    }
+
+    /// <summary>
+    /// Build the <c>/AP /N</c> Form XObject for a custom image Stamp: an
+    /// uncompressed DeviceRGB Image XObject, drawn full-bleed into the
+    /// <c>/BBox</c> via the standard <c>cx 0 0 cy 0 0 cm /Im0 Do</c> unit-square
+    /// mapping (§8.9.5.2).
+    /// </summary>
+    private static PdfStream BuildImageStampAppearanceStream(
+        PdfDocument document, PdfRectangle rect, byte[] rgbPixels, int pixelWidth, int pixelHeight)
+    {
+        double w = rect.Width, h = rect.Height;
+
+        var image = new PdfStream(rgbPixels);
+        image.SetName("Type", "XObject");
+        image.SetName("Subtype", "Image");
+        image.SetInt("Width", pixelWidth);
+        image.SetInt("Height", pixelHeight);
+        image.SetName("ColorSpace", "DeviceRGB");
+        image.SetInt("BitsPerComponent", 8);
+        var imageRef = document.AddIndirectObject(image);
+
+        var sb = new StringBuilder();
+        sb.Append("q\n");
+        sb.Append($"{Num(w)} 0 0 {Num(h)} 0 0 cm\n");
+        sb.Append("/Im0 Do\n");
+        sb.Append("Q\n");
+
+        var stream = new PdfStream(Encoding.ASCII.GetBytes(sb.ToString()));
+        stream.SetName("Type", "XObject");
+        stream.SetName("Subtype", "Form");
+        stream.SetInt("FormType", 1);
+        stream["BBox"] = PdfArray.FromRectangle(0, 0, w, h);
+
+        var xobjects = new PdfDictionary();
+        xobjects["Im0"] = imageRef;
+        var resources = new PdfDictionary();
+        resources["XObject"] = xobjects;
+        stream["Resources"] = resources;
+
+        return stream;
+    }
+
+    // ── Edit / delete existing annotations (#626) ────────────────────────────
+
+    /// <summary>
+    /// Update an existing annotation's <c>/Contents</c> (comment/body text) in
+    /// place. Pass <c>null</c> to remove the entry. Also refreshes <c>/M</c>
+    /// (last-modified date, §12.5.2 Table 164's edit-tracking convention).
+    /// </summary>
+    public static void SetAnnotationContents(this PdfAnnotation annotation, string? contents)
+    {
+        ArgumentNullException.ThrowIfNull(annotation);
+        if (contents == null)
+            annotation.RawDictionary.Remove("Contents");
+        else
+            annotation.RawDictionary.SetString("Contents", contents);
+        annotation.RawDictionary.SetString("M", PdfDate(DateTimeOffset.UtcNow));
+    }
+
+    /// <summary>
+    /// Update an existing annotation's <c>/C</c> color in place (border/stroke
+    /// color for shapes and lines, icon color for Text, background for
+    /// FreeText). Does not touch <c>/IC</c> (interior fill) or repaint any
+    /// existing <c>/AP</c> appearance stream — callers that need the baked
+    /// pixels to match should re-author the annotation instead.
+    /// </summary>
+    public static void SetAnnotationColor(this PdfAnnotation annotation, double red, double green, double blue)
+    {
+        ArgumentNullException.ThrowIfNull(annotation);
+        ValidateColor(red, nameof(red));
+        ValidateColor(green, nameof(green));
+        ValidateColor(blue, nameof(blue));
+        annotation.RawDictionary["C"] = new PdfArray(new PdfReal(red), new PdfReal(green), new PdfReal(blue));
+        annotation.RawDictionary.SetString("M", PdfDate(DateTimeOffset.UtcNow));
+    }
+
+    /// <summary>
+    /// Update an existing annotation's <c>/CA</c> constant opacity in place
+    /// (ISO 32000-2:2020 §12.5.2 Table 164). 0 is fully transparent, 1 (the
+    /// default when absent) is fully opaque.
+    /// </summary>
+    public static void SetAnnotationOpacity(this PdfAnnotation annotation, double opacity)
+    {
+        ArgumentNullException.ThrowIfNull(annotation);
+        if (double.IsNaN(opacity) || opacity < 0 || opacity > 1)
+            throw new ArgumentOutOfRangeException(nameof(opacity), "Opacity must be between 0 and 1.");
+        annotation.RawDictionary.SetNumber("CA", opacity);
+        annotation.RawDictionary.SetString("M", PdfDate(DateTimeOffset.UtcNow));
+    }
+
+    /// <summary>
+    /// Remove an annotation from a page's <c>/Annots</c> array.
+    /// </summary>
+    /// <remarks>
+    /// The underlying indirect object is left in the xref (unreachable, and
+    /// garbage-collected on the next full rewrite by whatever wrote the file)
+    /// — this only detaches it from the page, matching how every other
+    /// mutation in this class works on the in-memory object graph.
+    /// </remarks>
+    /// <returns><c>true</c> if the annotation was found and removed;
+    /// <c>false</c> if it wasn't on that page's /Annots array (already
+    /// removed, or belongs to a different page).</returns>
+    public static bool RemoveAnnotation(this PdfDocument document, int pageNumber, PdfAnnotation annotation)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+        ArgumentNullException.ThrowIfNull(annotation);
+
+        var page = document.GetPage(pageNumber);
+        var annotsObj = page.Dictionary.GetOptional("Annots");
+        if (annotsObj == null || document.Resolve(annotsObj) is not PdfArray annots)
+            return false;
+
+        for (int i = 0; i < annots.Count; i++)
+        {
+            if (document.Resolve(annots[i]) is PdfDictionary d && ReferenceEquals(d, annotation.RawDictionary))
+            {
+                annots.RemoveAt(i);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // ── Reply threads (#626, ISO 32000-2 §12.5.6.2 — /IRT and /RT) ───────────
+
+    /// <summary>
+    /// Turn <paramref name="reply"/> into a reply to <paramref name="parent"/>
+    /// by setting <c>/IRT</c> (in-reply-to — an indirect reference to the
+    /// parent annotation) and <c>/RT</c> (reply type).
+    /// </summary>
+    /// <remarks>
+    /// Both annotations must already be attached to <paramref name="document"/>
+    /// (created through one of the <c>Add*Annotation</c> methods, or
+    /// imported) — <c>/IRT</c> needs the parent's real indirect object
+    /// reference, which only exists once it has been written into the
+    /// document.
+    /// </remarks>
+    /// <param name="replyType">"R" (the default — a visible threaded reply)
+    /// or "Group" (groups the annotations without implying a reply
+    /// relationship, per Table 173).</param>
+    /// <exception cref="InvalidOperationException"><paramref name="parent"/>
+    /// is not a top-level indirect object of <paramref name="document"/>.</exception>
+    public static void SetReplyTo(
+        this PdfAnnotation reply, PdfDocument document, PdfAnnotation parent, string replyType = "R")
+    {
+        ArgumentNullException.ThrowIfNull(reply);
+        ArgumentNullException.ThrowIfNull(document);
+        ArgumentNullException.ThrowIfNull(parent);
+        if (replyType is not ("R" or "Group"))
+            throw new ArgumentException("Reply type must be \"R\" or \"Group\".", nameof(replyType));
+
+        var parentRef = document.GetReferenceTo(parent.RawDictionary)
+            ?? throw new InvalidOperationException(
+                "The parent annotation is not an indirect object of this document yet " +
+                "— attach it first (Add*Annotation, or an XFDF/FDF import).");
+
+        reply.RawDictionary["IRT"] = parentRef;
+        reply.RawDictionary.SetName("RT", replyType);
+    }
+
     /// <summary>
     /// Attach a fully-built annotation dictionary to a page — the shared
     /// /P + /Annots plumbing, reused by the XFDF importer

--- a/Excise.Core/Forms/FdfSerializer.cs
+++ b/Excise.Core/Forms/FdfSerializer.cs
@@ -52,13 +52,15 @@ public sealed class FdfImportResult
 /// </para>
 /// <para>
 /// <b>Import</b> supports Text, FreeText, Line, Square, Circle, Polygon,
-/// PolyLine, Highlight, Underline, Squiggly, StrikeOut, Caret and Ink
+/// PolyLine, Highlight, Underline, Squiggly, StrikeOut, Stamp, Caret and Ink
 /// dictionaries. Subtypes with an authoring method
 /// (<see cref="PdfAnnotationAuthoring"/>) are created through it so they get
-/// a baked <c>/AP</c> appearance stream; the remainder are written as
-/// spec-correct dictionaries without an appearance (viewers synthesize one,
-/// as they do for Acrobat's own AP-less markup). Unknown subtypes are
-/// reported in <see cref="FdfImportResult.Skipped"/>, never an error.
+/// a baked <c>/AP</c> appearance stream (a Stamp's <c>/Name</c> must be one
+/// of <see cref="PdfAnnotationAuthoring.StandardStampNames"/> to qualify);
+/// the remainder are written as spec-correct dictionaries without an
+/// appearance (viewers synthesize one, as they do for Acrobat's own AP-less
+/// markup). Unknown subtypes are reported in
+/// <see cref="FdfImportResult.Skipped"/>, never an error.
 /// </para>
 /// </remarks>
 public static class FdfSerializer
@@ -617,6 +619,11 @@ public static class FdfSerializer
                 dict["Vertices"] = vertices;
                 if (color is { } pc)
                     dict["C"] = ColorArray(pc);
+                // Interior fill (/IC) applies to Polygon only — PolyLine has
+                // no fill per §12.5.6.9 — but must not be dropped for Polygon
+                // just because it went through the generic-dictionary path.
+                if (subtype == "Polygon" && interior is { } pic)
+                    dict["IC"] = ColorArray(pic);
                 created = PdfAnnotationAuthoring.AttachImported(document, pageNumber, dict);
                 break;
             }
@@ -628,6 +635,29 @@ public static class FdfSerializer
                 if (color is { } cc)
                     dict["C"] = ColorArray(cc);
                 created = PdfAnnotationAuthoring.AttachImported(document, pageNumber, dict);
+                break;
+            }
+
+            case "Stamp":
+            {
+                var r = RequireRect(rect);
+                var icon = annot.GetNameOrNull("Name");
+                if (!string.IsNullOrWhiteSpace(icon) &&
+                    PdfAnnotationAuthoring.StandardStampNames.Contains(icon))
+                {
+                    created = document.AddStampAnnotation(pageNumber, r, icon, contents, author);
+                }
+                else
+                {
+                    // Not one of the standard #626 names: keep the data
+                    // without a baked appearance rather than reject it.
+                    var dict = NewImportDict("Stamp", r);
+                    if (!string.IsNullOrWhiteSpace(icon))
+                        dict.SetName("Name", icon);
+                    if (color is { } sc)
+                        dict["C"] = ColorArray(sc);
+                    created = PdfAnnotationAuthoring.AttachImported(document, pageNumber, dict);
+                }
                 break;
             }
 

--- a/Excise.Core/Forms/XfdfSerializer.cs
+++ b/Excise.Core/Forms/XfdfSerializer.cs
@@ -51,13 +51,15 @@ public sealed class XfdfImportResult
 /// </para>
 /// <para>
 /// <b>Import</b> supports text, freetext, line, square, circle, polygon,
-/// polyline, highlight, underline, squiggly, strikeout, caret and ink
+/// polyline, highlight, underline, squiggly, strikeout, stamp, caret and ink
 /// elements. Subtypes with an authoring method
 /// (<see cref="PdfAnnotationAuthoring"/>) are created through it so they get
-/// a baked <c>/AP</c> appearance stream; the remainder are written as
-/// spec-correct dictionaries without an appearance (viewers synthesize one,
-/// as they do for Acrobat's own AP-less markup). Unknown elements are
-/// reported in <see cref="XfdfImportResult.Skipped"/>, never an error.
+/// a baked <c>/AP</c> appearance stream (a stamp element's <c>icon</c> must
+/// be one of <see cref="PdfAnnotationAuthoring.StandardStampNames"/> to
+/// qualify); the remainder are written as spec-correct dictionaries without
+/// an appearance (viewers synthesize one, as they do for Acrobat's own
+/// AP-less markup). Unknown elements are reported in
+/// <see cref="XfdfImportResult.Skipped"/>, never an error.
 /// </para>
 /// </remarks>
 public static class XfdfSerializer
@@ -493,6 +495,11 @@ public static class XfdfSerializer
                 dict["Vertices"] = vertices;
                 if (color is { } pc)
                     dict["C"] = ColorArray(pc);
+                // Interior fill (/IC) applies to Polygon only — PolyLine has
+                // no fill per §12.5.6.9 — but must not be dropped for Polygon
+                // just because it went through the generic-dictionary path.
+                if (localName == "polygon" && interior is { } pic)
+                    dict["IC"] = ColorArray(pic);
                 created = PdfAnnotationAuthoring.AttachImported(document, pageNumber, dict);
                 break;
             }
@@ -504,6 +511,30 @@ public static class XfdfSerializer
                 if (color is { } cc)
                     dict["C"] = ColorArray(cc);
                 created = PdfAnnotationAuthoring.AttachImported(document, pageNumber, dict);
+                break;
+            }
+
+            case "stamp":
+            {
+                var r = RequireRect(rect);
+                var icon = el.Attribute("icon")?.Value;
+                if (!string.IsNullOrWhiteSpace(icon) &&
+                    PdfAnnotationAuthoring.StandardStampNames.Contains(icon))
+                {
+                    created = document.AddStampAnnotation(pageNumber, r, icon, contents, author);
+                }
+                else
+                {
+                    // Not one of the standard #626 names (custom/unknown icon,
+                    // e.g. a viewer-specific or image stamp): keep the data
+                    // without a baked appearance rather than reject it.
+                    var dict = NewImportDict("Stamp", r);
+                    if (!string.IsNullOrWhiteSpace(icon))
+                        dict.SetName("Name", icon);
+                    if (color is { } sc)
+                        dict["C"] = ColorArray(sc);
+                    created = PdfAnnotationAuthoring.AttachImported(document, pageNumber, dict);
+                }
                 break;
             }
 

--- a/Excise.Rendering.Tests/Differential/RemainingAnnotationSubtypesDifferentialTests.cs
+++ b/Excise.Rendering.Tests/Differential/RemainingAnnotationSubtypesDifferentialTests.cs
@@ -1,0 +1,461 @@
+using AwesomeAssertions;
+using Excise.Core.Document;
+using Excise.Rendering.Differential;
+using SkiaSharp;
+using Xunit;
+
+namespace Excise.Rendering.Tests.Differential;
+
+/// <summary>
+/// No-self-oracle corroboration for the #626 "remaining annotation subtypes"
+/// work (Underline/StrikeOut/Squiggly markup, Line/Arrow, Polygon/PolyLine,
+/// standard-name and image Stamp): excise generating an /AP /N appearance
+/// stream and excise rendering it proves only self-consistency. Here the
+/// authored files are handed to renderers that are not excise (mutool,
+/// pdftocairo) and both must draw each annotation the same way. Mirrors the
+/// pattern established in <see cref="AnnotationAuthoringDifferentialTests"/>
+/// for the earlier #626 subtypes (Square/Circle/FreeText/Ink).
+/// </summary>
+public class RemainingAnnotationSubtypesDifferentialTests : IDisposable
+{
+    private const int Dpi = 72; // 1 PDF point == 1 pixel on a 612x792 page
+    private const int PageH = 792;
+
+    private readonly List<string> _temp = new();
+
+    // ── Underline / StrikeOut / Squiggly (§12.5.6.10) ────────────────────────
+
+    [Fact]
+    public void AuthoredTextMarkup_IsDrawnByMutool_AtDistinctHeights()
+    {
+        Assert.SkipUnless(MutoolReferenceRenderer.IsAvailable, "mutool not installed");
+
+        var path = SaveMarkupPdf();
+        using var rendered = MutoolReferenceRenderer.RenderPage(path, 1, Dpi);
+        rendered.Should().NotBeNull("mutool must be able to open and render the authored file");
+
+        AssertMarkupPixels(rendered!, "mutool");
+    }
+
+    [Fact]
+    public void AuthoredTextMarkup_IsDrawnByPdftocairo_AtDistinctHeights()
+    {
+        Assert.SkipUnless(PdftocairoReferenceRenderer.IsAvailable, "pdftocairo not installed");
+
+        var path = SaveMarkupPdf();
+        using var rendered = PdftocairoReferenceRenderer.RenderPage(path, 1, Dpi);
+        rendered.Should().NotBeNull("pdftocairo must be able to open and render the authored file");
+
+        AssertMarkupPixels(rendered!, "pdftocairo");
+    }
+
+    [Fact]
+    public void ExciseAndReferenceRenderer_AgreeOnAuthoredTextMarkupInk()
+    {
+        Assert.SkipUnless(MutoolReferenceRenderer.IsAvailable, "mutool not installed");
+
+        var path = SaveMarkupPdf();
+        using var reference = MutoolReferenceRenderer.RenderPage(path, 1, Dpi);
+        reference.Should().NotBeNull();
+
+        using var reopened = PdfDocument.Open(path);
+        using var excise = new SkiaRenderer().RenderPage(
+            reopened.GetPage(1),
+            new RenderOptions { Dpi = Dpi, AntiAlias = false, BackgroundColor = SKColors.White });
+
+        var underlineBand = Box(105, 702, 395, 706);
+        InkFraction(excise, underlineBand).Should().BeGreaterThan(0.1,
+            "excise must stroke the authored underline");
+        InkFraction(reference!, underlineBand).Should().BeGreaterThan(0.1,
+            "mutool must stroke the authored underline from the /AP stream");
+
+        var emptyArea = Box(420, 500, 560, 600);
+        InkFraction(excise, emptyArea).Should().Be(0, "excise: no ink outside the markup annotations");
+        InkFraction(reference!, emptyArea).Should().Be(0, "mutool: no ink outside the markup annotations");
+    }
+
+    private void AssertMarkupPixels(SKBitmap bmp, string tool)
+    {
+        var underlineBand = Box(105, 702, 395, 706);
+        var strikeOutBand = Box(105, 642, 395, 646);
+        var squigglyBand = Box(105, 560.5, 395, 566);
+        var gapBand = Box(105, 660, 395, 695);
+        var emptyArea = Box(420, 500, 560, 600);
+
+        InkFraction(bmp, underlineBand).Should().BeGreaterThan(0.1,
+            $"{tool} must stroke the authored underline from the /AP stream");
+        RedFraction(bmp, underlineBand).Should().BeGreaterThan(0.1,
+            $"{tool} must use the authored red /C color for the underline");
+
+        InkFraction(bmp, strikeOutBand).Should().BeGreaterThan(0.1,
+            $"{tool} must stroke the authored strikeout from the /AP stream");
+
+        InkFraction(bmp, squigglyBand).Should().BeGreaterThan(0.05,
+            $"{tool} must stroke the authored squiggly zig-zag from the /AP stream");
+
+        InkFraction(bmp, gapBand).Should().Be(0,
+            $"{tool}: nothing between the underline and strikeout annotation rects");
+        InkFraction(bmp, emptyArea).Should().Be(0, $"{tool}: no ink outside the markup annotations");
+    }
+
+    /// <summary>
+    /// One blank page carrying an authored Underline, StrikeOut and Squiggly,
+    /// each in its own 300x30 band, all red. Saved, reopened from bytes, and
+    /// written to a temp file — the file the reference tools see is a genuine
+    /// save/reload product, not in-memory state.
+    /// </summary>
+    private string SaveMarkupPdf()
+    {
+        byte[] saved;
+        using (var doc = PdfDocument.CreateNew())
+        {
+            doc.Pages.AddBlank();
+            doc.AddUnderlineAnnotation(1, new PdfRectangle(100, 700, 400, 730), red: 1, green: 0, blue: 0);
+            doc.AddStrikeOutAnnotation(1, new PdfRectangle(100, 630, 400, 660), red: 1, green: 0, blue: 0);
+            doc.AddSquigglyAnnotation(1, new PdfRectangle(100, 560, 400, 590), red: 1, green: 0, blue: 0);
+            saved = doc.SaveToBytes();
+        }
+
+        var path = Path.Combine(Path.GetTempPath(), $"excise-annot-markup-{Guid.NewGuid():N}.pdf");
+        File.WriteAllBytes(path, saved);
+        _temp.Add(path);
+        return path;
+    }
+
+    // ── Line / Arrow (§12.5.6.7) ──────────────────────────────────────────────
+
+    [Fact]
+    public void AuthoredLineAndArrow_IsDrawnByMutool_WithArrowheadOnlyOnTheArrow()
+    {
+        Assert.SkipUnless(MutoolReferenceRenderer.IsAvailable, "mutool not installed");
+
+        var path = SaveLineArrowPdf();
+        using var rendered = MutoolReferenceRenderer.RenderPage(path, 1, Dpi);
+        rendered.Should().NotBeNull("mutool must be able to open and render the authored file");
+
+        AssertLineArrowPixels(rendered!, "mutool");
+    }
+
+    [Fact]
+    public void AuthoredLineAndArrow_IsDrawnByPdftocairo_WithArrowheadOnlyOnTheArrow()
+    {
+        Assert.SkipUnless(PdftocairoReferenceRenderer.IsAvailable, "pdftocairo not installed");
+
+        var path = SaveLineArrowPdf();
+        using var rendered = PdftocairoReferenceRenderer.RenderPage(path, 1, Dpi);
+        rendered.Should().NotBeNull("pdftocairo must be able to open and render the authored file");
+
+        AssertLineArrowPixels(rendered!, "pdftocairo");
+    }
+
+    [Fact]
+    public void ExciseAndReferenceRenderer_AgreeOnAuthoredLineAndArrowInk()
+    {
+        Assert.SkipUnless(MutoolReferenceRenderer.IsAvailable, "mutool not installed");
+
+        var path = SaveLineArrowPdf();
+        using var reference = MutoolReferenceRenderer.RenderPage(path, 1, Dpi);
+        reference.Should().NotBeNull();
+
+        using var reopened = PdfDocument.Open(path);
+        using var excise = new SkiaRenderer().RenderPage(
+            reopened.GetPage(1),
+            new RenderOptions { Dpi = Dpi, AntiAlias = false, BackgroundColor = SKColors.White });
+
+        var arrowHeadRegion = Box(285, 602, 299, 608);
+        InkFraction(excise, arrowHeadRegion).Should().BeGreaterThan(0.1,
+            "excise must draw the arrowhead wing above the shaft");
+        InkFraction(reference!, arrowHeadRegion).Should().BeGreaterThan(0.1,
+            "mutool must draw the arrowhead wing above the shaft from the /AP stream");
+
+        var emptyArea = Box(400, 300, 560, 500);
+        InkFraction(excise, emptyArea).Should().Be(0, "excise: no ink outside the line/arrow");
+        InkFraction(reference!, emptyArea).Should().Be(0, "mutool: no ink outside the line/arrow");
+    }
+
+    private void AssertLineArrowPixels(SKBitmap bmp, string tool)
+    {
+        var lineBand = Box(105, 698, 295, 702);
+        var arrowShaftBand = Box(105, 598, 295, 602);
+        var arrowHeadRegion = Box(285, 602, 299, 608);
+        var lineEndNoHeadRegion = Box(285, 704, 299, 710);
+        var emptyArea = Box(400, 300, 560, 500);
+
+        InkFraction(bmp, lineBand).Should().BeGreaterThan(0.2,
+            $"{tool} must stroke the plain Line");
+        InkFraction(bmp, arrowShaftBand).Should().BeGreaterThan(0.2,
+            $"{tool} must stroke the Arrow's shaft");
+        InkFraction(bmp, arrowHeadRegion).Should().BeGreaterThan(0.1,
+            $"{tool} must draw the Arrow's ClosedArrow head above its shaft");
+        InkFraction(bmp, lineEndNoHeadRegion).Should().Be(0,
+            $"{tool}: the plain Line has /LE [None None] — no arrowhead ink near its end");
+        InkFraction(bmp, emptyArea).Should().Be(0, $"{tool}: no ink outside the line/arrow annotations");
+    }
+
+    /// <summary>
+    /// One blank page carrying a plain Line (100,700)-(300,700) and an Arrow
+    /// (100,600)-(300,600) with a ClosedArrow head at its end, both red, 3pt.
+    /// Saved, reopened from bytes, and written to a temp file.
+    /// </summary>
+    private string SaveLineArrowPdf()
+    {
+        byte[] saved;
+        using (var doc = PdfDocument.CreateNew())
+        {
+            doc.Pages.AddBlank();
+            doc.AddLineAnnotation(1, 100, 700, 300, 700, red: 1, green: 0, blue: 0, lineWidth: 3);
+            doc.AddArrowAnnotation(1, 100, 600, 300, 600, red: 1, green: 0, blue: 0, lineWidth: 3,
+                endLineEnding: "ClosedArrow");
+            saved = doc.SaveToBytes();
+        }
+
+        var path = Path.Combine(Path.GetTempPath(), $"excise-annot-line-arrow-{Guid.NewGuid():N}.pdf");
+        File.WriteAllBytes(path, saved);
+        _temp.Add(path);
+        return path;
+    }
+
+    // ── Polygon / PolyLine (§12.5.6.9) ────────────────────────────────────────
+
+    [Fact]
+    public void AuthoredPolygonAndPolyLine_IsDrawnByMutool_WithPolygonFilledAndPolyLineOpen()
+    {
+        Assert.SkipUnless(MutoolReferenceRenderer.IsAvailable, "mutool not installed");
+
+        var path = SavePolyPdf();
+        using var rendered = MutoolReferenceRenderer.RenderPage(path, 1, Dpi);
+        rendered.Should().NotBeNull("mutool must be able to open and render the authored file");
+
+        AssertPolyPixels(rendered!, "mutool");
+    }
+
+    [Fact]
+    public void AuthoredPolygonAndPolyLine_IsDrawnByPdftocairo_WithPolygonFilledAndPolyLineOpen()
+    {
+        Assert.SkipUnless(PdftocairoReferenceRenderer.IsAvailable, "pdftocairo not installed");
+
+        var path = SavePolyPdf();
+        using var rendered = PdftocairoReferenceRenderer.RenderPage(path, 1, Dpi);
+        rendered.Should().NotBeNull("pdftocairo must be able to open and render the authored file");
+
+        AssertPolyPixels(rendered!, "pdftocairo");
+    }
+
+    [Fact]
+    public void ExciseAndReferenceRenderer_AgreeOnAuthoredPolygonFill()
+    {
+        Assert.SkipUnless(MutoolReferenceRenderer.IsAvailable, "mutool not installed");
+
+        var path = SavePolyPdf();
+        using var reference = MutoolReferenceRenderer.RenderPage(path, 1, Dpi);
+        reference.Should().NotBeNull();
+
+        using var reopened = PdfDocument.Open(path);
+        using var excise = new SkiaRenderer().RenderPage(
+            reopened.GetPage(1),
+            new RenderOptions { Dpi = Dpi, AntiAlias = false, BackgroundColor = SKColors.White });
+
+        var polygonInterior = Box(180, 140, 220, 160);
+        var exciseFill = GreenFraction(excise, polygonInterior);
+        var referenceFill = GreenFraction(reference!, polygonInterior);
+        exciseFill.Should().BeGreaterThan(0.9, "excise must fill the authored polygon interior");
+        referenceFill.Should().BeGreaterThan(0.9, "mutool must fill the authored polygon interior");
+
+        var emptyArea = Box(460, 90, 490, 190);
+        InkFraction(excise, emptyArea).Should().Be(0, "excise: no ink outside the polygon/polyline");
+        InkFraction(reference!, emptyArea).Should().Be(0, "mutool: no ink outside the polygon/polyline");
+    }
+
+    private void AssertPolyPixels(SKBitmap bmp, string tool)
+    {
+        var polygonInterior = Box(180, 140, 220, 160);
+        var polygonOutside = Box(60, 60, 90, 90);
+        var polylineVertex = Box(395, 175, 405, 185);
+        var polylineClosingGap = Box(395, 99, 405, 101);
+        var emptyArea = Box(460, 90, 490, 190);
+
+        GreenFraction(bmp, polygonInterior).Should().BeGreaterThan(0.9,
+            $"{tool} must fill the authored Polygon's interior with its /IC color");
+        InkFraction(bmp, polygonOutside).Should().Be(0,
+            $"{tool}: the polygon fill must not spill outside its border");
+
+        InkFraction(bmp, polylineVertex).Should().BeGreaterThan(0.1,
+            $"{tool} must stroke the PolyLine through its middle vertex");
+        InkFraction(bmp, polylineClosingGap).Should().Be(0,
+            $"{tool}: a PolyLine must stay open — no stroke closing its first and last vertices");
+
+        InkFraction(bmp, emptyArea).Should().Be(0, $"{tool}: no ink outside the polygon/polyline annotations");
+    }
+
+    /// <summary>
+    /// One blank page carrying a filled-green Polygon triangle
+    /// (100,100)-(300,100)-(200,250) and an open red PolyLine zig-zag
+    /// (350,100)-(400,180)-(450,100). Saved, reopened from bytes, and
+    /// written to a temp file.
+    /// </summary>
+    private string SavePolyPdf()
+    {
+        byte[] saved;
+        using (var doc = PdfDocument.CreateNew())
+        {
+            doc.Pages.AddBlank();
+            doc.AddPolygonAnnotation(
+                1, new (double X, double Y)[] { (100, 100), (300, 100), (200, 250) },
+                red: 0, green: 0, blue: 0, borderWidth: 2,
+                interiorRed: 0, interiorGreen: 1, interiorBlue: 0);
+            doc.AddPolyLineAnnotation(
+                1, new (double X, double Y)[] { (350, 100), (400, 180), (450, 100) },
+                red: 1, green: 0, blue: 0, borderWidth: 2);
+            saved = doc.SaveToBytes();
+        }
+
+        var path = Path.Combine(Path.GetTempPath(), $"excise-annot-poly-{Guid.NewGuid():N}.pdf");
+        File.WriteAllBytes(path, saved);
+        _temp.Add(path);
+        return path;
+    }
+
+    // ── Stamp (§12.5.6.12) ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void AuthoredStamps_AreDrawnByMutool_StandardNameAndImage()
+    {
+        Assert.SkipUnless(MutoolReferenceRenderer.IsAvailable, "mutool not installed");
+
+        var path = SaveStampsPdf();
+        using var rendered = MutoolReferenceRenderer.RenderPage(path, 1, Dpi);
+        rendered.Should().NotBeNull("mutool must be able to open and render the authored file");
+
+        AssertStampPixels(rendered!, "mutool");
+    }
+
+    [Fact]
+    public void AuthoredStamps_AreDrawnByPdftocairo_StandardNameAndImage()
+    {
+        Assert.SkipUnless(PdftocairoReferenceRenderer.IsAvailable, "pdftocairo not installed");
+
+        var path = SaveStampsPdf();
+        using var rendered = PdftocairoReferenceRenderer.RenderPage(path, 1, Dpi);
+        rendered.Should().NotBeNull("pdftocairo must be able to open and render the authored file");
+
+        AssertStampPixels(rendered!, "pdftocairo");
+    }
+
+    [Fact]
+    public void ExciseAndReferenceRenderer_AgreeOnAuthoredStampInk()
+    {
+        Assert.SkipUnless(MutoolReferenceRenderer.IsAvailable, "mutool not installed");
+
+        var path = SaveStampsPdf();
+        using var reference = MutoolReferenceRenderer.RenderPage(path, 1, Dpi);
+        reference.Should().NotBeNull();
+
+        using var reopened = PdfDocument.Open(path);
+        using var excise = new SkiaRenderer().RenderPage(
+            reopened.GetPage(1),
+            new RenderOptions { Dpi = Dpi, AntiAlias = false, BackgroundColor = SKColors.White });
+
+        // The image stamp is a full-bleed solid-blue 4x4 image stretched over
+        // its /Rect — both renderers must show near-pure blue there.
+        var imageStampInterior = Box(354, 704, 446, 746);
+        BlueFraction(excise, imageStampInterior).Should().BeGreaterThan(0.9,
+            "excise must draw the embedded image XObject full-bleed");
+        BlueFraction(reference!, imageStampInterior).Should().BeGreaterThan(0.9,
+            "mutool must draw the embedded image XObject from the /AP stream");
+
+        var emptyArea = Box(460, 700, 560, 760);
+        InkFraction(excise, emptyArea).Should().Be(0, "excise: no ink outside the stamps");
+        InkFraction(reference!, emptyArea).Should().Be(0, "mutool: no ink outside the stamps");
+    }
+
+    private void AssertStampPixels(SKBitmap bmp, string tool)
+    {
+        var standardBorder = Box(100, 701, 104, 749);
+        var standardText = Box(110, 712, 290, 726);
+        var imageStampInterior = Box(354, 704, 446, 746);
+        var gapBetweenStamps = Box(302, 700, 348, 750);
+        var emptyArea = Box(460, 700, 560, 760);
+
+        InkFraction(bmp, standardBorder).Should().BeGreaterThan(0.3,
+            $"{tool} must stroke the standard-name Stamp's border");
+        InkFraction(bmp, standardText).Should().BeGreaterThan(0.02,
+            $"{tool} must draw the standard-name Stamp's label text");
+
+        BlueFraction(bmp, imageStampInterior).Should().BeGreaterThan(0.9,
+            $"{tool} must draw the embedded image XObject full-bleed from the /AP stream");
+
+        InkFraction(bmp, gapBetweenStamps).Should().Be(0,
+            $"{tool}: no ink in the gap between the two stamps");
+        InkFraction(bmp, emptyArea).Should().Be(0, $"{tool}: no ink outside the stamp annotations");
+    }
+
+    /// <summary>
+    /// One blank page carrying a standard-name Stamp ("Approved",
+    /// 200x50 @ (100,700)) and a custom image Stamp (a solid-blue 4x4 RGB24
+    /// image, 100x50 @ (350,700)). Saved, reopened from bytes, and written to
+    /// a temp file.
+    /// </summary>
+    private string SaveStampsPdf()
+    {
+        byte[] saved;
+        using (var doc = PdfDocument.CreateNew())
+        {
+            doc.Pages.AddBlank();
+            doc.AddStampAnnotation(1, new PdfRectangle(100, 700, 300, 750), "Approved");
+
+            var pixels = new byte[4 * 4 * 3];
+            for (int i = 0; i < pixels.Length; i += 3)
+            {
+                pixels[i] = 0; pixels[i + 1] = 0; pixels[i + 2] = 255;
+            }
+            doc.AddImageStampAnnotation(1, new PdfRectangle(350, 700, 450, 750), pixels, 4, 4);
+
+            saved = doc.SaveToBytes();
+        }
+
+        var path = Path.Combine(Path.GetTempPath(), $"excise-annot-stamp-{Guid.NewGuid():N}.pdf");
+        File.WriteAllBytes(path, saved);
+        _temp.Add(path);
+        return path;
+    }
+
+    // ── Shared pixel helpers (mirrors AnnotationAuthoringDifferentialTests) ──
+
+    /// <summary>Pixel box from PDF coordinates (Y-up) at 72 dpi.</summary>
+    private static SKRectI Box(double left, double bottom, double right, double top) =>
+        new((int)left, PageH - (int)top, (int)right, PageH - (int)bottom);
+
+    private static double Fraction(SKBitmap bmp, SKRectI box, Func<SKColor, bool> predicate)
+    {
+        int hit = 0, total = 0;
+        int x0 = Math.Max(0, box.Left), x1 = Math.Min(bmp.Width - 1, box.Right);
+        int y0 = Math.Max(0, box.Top), y1 = Math.Min(bmp.Height - 1, box.Bottom);
+        for (int y = y0; y <= y1; y++)
+        for (int x = x0; x <= x1; x++)
+        {
+            total++;
+            if (predicate(bmp.GetPixel(x, y))) hit++;
+        }
+        return total == 0 ? 0 : (double)hit / total;
+    }
+
+    private static double InkFraction(SKBitmap bmp, SKRectI box) =>
+        Fraction(bmp, box, p => p.Red < 200 || p.Green < 200 || p.Blue < 200);
+
+    private static double RedFraction(SKBitmap bmp, SKRectI box) =>
+        Fraction(bmp, box, p => p.Red > 180 && p.Green < 100 && p.Blue < 100);
+
+    private static double GreenFraction(SKBitmap bmp, SKRectI box) =>
+        Fraction(bmp, box, p => p.Green > 180 && p.Red < 100 && p.Blue < 100);
+
+    private static double BlueFraction(SKBitmap bmp, SKRectI box) =>
+        Fraction(bmp, box, p => p.Blue > 180 && p.Red < 100 && p.Green < 100);
+
+    public void Dispose()
+    {
+        foreach (var p in _temp)
+        {
+            try { File.Delete(p); } catch { /* best effort */ }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Completes the remaining scope of #626 on top of what's already on `develop` (Square/Circle/FreeText/Ink/Highlight/Text authoring, XFDF/FDF import/export):

- **Text markup**: `AddUnderlineAnnotation`, `AddStrikeOutAnnotation`, `AddSquigglyAnnotation` — mirror `AddHighlightAnnotation`'s single-quad shape, each with a baked `/AP /N` stroked-line/zig-zag appearance (unlike Highlight, most viewers don't synthesize an appearance for these).
- **Shapes**: `AddLineAnnotation` / `AddArrowAnnotation` (`/L`, `/LE` line-endings with a matching baked triangular arrowhead — `None`/`OpenArrow`/`ClosedArrow`), `AddPolygonAnnotation` (closed, optional `/IC` fill), `AddPolyLineAnnotation` (open, stroke-only).
- **Stamp**: `AddStampAnnotation` (15 standard ISO 32000-2 §12.5.6.12 rubber-stamp names, `PdfAnnotationAuthoring.StandardStampNames`) and `AddImageStampAnnotation` (embeds a caller-supplied raw RGB24 image as an uncompressed DeviceRGB Image XObject — no JPEG/PNG codec dependency).
- **Edit + delete**: `SetAnnotationContents` / `SetAnnotationColor` / `SetAnnotationOpacity` mutate `/Contents`, `/C`, `/CA` on an existing annotation in place; `RemoveAnnotation` detaches from a page's `/Annots`.
- **Reply threads**: `SetReplyTo` sets `/IRT` (via the document's internal `GetReferenceTo`) and `/RT` (`R`/`Group`).
- `XfdfSerializer` / `FdfSerializer`: added the missing `stamp`/`Stamp` import case (previously exported but not re-importable — the only real Stamp round-trip gap), and fixed a pre-existing bug where generic Polygon imports silently dropped `/IC` interior fill.

## No-self-oracle verification
Per `CLAUDE.md`'s redaction/authoring rule, excise doesn't get to be its own oracle:
- `Excise.Rendering.Tests/Differential/RemainingAnnotationSubtypesDifferentialTests.cs` — mutool and pdftocairo (both installed locally) render every new appearance stream from the *saved file*, asserting ink lands in the right region/color (arrowhead only on the Arrow, not the plain Line; Polygon fill vs. open PolyLine; standard-stamp border+text; image-stamp full-bleed blue). A third test per subtype confirms excise's own `SkiaRenderer` agrees with mutool's ink regions.
- `Excise.Core.Tests/Document/PdfAnnotationAuthoringTests.cs` — dictionary/appearance-stream structural tests per subtype (24 new tests).
- `Excise.Core.Tests/Forms/{Xfdf,Fdf}SerializerTests.cs` — round-trip tests (position, color, `/T` author, `/Contents`, `/CA` opacity) for every new subtype through both formats, plus the Stamp-specific and non-standard-icon-fallback cases.

## Test plan
- [x] `dotnet build Excise.sln -c Release` — 0 warnings, 0 errors
- [x] `Excise.Core.Tests` — 3718 passed, 0 failed (16 pre-existing skips, missing corpus)
- [x] `Excise.Rendering.Tests` — 3372 passed, 0 failed (17 pre-existing skips, missing corpus)
- [x] `scripts/test-tier.sh t0` — all green
- [x] `scripts/verify-doc-claims.sh` — passed
- [x] Public API baseline regenerated (`APPROVE_PUBLIC_API=1`) — 19 new lines in `Excise.Core.Tests/PublicApi/Excise.Core.approved.txt`
- [x] `CHANGELOG.md` — one `[Unreleased] / ### Added` entry (#626)

## Blockers
None. Not merged — leaving for review per instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)