### PR TITLE
RTL text selection + bounded column-gap awareness in viewer (#373)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,15 @@ semantic versioning.
   pdftocairo/Ghostscript differentials pinning the out-of-range fallback.
 
 ### Added
+- **Right-to-left text selection in the viewer** (#373) — selecting a line that
+  contains Arabic/Hebrew now copies the text in logical reading order (the way
+  it is read) rather than the visual order it is painted in, reusing the same
+  bidi ordering the extractor already applies (#632) instead of a second bidi
+  pass. The on-screen highlight still follows visual order, so each glyph
+  rectangle — including within an RTL run — is drawn where the user sees it. A
+  bounded multi-column improvement also keeps a column-local drag from vacuuming
+  up an adjacent column that shares a Y-band; full multi-column and CJK
+  selection correctness remain deferred (#774).
 - **Tagged-PDF structure accessibility layer** (#631) — the Avalonia viewer's
   automation peer tree now exposes the tagged-PDF structure tree to screen
   readers: the page's accessible text is ordered by the structure tree when a

--- a/Excise.Avalonia.Tests/TextSelectionRtlTests.cs
+++ b/Excise.Avalonia.Tests/TextSelectionRtlTests.cs
@@ -1,0 +1,322 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using AwesomeAssertions;
+using Excise.Avalonia.Controls;
+using Excise.Avalonia.Services;
+using Excise.Core.Document;
+using Excise.Core.Text;
+using Xunit;
+
+namespace Excise.Avalonia.Tests;
+
+/// <summary>
+/// RTL text selection and bounded multi-column selection for the viewer
+/// (#373). The selection engine builds the on-screen highlight in VISUAL
+/// order (so each glyph rectangle is drawn where the user sees it, including
+/// inside an RTL run) while re-ordering the COPIED text into logical reading
+/// order — reusing the logical order Excise.Core's extractor already produced
+/// via its bidi reorderer (#632), not a second bidi implementation.
+///
+/// The logical-order expectations here are hand-authored Unicode strings
+/// (independent of excise): the fixtures paint Arabic in the visual order that
+/// virtually every producer emits, and the tests assert the letters come back
+/// out in the order a human reads them. The #632 extraction layer these build
+/// on is itself pinned against mutool / python-bidi in Excise.Core.Tests.
+///
+/// The assembly disables parallelization (SkiaSharp's font manager is
+/// process-wide); the engine tests are pure logic and the one control test
+/// runs through <see cref="HeadlessSessionGuard"/>.
+/// </summary>
+public class TextSelectionRtlTests
+{
+    // Logical order (first character = first letter a reader pronounces).
+    // سلام — U+0633 U+0644 U+0627 U+0645.
+    private const string ArabicWord = "سلام";
+    private static readonly int[] ArabicScalars = { 0x0633, 0x0644, 0x0627, 0x0645 };
+
+    // ── (a) mixed LTR+RTL line copies in logical order ───────────────────────
+
+    [Fact]
+    public void MixedLatinRtlLine_CopiesInLogicalOrder()
+    {
+        using var doc = PdfDocument.Open(
+            RtlFixtures.SingleTjWithLatinPrefix("HELLO", ArabicScalars));
+        var letters = doc.GetPage(1).Letters;
+
+        var reading = TextSelectionEngine.SortReadingOrder(letters);
+        reading.Should().HaveCount(9);
+
+        var range = TextSelectionEngine.ColumnAwareRange(
+            reading, reading[0], reading[^1],
+            TextSelectionEngine.EstimateColumnGap(reading));
+
+        // Painted order is visual: the Arabic run is reversed on screen.
+        Concat(range).Should().Be("HELLO" + Reverse(ArabicWord),
+            "the highlighted run follows visual (painted) order");
+
+        // Copied text is logical: HELLO then the Arabic word as read.
+        var logical = TextSelectionEngine.ToLogicalOrder(range, letters);
+        Concat(logical).Should().Be("HELLO" + ArabicWord,
+            "copied RTL text must read in logical order, not visual order");
+    }
+
+    // ── (b) selecting within an RTL run highlights the correct rects ─────────
+
+    [Fact]
+    public void SelectionWithinRtlRun_HighlightsCorrectContiguousRects()
+    {
+        using var doc = PdfDocument.Open(RtlFixtures.SingleTj(ArabicScalars, visualOrder: true));
+        var letters = doc.GetPage(1).Letters;
+        Concat(letters).Should().Be(ArabicWord, "extraction is logical order (#632)");
+
+        // Visual (painted) order, left-to-right: مالس — the mirror of سلام.
+        var reading = TextSelectionEngine.SortReadingOrder(letters);
+        Concat(reading).Should().Be(Reverse(ArabicWord));
+
+        // Drag over the two middle glyphs of the run (visually adjacent).
+        var range = TextSelectionEngine.ColumnAwareRange(
+            reading, reading[1], reading[2],
+            TextSelectionEngine.EstimateColumnGap(reading));
+
+        range.Should().HaveCount(2, "only the two selected glyphs are highlighted");
+
+        // The highlight rectangles are exactly the two selected glyph rects...
+        var rects = range.Select(l => l.GlyphRectangle).OrderBy(r => r.Left).ToList();
+        rects.Should().OnlyContain(r => letters.Any(l =>
+            Math.Abs(l.GlyphRectangle.Left - r.Left) < 0.001 &&
+            Math.Abs(l.GlyphRectangle.Right - r.Right) < 0.001));
+
+        // ...and they are a VISUALLY CONTIGUOUS block: no other glyph on the
+        // page sits horizontally between them, so the highlight covers the run
+        // the user dragged over with nothing leaking in and nothing missed.
+        letters.Should().NotContain(l =>
+            l.GlyphRectangle.Left > rects[0].Left + 0.001 &&
+            l.GlyphRectangle.Left < rects[1].Left - 0.001,
+            "the two highlighted RTL glyphs are visually adjacent");
+
+        // The copied sub-selection is the correct LOGICAL substring (chars 2–3
+        // of سلام = لا), not the visual pair.
+        var logical = TextSelectionEngine.ToLogicalOrder(range, letters);
+        Concat(logical).Should().Be("لا");
+    }
+
+    // ── (c) a column-local drag does not include the neighbour column ────────
+
+    [Fact]
+    public void ColumnLocalDrag_ExcludesAdjacentColumnOnSameYBand()
+    {
+        // Two columns on two shared Y-bands; a wide gutter separates them.
+        var left1 = L("a", 10, 100); var left2 = L("b", 20, 100);
+        var right1 = L("Y", 200, 100); var right2 = L("Z", 210, 100);
+        var left3 = L("c", 10, 80); var left4 = L("d", 20, 80);
+        var right3 = L("Y", 200, 80); var right4 = L("Z", 210, 80);
+
+        var all = new[] { left1, left2, right1, right2, left3, left4, right3, right4 };
+        var reading = TextSelectionEngine.SortReadingOrder(all);
+        var gap = TextSelectionEngine.EstimateColumnGap(reading);
+
+        // Drag down the LEFT column: anchor a (top line), focus d (next line).
+        var plain = TextSelectionEngine.RangeBetween(reading, left1, left4);
+        Concat(plain).Should().Contain("Y",
+            "without column awareness the plain range vacuums up the right column");
+
+        var range = TextSelectionEngine.ColumnAwareRange(reading, left1, left4, gap);
+        Concat(range).Should().Be("abcd",
+            "a column-local drag must not include the adjacent column's words");
+        range.Should().NotContain(l => l.Value == "Y" || l.Value == "Z");
+    }
+
+    // ── direction-agnostic word spacing (locks the JoinText change) ──────────
+
+    [Fact]
+    public void JoinText_InsertsWordSpace_InRtlLogicalOrder()
+    {
+        // Two RTL "words" in logical (right-to-left) order with a wide gap.
+        // Logical order means each next glyph sits to the LEFT of the previous.
+        var w1a = L("س", 100, 100, 8, 12); var w1b = L("ل", 92, 100, 8, 12);
+        var w2a = L("ا", 60, 100, 8, 12); var w2b = L("م", 52, 100, 8, 12);
+
+        var text = TextSelectionEngine.JoinText(new[] { w1a, w1b, w2a, w2b });
+
+        text.Should().Be("سل ام",
+            "a wide RTL gap (prev to the right of cur) still marks a word break");
+    }
+
+    // ── control smoke test (headless) ────────────────────────────────────────
+
+    [Fact]
+    public async Task Viewer_LoadsRtlDocument_WithoutThrowing()
+    {
+        await HeadlessSessionGuard.Session().Dispatch(() =>
+        {
+            using var doc = PdfDocument.Open(RtlFixtures.SingleTj(ArabicScalars, visualOrder: true));
+            var viewer = new PdfViewerControl { Document = doc };
+
+            // The text pipeline the selection code consumes is reachable and
+            // logical for an RTL page loaded into the real control.
+            viewer.GetAccessiblePageText().Should().NotBeNullOrEmpty();
+            Concat(doc.GetPage(1).Letters).Should().Be(ArabicWord);
+            return true;
+        }, CancellationToken.None);
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private static string Concat(IEnumerable<Letter> letters) =>
+        string.Concat(letters.Select(l => l.Value));
+
+    private static string Reverse(string s)
+    {
+        var a = s.ToCharArray();
+        Array.Reverse(a);
+        return new string(a);
+    }
+
+    private static Letter L(string value, double left, double bottom,
+        double width = 8, double height = 12)
+    {
+        var rect = new PdfRectangle(left, bottom, left + width, bottom + height);
+        return new Letter(value, rect, fontSize: height, fontName: "Helvetica",
+            startX: left, startY: bottom, width: width, characterCode: value[0]);
+    }
+}
+
+/// <summary>
+/// Minimal raw-PDF fixtures with a Type1 font and a ToUnicode CMap, mirroring
+/// the #632 <c>RtlPdfFixtures</c> (which live in Excise.Core.Tests and are not
+/// visible here). Character codes 0x41.. are assigned positionally so the
+/// content stream's byte order is the only thing controlling extraction order.
+/// </summary>
+internal static class RtlFixtures
+{
+    /// <summary>
+    /// One Tj painting the word left-to-right with positive advances.
+    /// <paramref name="visualOrder"/> true reverses the codes (leftmost glyph
+    /// is the LAST logical character — the common producer encoding).
+    /// </summary>
+    public static byte[] SingleTj(int[] logicalScalars, bool visualOrder)
+    {
+        var codes = Codes(logicalScalars.Length);
+        if (visualOrder) Array.Reverse(codes);
+        var content = $"BT /F1 24 Tf 100 700 Td ({new string(codes)}) Tj ET";
+        return Build(content, Bfchar(logicalScalars), logicalScalars.Length);
+    }
+
+    /// <summary>
+    /// A Latin prefix then the visual-order RTL word, one Tj. The prefix maps
+    /// to itself; it must not collide with the 0x41.. code range (so keep
+    /// clear of 'A'..).
+    /// </summary>
+    public static byte[] SingleTjWithLatinPrefix(string latinPrefix, int[] logicalScalars)
+    {
+        var codes = Codes(logicalScalars.Length);
+        Array.Reverse(codes);
+        var content = $"BT /F1 24 Tf 100 700 Td ({latinPrefix}{new string(codes)}) Tj ET";
+
+        var mapping = new StringBuilder();
+        foreach (var ch in latinPrefix)
+            mapping.Append($"<{(int)ch:X2}> <{(int)ch:X4}>\n");
+        for (int i = 0; i < logicalScalars.Length; i++)
+            mapping.Append($"<{0x41 + i:X2}> <{logicalScalars[i]:X4}>\n");
+        return Build(content, mapping.ToString(), latinPrefix.Length + logicalScalars.Length);
+    }
+
+    private static char[] Codes(int count)
+    {
+        var codes = new char[count];
+        for (int i = 0; i < count; i++) codes[i] = (char)(0x41 + i);
+        return codes;
+    }
+
+    private static string Bfchar(int[] scalars)
+    {
+        var sb = new StringBuilder();
+        for (int i = 0; i < scalars.Length; i++)
+            sb.Append($"<{0x41 + i:X2}> <{scalars[i]:X4}>\n");
+        return sb.ToString();
+    }
+
+    private static byte[] Build(string content, string bfcharEntries, int bfcharCount)
+    {
+        var cmap =
+            "/CIDInit /ProcSet findresource begin\n" +
+            "12 dict begin\n" +
+            "begincmap\n" +
+            "/CIDSystemInfo << /Registry (Adobe) /Ordering (UCS) /Supplement 0 >> def\n" +
+            "/CMapName /Adobe-Identity-UCS def\n" +
+            "/CMapType 2 def\n" +
+            "1 begincodespacerange\n<00> <FF>\nendcodespacerange\n" +
+            $"{bfcharCount} beginbfchar\n{bfcharEntries}endbfchar\n" +
+            "endcmap\nCMapName currentdict /CMap defineresource pop\nend\nend";
+
+        using var ms = new MemoryStream();
+        using var writer = new StreamWriter(ms, Encoding.Latin1, leaveOpen: true) { NewLine = "\n" };
+
+        writer.WriteLine("%PDF-1.7");
+        var offsets = new long[7];
+
+        offsets[1] = Flush(writer, ms);
+        writer.WriteLine("1 0 obj");
+        writer.WriteLine("<< /Type /Catalog /Pages 2 0 R >>");
+        writer.WriteLine("endobj");
+
+        offsets[2] = Flush(writer, ms);
+        writer.WriteLine("2 0 obj");
+        writer.WriteLine("<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+        writer.WriteLine("endobj");
+
+        offsets[3] = Flush(writer, ms);
+        writer.WriteLine("3 0 obj");
+        writer.WriteLine("<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] " +
+                         "/Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>");
+        writer.WriteLine("endobj");
+
+        offsets[4] = Flush(writer, ms);
+        writer.WriteLine("4 0 obj");
+        writer.WriteLine($"<< /Length {content.Length} >>");
+        writer.WriteLine("stream");
+        writer.WriteLine(content);
+        writer.WriteLine("endstream");
+        writer.WriteLine("endobj");
+
+        offsets[5] = Flush(writer, ms);
+        writer.WriteLine("5 0 obj");
+        writer.WriteLine("<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica " +
+                         "/FirstChar 32 /LastChar 127 /ToUnicode 6 0 R >>");
+        writer.WriteLine("endobj");
+
+        offsets[6] = Flush(writer, ms);
+        writer.WriteLine("6 0 obj");
+        writer.WriteLine($"<< /Length {cmap.Length} >>");
+        writer.WriteLine("stream");
+        writer.WriteLine(cmap);
+        writer.WriteLine("endstream");
+        writer.WriteLine("endobj");
+
+        long xrefPos = Flush(writer, ms);
+        writer.WriteLine("xref");
+        writer.WriteLine("0 7");
+        writer.WriteLine("0000000000 65535 f ");
+        for (int i = 1; i <= 6; i++)
+            writer.WriteLine($"{offsets[i]:D10} 00000 n ");
+        writer.WriteLine("trailer");
+        writer.WriteLine("<< /Root 1 0 R /Size 7 >>");
+        writer.WriteLine("startxref");
+        writer.WriteLine(xrefPos.ToString());
+        writer.WriteLine("%%EOF");
+        writer.Flush();
+
+        return ms.ToArray();
+    }
+
+    private static long Flush(StreamWriter writer, MemoryStream ms)
+    {
+        writer.Flush();
+        return ms.Position;
+    }
+}

--- a/Excise.Avalonia/Controls/PdfViewerControl.Interaction.cs
+++ b/Excise.Avalonia/Controls/PdfViewerControl.Interaction.cs
@@ -120,8 +120,11 @@ public partial class PdfViewerControl
             // Re-draw only when focus actually moves to a different letter.
             if (ReferenceEquals(hit, _selectionFocus)) return;
             _selectionFocus = hit;
-            var range = TextSelectionEngine.RangeBetween(
-                _readingOrderedLetters, _selectionAnchor, _selectionFocus);
+            // Column-gutter aware so a drag inside one column doesn't vacuum up
+            // an adjacent column sharing a Y-band (#373). Highlight follows
+            // visual order — DrawSelectionRange paints each glyph rect.
+            var range = TextSelectionEngine.ColumnAwareRange(
+                _readingOrderedLetters, _selectionAnchor, _selectionFocus, _columnGapThreshold);
             DrawSelectionRange(range);
         }
 
@@ -183,10 +186,16 @@ public partial class PdfViewerControl
                  _selectionAnchor != null && _selectionFocus != null &&
                  _readingOrderedLetters != null)
         {
-            var range = TextSelectionEngine.RangeBetween(
-                _readingOrderedLetters, _selectionAnchor, _selectionFocus);
-            var text = TextSelectionEngine.JoinText(range);
-            var letterDips = range
+            // Highlight rects follow visual order (contiguous glyphs, incl.
+            // within an RTL run); the copied text is re-ordered to logical
+            // reading order so Arabic/Hebrew reads correctly (#373). Column
+            // gutters are respected so a column-local drag stays in-column.
+            var selection = TextSelectionEngine.BuildSelection(
+                _readingOrderedLetters,
+                _currentPageLetters ?? _readingOrderedLetters,
+                _selectionAnchor, _selectionFocus, _columnGapThreshold);
+            var text = selection.Text;
+            var letterDips = selection.VisualRange
                 .Select(l => PdfRectangleToDips(l.GlyphRectangle))
                 .ToList();
             // Bounding box of the whole run — keeps backwards compat with
@@ -219,12 +228,16 @@ public partial class PdfViewerControl
             var page = Document.GetPage(CurrentPage);
             _currentPageLetters = page.Letters?.ToList() ?? new List<Letter>();
             _readingOrderedLetters = TextSelectionEngine.SortReadingOrder(_currentPageLetters);
+            // Column-gutter width depends only on the page's glyph metrics, so
+            // compute it once here rather than on every pointer-move (#373).
+            _columnGapThreshold = TextSelectionEngine.EstimateColumnGap(_readingOrderedLetters);
             _lettersPageNumber = CurrentPage;
         }
         catch
         {
             _currentPageLetters = new List<Letter>();
             _readingOrderedLetters = new List<Letter>();
+            _columnGapThreshold = double.PositiveInfinity;
             _lettersPageNumber = CurrentPage;
         }
     }

--- a/Excise.Avalonia/Controls/PdfViewerControl.axaml.cs
+++ b/Excise.Avalonia/Controls/PdfViewerControl.axaml.cs
@@ -313,6 +313,7 @@ public partial class PdfViewerControl : UserControl
     private int _lettersPageNumber = -1;
     private List<Letter>? _currentPageLetters; // raw glyph order
     private List<Letter>? _readingOrderedLetters; // for range slicing
+    private double _columnGapThreshold = double.PositiveInfinity; // cached per page (#373)
     private Letter? _selectionAnchor;
     private Letter? _selectionFocus;
 

--- a/Excise.Avalonia/Services/TextSelectionEngine.cs
+++ b/Excise.Avalonia/Services/TextSelectionEngine.cs
@@ -67,9 +67,28 @@ public static class TextSelectionEngine
     /// </summary>
     public static List<Letter> SortReadingOrder(IEnumerable<Letter> letters)
     {
-        // First group by approximate line — bucket by rounded baseline Y.
-        // Use 50 % of font size as the line-merge tolerance so kerned text
-        // and superscripts don't get split into multiple "lines".
+        var lines = GroupIntoLines(letters);
+
+        // Sort each line left-to-right (visual order — see class remarks).
+        foreach (var line in lines)
+            line.Sort((a, b) => a.GlyphRectangle.Left.CompareTo(b.GlyphRectangle.Left));
+
+        // Sort lines top-to-bottom (PDF Y-up: descending centre Y).
+        lines.Sort((a, b) => LineCentreY(b).CompareTo(LineCentreY(a)));
+
+        return lines.SelectMany(l => l).ToList();
+    }
+
+    /// <summary>
+    /// Bucket letters into approximate lines by baseline/centre Y. Two letters
+    /// share a line when their vertical centres differ by less than half the
+    /// smaller font size (kerned text and superscripts stay on one line).
+    /// Within a returned line the letters keep their input relative order;
+    /// callers sort as they need (visual L-R for selection ranges, logical
+    /// page order for copied text). Lines themselves are unsorted.
+    /// </summary>
+    private static List<List<Letter>> GroupIntoLines(IEnumerable<Letter> letters)
+    {
         var ordered = letters
             .OrderByDescending(l => l.GlyphRectangle.Top)  // PDF Y-up: higher Top = earlier
             .ToList();
@@ -78,7 +97,6 @@ public static class TextSelectionEngine
         foreach (var l in ordered)
         {
             var cy = (l.GlyphRectangle.Bottom + l.GlyphRectangle.Top) * 0.5;
-            // Find an existing line whose centre Y is close.
             List<Letter>? hostLine = null;
             foreach (var line in lines)
             {
@@ -92,19 +110,13 @@ public static class TextSelectionEngine
             else lines.Add(new List<Letter> { l });
         }
 
-        // Sort each line left-to-right.
-        foreach (var line in lines)
-            line.Sort((a, b) => a.GlyphRectangle.Left.CompareTo(b.GlyphRectangle.Left));
+        return lines;
+    }
 
-        // Sort lines top-to-bottom (PDF Y-up: descending centre Y).
-        lines.Sort((a, b) =>
-        {
-            var ay = (a[0].GlyphRectangle.Bottom + a[0].GlyphRectangle.Top) * 0.5;
-            var by = (b[0].GlyphRectangle.Bottom + b[0].GlyphRectangle.Top) * 0.5;
-            return by.CompareTo(ay);
-        });
-
-        return lines.SelectMany(l => l).ToList();
+    private static double LineCentreY(List<Letter> line)
+    {
+        var r = line[0].GlyphRectangle;
+        return (r.Bottom + r.Top) * 0.5;
     }
 
     /// <summary>
@@ -156,11 +168,195 @@ public static class TextSelectionEngine
             }
             else
             {
-                var gap = cur.Left - prev.Right;
+                // Horizontal gap, measured direction-agnostically so a word
+                // break is detected whether the run reads left-to-right (LTR,
+                // prev on the left) or right-to-left (RTL logical order, prev
+                // on the right). For every existing ascending-X caller this is
+                // identical to the old `cur.Left - prev.Right` (#373).
+                var gap = Math.Max(cur.Left - prev.Right, prev.Left - cur.Right);
                 if (gap > 0.5 * lineHeight) sb.Append(' ');
             }
             sb.Append(letters[i].Value);
         }
         return sb.ToString();
+    }
+
+    // ── RTL selection + multi-column awareness (#373) ────────────────────────
+
+    /// <summary>
+    /// Result of resolving a drag selection: the letters to HIGHLIGHT, in
+    /// visual (left-to-right) order so their glyph rectangles are drawn as
+    /// the user sees them, and the copied TEXT in logical reading order.
+    /// </summary>
+    internal readonly record struct SelectionResult(List<Letter> VisualRange, string Text);
+
+    /// <summary>
+    /// Resolve a drag from <paramref name="anchor"/> to <paramref name="focus"/>
+    /// into the highlight rectangles and the copied text (#373). The highlight
+    /// follows visual order (contiguous glyph rects, including within an RTL
+    /// run), while the text is re-ordered to logical reading order so Arabic/
+    /// Hebrew comes out the way it is read, not the way it is painted.
+    /// <paramref name="readingOrdered"/> is <see cref="SortReadingOrder"/>'s
+    /// visual output; <paramref name="logicalPageLetters"/> is the page's
+    /// letter sequence from Excise.Core (already in logical order via its bidi
+    /// reorderer, #632).
+    /// </summary>
+    internal static SelectionResult BuildSelection(
+        IReadOnlyList<Letter> readingOrdered,
+        IReadOnlyList<Letter> logicalPageLetters,
+        Letter anchor, Letter focus,
+        double columnGapThreshold)
+    {
+        var visualRange = ColumnAwareRange(readingOrdered, anchor, focus, columnGapThreshold);
+        var logical = ToLogicalOrder(visualRange, logicalPageLetters);
+        return new SelectionResult(visualRange, JoinText(logical));
+    }
+
+    /// <summary>
+    /// Re-order a visually-selected letter run into logical reading order for
+    /// copy/extraction (#373). The selection is built visually so the on-screen
+    /// highlight rectangles stay contiguous, but copied RTL text must read in
+    /// logical order. This does NOT re-run bidi: it reuses the order Excise.Core
+    /// already produced (<see cref="PdfPage"/> letters were reordered by the
+    /// extractor's bidi pass, #632) by sorting each line's selected letters on
+    /// their index in <paramref name="logicalPageLetters"/>. Selections with no
+    /// strong-RTL glyph short-circuit unchanged, so pure-LTR copy is provably
+    /// untouched.
+    /// </summary>
+    internal static List<Letter> ToLogicalOrder(
+        IReadOnlyList<Letter> selected, IReadOnlyList<Letter> logicalPageLetters)
+    {
+        if (selected.Count <= 1) return selected.ToList();
+
+        bool anyRtl = false;
+        foreach (var l in selected)
+            if (ContainsStrongRtl(l.Value)) { anyRtl = true; break; }
+        if (!anyRtl) return selected.ToList();
+
+        var logicalIndex = new Dictionary<Letter, int>(ReferenceEqualityComparer.Instance);
+        for (int i = 0; i < logicalPageLetters.Count; i++)
+            logicalIndex[logicalPageLetters[i]] = i;
+
+        var lines = GroupIntoLines(selected);
+        lines.Sort((a, b) => LineCentreY(b).CompareTo(LineCentreY(a)));
+
+        var result = new List<Letter>(selected.Count);
+        foreach (var line in lines)
+        {
+            line.Sort((a, b) =>
+            {
+                var ia = logicalIndex.TryGetValue(a, out var va) ? va : int.MaxValue;
+                var ib = logicalIndex.TryGetValue(b, out var vb) ? vb : int.MaxValue;
+                if (ia != ib) return ia.CompareTo(ib);
+                return a.GlyphRectangle.Left.CompareTo(b.GlyphRectangle.Left);
+            });
+            result.AddRange(line);
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// <see cref="RangeBetween"/> with bounded column-gutter awareness (#373):
+    /// when both endpoints sit in the same column band, letters that fall in a
+    /// DIFFERENT column band (an adjacent column sharing an intervening line's
+    /// Y-band) are dropped, so a column-local drag does not vacuum up the
+    /// neighbouring column. Cross-column selections (endpoints in different
+    /// bands) are left as the plain range — full multi-column reading order is
+    /// deferred to #774. Columns are detected as maximal horizontal gaps wider
+    /// than <paramref name="columnGapThreshold"/>.
+    /// </summary>
+    internal static List<Letter> ColumnAwareRange(
+        IReadOnlyList<Letter> ordered, Letter anchor, Letter focus, double columnGapThreshold)
+    {
+        var range = RangeBetween(ordered, anchor, focus);
+        if (range.Count == 0 || columnGapThreshold <= 0 || double.IsInfinity(columnGapThreshold))
+            return range;
+
+        var bandOf = ComputeColumnBands(ordered, columnGapThreshold);
+        if (!bandOf.TryGetValue(anchor, out var anchorBand) ||
+            !bandOf.TryGetValue(focus, out var focusBand) ||
+            anchorBand != focusBand)
+            return range;
+
+        var filtered = new List<Letter>(range.Count);
+        foreach (var l in range)
+            if (bandOf.TryGetValue(l, out var band) && band == anchorBand)
+                filtered.Add(l);
+        return filtered;
+    }
+
+    /// <summary>
+    /// A page-geometry-derived column-gutter width: a horizontal gap wider than
+    /// this many times the median glyph width is treated as a column boundary,
+    /// not a word space. Returns +∞ when there are no letters (no columns).
+    /// </summary>
+    internal static double EstimateColumnGap(IReadOnlyList<Letter> letters)
+    {
+        if (letters.Count == 0) return double.PositiveInfinity;
+        var widths = letters
+            .Select(l => l.GlyphRectangle.Width)
+            .Where(w => w > 0)
+            .OrderBy(w => w)
+            .ToList();
+        if (widths.Count == 0) return double.PositiveInfinity;
+        var median = widths[widths.Count / 2];
+        return median * ColumnGapFactor;
+    }
+
+    /// <summary>Column-gutter width as a multiple of the median glyph width.</summary>
+    private const double ColumnGapFactor = 3.0;
+
+    /// <summary>
+    /// Assign each letter a left-to-right column-band index by sweeping X and
+    /// starting a new band whenever the gap to the running right edge exceeds
+    /// <paramref name="gapThreshold"/>. Bands ignore Y (bounded — a full-width
+    /// line can merge two columns; full analysis is #774).
+    /// </summary>
+    private static Dictionary<Letter, int> ComputeColumnBands(
+        IReadOnlyList<Letter> letters, double gapThreshold)
+    {
+        var map = new Dictionary<Letter, int>(ReferenceEqualityComparer.Instance);
+        var sorted = letters.OrderBy(l => l.GlyphRectangle.Left).ToList();
+        int band = -1;
+        double runningRight = double.NegativeInfinity;
+        foreach (var l in sorted)
+        {
+            var r = l.GlyphRectangle;
+            if (band < 0 || r.Left - runningRight > gapThreshold)
+            {
+                band++;
+                runningRight = r.Right;
+            }
+            else
+            {
+                runningRight = Math.Max(runningRight, r.Right);
+            }
+            map[l] = band;
+        }
+        return map;
+    }
+
+    /// <summary>
+    /// True when <paramref name="value"/> contains a strong right-to-left
+    /// scalar (Hebrew/Arabic/Syriac blocks and their presentation forms,
+    /// excluding the Arabic-Indic digit ranges which are bidi-weak). This is a
+    /// codepoint-range test, not a bidi implementation — it only gates whether
+    /// the logical re-order in <see cref="ToLogicalOrder"/> needs to run. Ranges
+    /// mirror Excise.Core's reorderer (#632/#373).
+    /// </summary>
+    internal static bool ContainsStrongRtl(string? value)
+    {
+        if (string.IsNullOrEmpty(value)) return false;
+        foreach (var c in value)
+        {
+            if (c >= '\u0660' && c <= '\u0669') continue; // Arabic-Indic digits (weak)
+            if (c >= '\u06F0' && c <= '\u06F9') continue; // Extended Arabic-Indic digits (weak)
+            if ((c >= '\u0590' && c <= '\u08FF') ||       // Hebrew … Arabic Extended
+                (c >= '\uFB1D' && c <= '\uFB4F') ||       // Hebrew presentation forms
+                (c >= '\uFB50' && c <= '\uFDFF') ||       // Arabic presentation forms A
+                (c >= '\uFE70' && c <= '\uFEFF'))         // Arabic presentation forms B
+                return true;
+        }
+        return false;
     }
 }


### PR DESCRIPTION
## Summary
Implements the finishable core of #373 for the `Excise.Avalonia` viewer.

- **RTL text selection.** Selection sorted every line strictly left-to-right, so copying a line containing Arabic/Hebrew returned the text in visual (painted) order — reversed from how it reads. Excise.Core's extractor already emits letters in logical order via its bidi reorderer (#632); selection re-visualized that by re-sorting on X. Copied text is now re-ordered back to logical reading order **by reusing the page's existing logical letter sequence** (no second bidi implementation). The on-screen highlight still follows visual order, so each glyph rectangle — including within an RTL run — is drawn where the user sees it. `JoinText`'s word-gap test is now direction-agnostic (a provable no-op for every existing left-to-right caller) so RTL word spaces survive the reorder.
- **Bounded multi-column improvement.** A column-local drag no longer vacuums up an adjacent column that shares a Y-band (simple gutter detection in range building). Full multi-column and CJK selection correctness remain **deferred (#774)** and were not started.

## Scope / constraints
- Touches only `Excise.Avalonia/**` (+ tests). Read-only use of `Excise.Core` `PdfPage.Letters` (already bidi-ordered).
- New engine members are **internal** — public API and `Excise.Avalonia.approved.txt` are **unchanged**.
- `SortReadingOrder`/`JoinText` public behavior preserved (existing `TextSelectionEngineTests` in App.Tests stay green).
- Hot-path note: the column-gutter width is cached per page (computed once when letters load), not recomputed per pointer-move.

## Tests
`Excise.Avalonia.Tests/TextSelectionRtlTests.cs` (headless, serial collection respected):
- (a) mixed LTR+RTL line copies in **logical** order (asserts the visual range is the reverse, then the reorder is logical);
- (b) selecting within an RTL run highlights the correct, visually-contiguous glyph rects — asserted via the range's `GlyphRectangle`s (the control paints exactly that set; headless has no Skia to inspect Canvas children) — and copies the correct logical substring;
- (c) a column-local drag excludes the neighbouring column's words;
- plus a direction-agnostic RTL word-spacing test and a headless control smoke test.

Logical-order expectations are **hand-authored Unicode strings** on the same fixtures #632 pins against python-bidi/mutool — excise is not its own oracle for reordering.

## Results
- New tests: 5 pass. Full `Excise.Avalonia.Tests`: 86 pass, 0 skip. Existing App.Tests `TextSelectionEngineTests`: 7 pass. App.Tests drag/alignment UI: 7 pass, 10 skipped (pre-existing, fixture-gated by absent local PDFs).
- Build: 0 warnings / 0 errors. `verify-doc-claims.sh`: passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)