### PR TITLE
feat(signing): visible signature appearance (#623, last bullet)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,19 @@ semantic versioning.
   pdftocairo/Ghostscript differentials pinning the out-of-range fallback.
 
 ### Added
+- **Visible signature appearance** (#623, last remaining bullet) — a signed
+  signature field whose widget `/Rect` has non-zero area now gets a baked
+  `/AP /N` appearance stream (`SignatureAppearanceAuthoring` in
+  `Excise.Core`, mirroring the annotation-authoring baked-appearance pattern
+  from #626): a bordered box with "Digitally signed by {name}", the signing
+  date, and any `/Reason`/`/Location` the caller supplied. `SignFile`/
+  `SignDocument` wire this in automatically after the field is signed, and it
+  touches only the widget's appearance — the CMS/ByteRange machinery is
+  unchanged. A zero-size (or absent) `/Rect` — the default for a
+  freshly-authored field — stays untouched: invisible signatures remain
+  fully valid, as before. Verified with an independent renderer (mutool) so
+  excise is not its own oracle for whether a third-party viewer actually
+  draws the appearance.
 - **Tagged-PDF structure accessibility layer** (#631) — the Avalonia viewer's
   automation peer tree now exposes the tagged-PDF structure tree to screen
   readers: the page's accessible text is ordered by the structure tree when a

--- a/Excise.App.Tests/Unit/SignatureApplicationServiceTests.cs
+++ b/Excise.App.Tests/Unit/SignatureApplicationServiceTests.cs
@@ -3,6 +3,8 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Excise.App.Services;
 using Excise.App.Tests.Utilities;
 using Excise.Core.Document;
+using Excise.Rendering.Differential;
+using SkiaSharp;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -190,6 +192,116 @@ public class SignatureApplicationServiceTests : IDisposable
         results[0].SignatureName.Should().Be("ApproverSignature");
         results[0].IsValid.Should().BeTrue();
         results[0].CoversWholeDocument.Should().BeTrue();
+    }
+
+    // ── visible signature appearance (#623, last bullet) ────────────────────
+    //
+    // No-self-oracle: excise reading its own /AP stream and declaring it
+    // present proves nothing about whether a real viewer draws it. These
+    // assertions render the signed page with mutool — an implementation we
+    // do not own — and measure ink in the widget rectangle.
+
+    [Fact]
+    public void SignDocument_VisibleRect_IndependentRendererShowsInkInSignatureRect_AndStillVerifies()
+    {
+        Assert.SkipUnless(MutoolReferenceRenderer.IsAvailable, "mutool not installed");
+
+        // CreateSimpleTextPdf's own text sits near the top of the page
+        // (pdfY ~= 692), so the widget goes in an otherwise-empty region
+        // near the bottom — any ink measured there can only be the baked
+        // appearance, not the base document's own content.
+        var rect = new PdfRectangle(72, 100, 300, 160);
+        var basePath = CreateBasePdf();
+
+        // Baseline: confirm the region is genuinely blank *before* signing,
+        // so a positive result after signing can't be attributed to
+        // pre-existing content in that rectangle.
+        using (var unsigned = MutoolReferenceRenderer.RenderPage(basePath, 1, dpi: 150))
+        {
+            unsigned.Should().NotBeNull();
+            InkFractionIn(unsigned!, rect, pageHeight: 792, dpi: 150).Should().BeLessThan(0.001,
+                "fixture sanity — the measurement rectangle must be blank before signing, or a " +
+                "positive ink reading after signing would prove nothing about the appearance");
+        }
+
+        using var certificate = SigningCertificateFactory.CreateSelfSigned("Visible Signer");
+
+        // Author the field and sign it on the SAME open document instance —
+        // signing reopens nothing, so the field must exist on the instance
+        // SignDocument receives (mirrors SignDocument_ExistingEmptySignatureField_SignsThatField).
+        using var document = PdfDocument.Open(basePath);
+        document.AddSignatureField(pageNumber: 1, rect: rect, fieldName: "VisibleSignature");
+
+        var signedBytes = _signer.SignDocument(document, certificate, new SignatureApplicationOptions
+        {
+            FieldName = "VisibleSignature",
+            Reason = "Approval",
+            Location = "Remote"
+        });
+        var signedPath = WriteTempFile(signedBytes);
+
+        // The appearance must not corrupt the CMS/ByteRange it sits beside.
+        var results = CreateVerifier().VerifySignatures(signedPath);
+        results.Should().HaveCount(1);
+        results[0].IsValid.Should().BeTrue(
+            "baking a visible appearance stream must not disturb the signed ByteRange or CMS");
+        results[0].CoversWholeDocument.Should().BeTrue();
+
+        using var rendered = MutoolReferenceRenderer.RenderPage(signedPath, 1, dpi: 150);
+        rendered.Should().NotBeNull("mutool must be able to render the signed page at all");
+
+        var ink = InkFractionIn(rendered!, rect, pageHeight: 792, dpi: 150);
+        ink.Should().BeGreaterThan(0.005,
+            "an independent renderer must draw *something* inside the signature widget's /Rect — " +
+            "the whole point of a baked /AP /N is that a third-party viewer honors it without " +
+            "excise's own rendering code in the loop. The region was confirmed blank before signing.");
+    }
+
+    [Fact]
+    public void SignDocument_DefaultZeroRectField_StaysAppearanceLess()
+    {
+        // FindOrCreateSignatureField authors a fresh field at Rect(0,0,0,0)
+        // when none exists (the invisible-signature default). That must
+        // remain untouched — invisible signatures are still fully valid
+        // per #623's acceptance criteria — not retrofitted with an /AP.
+        using var certificate = SigningCertificateFactory.CreateSelfSigned("Invisible Signer");
+        var signedPath = SignSamplePdf(certificate);
+
+        using var reopened = PdfDocument.Open(signedPath);
+        var field = reopened.GetAcroForm()?.FindField("Signature1");
+        field.Should().NotBeNull();
+        field!.RawDictionary.GetOptional("AP").Should().BeNull(
+            "a zero-size /Rect signature field must stay appearance-less, not gain a baked /AP");
+    }
+
+    /// <summary>
+    /// Fraction of non-white pixels inside <paramref name="box"/> (PDF content
+    /// coordinates, bottom-left origin) of a page rendered at <paramref name="dpi"/>.
+    /// Mirrors RedactionReferenceVerificationTests's InkFractionIn — the same
+    /// "is there ink here" measurement, applied to a signature widget instead
+    /// of a redaction target.
+    /// </summary>
+    private static double InkFractionIn(SKBitmap bmp, PdfRectangle box, double pageHeight, int dpi)
+    {
+        double scale = dpi / 72.0;
+
+        int x0 = Math.Max(0, (int)(box.Left * scale));
+        int x1 = Math.Min(bmp.Width - 1, (int)(box.Right * scale));
+        int y0 = Math.Max(0, (int)((pageHeight - box.Top) * scale));
+        int y1 = Math.Min(bmp.Height - 1, (int)((pageHeight - box.Bottom) * scale));
+
+        if (x1 <= x0 || y1 <= y0) return 0;
+
+        int ink = 0, total = 0;
+        for (int y = y0; y <= y1; y++)
+        for (int x = x0; x <= x1; x++)
+        {
+            var p = bmp.GetPixel(x, y);
+            total++;
+            if (p.Red < 200 || p.Green < 200 || p.Blue < 200) ink++;
+        }
+
+        return total == 0 ? 0 : (double)ink / total;
     }
 
     [Fact]

--- a/Excise.App/Services/SignatureApplicationService.cs
+++ b/Excise.App/Services/SignatureApplicationService.cs
@@ -102,8 +102,10 @@ public sealed class SignatureApplicationOptions
 /// <para>Signing rewrites the whole file (excise saves are full rewrites, not
 /// incremental updates), so it must be the last operation: any existing signed
 /// signature would be invalidated, and the service refuses to sign a document
-/// that already carries one. Timestamping (RFC3161), LTV and visible signature
-/// appearances are out of scope per #623.</para>
+/// that already carries one. Timestamping (RFC3161) and LTV remain out of
+/// scope per #623; a visible appearance (<c>/AP /N</c>) is baked onto the
+/// widget when its <c>/Rect</c> has non-zero area — see
+/// <see cref="SignatureAppearanceAuthoring"/>.</para>
 /// </summary>
 public class SignatureApplicationService
 {
@@ -166,9 +168,22 @@ public class SignatureApplicationService
 
         GuardNoExistingSignedSignature(document);
 
+        var signingTime = options.SigningTime ?? DateTimeOffset.UtcNow;
+        var signerName = ResolveSignerName(options, certificate);
+
         var fieldDictionary = FindOrCreateSignatureField(document, options.FieldName);
-        fieldDictionary["V"] = BuildSignatureDictionary(options, certificate);
+        fieldDictionary["V"] = BuildSignatureDictionary(options, signerName, signingTime);
         SetSigFlags(document);
+
+        // Visible signature appearance (#623, last bullet): a baked /AP /N
+        // is only added when the widget's /Rect has non-zero area. A
+        // zero-size /Rect (the default for a freshly-created field, see
+        // FindOrCreateSignatureField) stays invisible — still a fully valid
+        // signature. See SignatureAppearanceAuthoring for the appearance
+        // stream itself; it mirrors PdfAnnotationAuthoring's baked-appearance
+        // pattern (#626) and does not touch the CMS/ByteRange machinery below.
+        SignatureAppearanceAuthoring.ApplyVisibleAppearance(
+            document, fieldDictionary, BuildAppearanceLines(options, signerName, signingTime));
 
         _logger.LogInformation(
             "Signing document as {Subject} into field {Field}",
@@ -274,7 +289,8 @@ public class SignatureApplicationService
 
     private static PdfDictionary BuildSignatureDictionary(
         SignatureApplicationOptions options,
-        X509Certificate2 certificate)
+        string? signerName,
+        DateTimeOffset signingTime)
     {
         var signature = new PdfDictionary();
         signature.SetName("Type", "Sig");
@@ -291,7 +307,6 @@ public class SignatureApplicationService
         signature["ByteRange"] = byteRange;
         signature["Contents"] = new PdfString(new byte[options.SignatureCapacityBytes], isHex: true);
 
-        var signerName = options.SignerName ?? certificate.GetNameInfo(X509NameType.SimpleName, forIssuer: false);
         if (!string.IsNullOrEmpty(signerName))
         {
             signature.SetString("Name", signerName);
@@ -312,8 +327,44 @@ public class SignatureApplicationService
             signature.SetString("ContactInfo", options.ContactInfo);
         }
 
-        signature.SetString("M", FormatPdfDate(options.SigningTime ?? DateTimeOffset.UtcNow));
+        signature.SetString("M", FormatPdfDate(signingTime));
         return signature;
+    }
+
+    /// <summary>
+    /// Resolve the human-readable signer name used both in the signature
+    /// dictionary's <c>/Name</c> and in the visible appearance text.
+    /// </summary>
+    private static string? ResolveSignerName(SignatureApplicationOptions options, X509Certificate2 certificate) =>
+        options.SignerName ?? certificate.GetNameInfo(X509NameType.SimpleName, forIssuer: false);
+
+    /// <summary>
+    /// Build the text lines drawn into the visible signature appearance
+    /// (see <see cref="SignatureAppearanceAuthoring"/>): signer identity,
+    /// date, and any optional reason/location the caller supplied.
+    /// </summary>
+    private static IReadOnlyList<string> BuildAppearanceLines(
+        SignatureApplicationOptions options, string? signerName, DateTimeOffset signingTime)
+    {
+        var lines = new List<string>
+        {
+            string.IsNullOrEmpty(signerName)
+                ? "Digitally signed"
+                : $"Digitally signed by {signerName}",
+            $"Date: {signingTime:yyyy-MM-dd HH:mm:ss zzz}"
+        };
+
+        if (!string.IsNullOrEmpty(options.Reason))
+        {
+            lines.Add($"Reason: {options.Reason}");
+        }
+
+        if (!string.IsNullOrEmpty(options.Location))
+        {
+            lines.Add($"Location: {options.Location}");
+        }
+
+        return lines;
     }
 
     private static void SetSigFlags(PdfDocument document)

--- a/Excise.Core.Tests/PublicApi/Excise.Core.approved.txt
+++ b/Excise.Core.Tests/PublicApi/Excise.Core.approved.txt
@@ -854,6 +854,10 @@ namespace Excise.Core.Document
         public string Type { get; }
         public override string ToString() { }
     }
+    public static class SignatureAppearanceAuthoring
+    {
+        public static void ApplyVisibleAppearance(Excise.Core.Document.PdfDocument document, Excise.Core.Primitives.PdfDictionary widget, System.Collections.Generic.IReadOnlyList<string> lines) { }
+    }
     public sealed class SuggestedField : System.IEquatable<Excise.Core.Document.SuggestedField>
     {
         public SuggestedField(Excise.Core.Document.PdfFieldType FieldType, Excise.Core.Document.PdfRectangle Rect, int PageNumber, string SuggestedName, string Reason) { }

--- a/Excise.Core/Document/SignatureAppearanceAuthoring.cs
+++ b/Excise.Core/Document/SignatureAppearanceAuthoring.cs
@@ -1,0 +1,181 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+using Excise.Core.Graphics;
+using Excise.Core.Primitives;
+
+namespace Excise.Core.Document;
+
+/// <summary>
+/// Bakes a visible normal appearance (<c>/AP /N</c>) onto a signature
+/// widget so an applied digital signature actually shows on the page
+/// (ISO 32000-2:2020 §12.7.4.5, Table 252). This is the last bullet of
+/// issue #623 — the crypto (CMS/ByteRange) is unaffected; this only adds
+/// a Form XObject the widget already had room for via its <c>/Rect</c>.
+///
+/// <para>Mirrors the baked-appearance pattern already used for markup
+/// annotations in <see cref="PdfAnnotationAuthoring"/> (#626,
+/// <c>BuildFreeTextAppearanceStream</c>): a self-contained Form XObject —
+/// own <c>/Resources /Font</c>, stroked border, text drawn with
+/// BT/Tf/Td/Tj — clipped to its <c>/BBox</c> by the viewer per spec
+/// §8.10.2. No new appearance-stream mechanism is introduced.</para>
+/// </summary>
+public static class SignatureAppearanceAuthoring
+{
+    private const double BorderWidth = 1.0;
+    private const double MinFontSize = 5;
+    private const double MaxFontSize = 9;
+
+    /// <summary>
+    /// Bake a visible normal appearance onto <paramref name="widget"/> — the
+    /// signature field/widget merged dictionary — if its <c>/Rect</c> has a
+    /// non-zero area. A zero-size (or missing) <c>/Rect</c> is the
+    /// deliberate invisible-signature case (still a fully valid signature,
+    /// per #623's acceptance criteria) and is left untouched: no
+    /// <c>/AP</c> is added, matching prior behavior for invisible fields.
+    /// </summary>
+    /// <param name="document">Document the widget belongs to (for interning
+    /// the appearance stream and its font as indirect objects).</param>
+    /// <param name="widget">The signature field/widget dictionary, already
+    /// carrying its final <c>/Rect</c>.</param>
+    /// <param name="lines">Text lines to draw, in order (e.g. "Digitally
+    /// signed by X", "Date: ...", "Reason: ..."). Lines that don't fit the
+    /// box are not drawn (clipped by <c>/BBox</c>); a single line wider
+    /// than the box is truncated with an ellipsis.</param>
+    public static void ApplyVisibleAppearance(
+        PdfDocument document,
+        PdfDictionary widget,
+        IReadOnlyList<string> lines)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+        ArgumentNullException.ThrowIfNull(widget);
+        ArgumentNullException.ThrowIfNull(lines);
+
+        if (lines.Count == 0)
+            return;
+
+        var rectObj = document.Resolve(widget.GetOptional("Rect") ?? PdfNull.Instance);
+        if (rectObj is not PdfArray rectArr)
+            return;
+
+        var rect = PdfRectangle.FromArray(rectArr).Normalize();
+        if (rect.Width <= 0 || rect.Height <= 0)
+            return; // deliberate invisible signature — leave AP-less.
+
+        var apStream = BuildAppearanceStream(document, rect, lines);
+        var ap = new PdfDictionary();
+        ap["N"] = document.AddIndirectObject(apStream);
+        widget["AP"] = ap;
+    }
+
+    private static PdfStream BuildAppearanceStream(
+        PdfDocument document,
+        PdfRectangle rect,
+        IReadOnlyList<string> lines)
+    {
+        double w = rect.Width;
+        double h = rect.Height;
+
+        var sb = new StringBuilder();
+
+        double inset = Math.Min(BorderWidth / 2, Math.Min(w, h) / 2 * 0.999);
+        sb.Append("0 0 0 RG\n");
+        sb.Append($"{Num(BorderWidth)} w\n");
+        sb.Append($"{Num(inset)} {Num(inset)} {Num(w - 2 * inset)} {Num(h - 2 * inset)} re S\n");
+
+        double pad = BorderWidth + 2;
+        double availableWidth = Math.Max(1, w - 2 * pad);
+
+        double fontSize = Math.Clamp(h / (lines.Count * 1.4), MinFontSize, MaxFontSize);
+        var font = PdfFont.Helvetica(fontSize);
+        double leading = fontSize * 1.2;
+
+        sb.Append("BT\n");
+        sb.Append($"/Helv {Num(fontSize)} Tf\n");
+        sb.Append("0 0 0 rg\n");
+
+        double prevX = 0, prevY = 0;
+        double baseline = h - pad - fontSize * 0.8;
+        foreach (var rawLine in lines)
+        {
+            if (baseline < -fontSize)
+                break; // fully below the BBox — clipped anyway, stop emitting
+
+            var line = TruncateToWidth(rawLine, font, availableWidth);
+            sb.Append($"{Num(pad - prevX)} {Num(baseline - prevY)} Td\n");
+            sb.Append('(').Append(EscapePdfTextString(line)).Append(") Tj\n");
+            prevX = pad;
+            prevY = baseline;
+            baseline -= leading;
+        }
+
+        sb.Append("ET\n");
+
+        var stream = new PdfStream(Encoding.ASCII.GetBytes(sb.ToString()));
+        stream.SetName("Type", "XObject");
+        stream.SetName("Subtype", "Form");
+        stream.SetInt("FormType", 1);
+        stream["BBox"] = PdfArray.FromRectangle(0, 0, w, h);
+
+        // Self-contained resources, matching PdfAnnotationAuthoring's
+        // baked-appearance streams: the /Helv the Tf refers to.
+        var helv = new PdfDictionary();
+        helv.SetName("Type", "Font");
+        helv.SetName("Subtype", "Type1");
+        helv.SetName("BaseFont", "Helvetica");
+        helv.SetName("Encoding", "WinAnsiEncoding");
+
+        var fonts = new PdfDictionary();
+        fonts["Helv"] = document.AddIndirectObject(helv);
+        var resources = new PdfDictionary();
+        resources["Font"] = fonts;
+        stream["Resources"] = resources;
+
+        return stream;
+    }
+
+    /// <summary>Truncate to fit, appending an ellipsis, using real advance widths.</summary>
+    private static string TruncateToWidth(string text, PdfFont font, double maxWidth)
+    {
+        if (font.MeasureWidth(text) <= maxWidth)
+            return text;
+
+        const string ellipsis = "...";
+        var kept = new StringBuilder();
+        foreach (var ch in text)
+        {
+            if (font.MeasureWidth(kept.ToString() + ch + ellipsis) > maxWidth)
+                break;
+            kept.Append(ch);
+        }
+
+        return kept.Length > 0 ? kept.Append(ellipsis).ToString() : text;
+    }
+
+    /// <summary>
+    /// Escape a line for a PDF literal string. Printable-ASCII MVP: anything
+    /// outside 0x20-0x7E draws as '?' (mirrors
+    /// <c>PdfAnnotationAuthoring.EscapePdfTextString</c>).
+    /// </summary>
+    private static string EscapePdfTextString(string value)
+    {
+        var sb = new StringBuilder(value.Length + 8);
+        foreach (var ch in value)
+        {
+            switch (ch)
+            {
+                case '\\': sb.Append("\\\\"); break;
+                case '(': sb.Append("\\("); break;
+                case ')': sb.Append("\\)"); break;
+                default:
+                    sb.Append(ch is < ' ' or > '~' ? '?' : ch);
+                    break;
+            }
+        }
+        return sb.ToString();
+    }
+
+    private static string Num(double value) =>
+        value.ToString("0.####", CultureInfo.InvariantCulture);
+}


### PR DESCRIPTION
## Summary
- Implements the last remaining bullet of #623: a **visible signature appearance**.
- New `Excise.Core/Document/SignatureAppearanceAuthoring.cs` bakes a `/AP /N` Form XObject onto a signature widget when its `/Rect` has non-zero area — mirrors the baked-appearance pattern already used for markup annotations in `PdfAnnotationAuthoring` (#626): self-contained `/Resources /Font`, bordered box, text drawn with `BT/Tf/Td/Tj`, clipped to `/BBox`.
- `SignatureApplicationService.SignDocument` wires this in right after the signature dictionary is built (signer name, date, optional reason/location), before the two-pass ByteRange/CMS signing runs. **The crypto path is untouched.**
- A zero-size (or absent) `/Rect` — the default for a freshly-authored field — stays appearance-less: invisible signatures remain fully valid, as before.

## Scope
Touched only signing-related files, per the task constraint:
- `Excise.Core/Document/SignatureAppearanceAuthoring.cs` (new — the appearance helper)
- `Excise.App/Services/SignatureApplicationService.cs` (wiring + doc comment update)
- `Excise.App.Tests/Unit/SignatureApplicationServiceTests.cs` (tests)
- `Excise.Core.Tests/PublicApi/Excise.Core.approved.txt` (regenerated — one new public method)
- `CHANGELOG.md` (`[Unreleased] / Added`)

## No-self-oracle verification
- `SignDocument_VisibleRect_IndependentRendererShowsInkInSignatureRect_AndStillVerifies`: renders the page with **mutool** (not excise) before signing to confirm the widget region is genuinely blank, signs with a visible `/Rect`, re-renders, and asserts ink now appears there. Also asserts the signature still verifies through the independent #466 `SignatureVerificationService` (ByteRange/CMS untouched by the appearance).
- `SignDocument_DefaultZeroRectField_StaysAppearanceLess`: a freshly-authored zero-`/Rect` field gets no `/AP`.
- Sanity-checked the positive test against a false-positive: temporarily disabled the appearance call and reran — the ink assertion correctly failed (`0.0`, not `> 0.005`), confirming mutool doesn't synthesize its own appearance and the test exercises the real code path.

## Test plan
- [x] `dotnet build excise.sln` — 0 warnings, 0 errors
- [x] `Excise.App.Tests --filter FullyQualifiedName~SignatureApplicationServiceTests` — 16/16 passed (mutool available on this machine, ran for real, not skipped)
- [x] `scripts/test-tier.sh t0` — all green (build, Core/Cli/Avalonia tests, doc-claims, gate-asymmetry, redaction-architecture guard, testdata-sync, skip-budget)
- [x] `APPROVE_PUBLIC_API=1` regeneration of `Excise.Core.approved.txt` — diff is exactly the one new public method
- [ ] Full `Excise.App.Tests` suite (serial, ~17min) — running in background, will report before merge
- [ ] `scripts/test-tier.sh t1` — recommended before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)