### PR TITLE
fix: typewriter (type-over) workflow soundness + GUI coverage (#780)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ semantic versioning.
 ## [Unreleased]
 
 ### Fixed
+- **Typewriter (type-over) workflow: pending edits can no longer be lost or
+  flattened unseen** (#780) — pending type-over edits used to persist silently
+  after leaving typewriter mode and bake into the PDF on the next save with no
+  signal, off-page edits were never shown yet still flattened, and a plain
+  click placed nothing. Now: mode-exit is non-destructive and the pending-edit
+  count stays visible in the status bar; an explicit "Discard Pending Type-over
+  Edits" command is the only non-saving way to clear them; "Go to Next Pending
+  Type-over Edit" navigates to off-page edits before they commit; `Esc` removes
+  an empty active box and keeps typed text in a non-empty one; and a click now
+  places a default-sized box (drag still sizes it). Added GUI/headless coverage
+  for the pointer-driven creation path, DIP↔PDF round-trips (incl. `/Rotate`
+  90/180/270 and page clamp), the on-create permission re-check, and mode-exit
+  non-loss / discard verified by reopening the saved PDF.
 - **RTL redaction: numbers inside right-to-left lines no longer evade
   removal** (#632) — a number embedded in an Arabic/Hebrew line (an ID, date,
   or phone number) kept its surrounding words in visual order, so a

--- a/Excise.App.Tests/Controls/PdfViewerControlTypewriterTests.cs
+++ b/Excise.App.Tests/Controls/PdfViewerControlTypewriterTests.cs
@@ -1,0 +1,211 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using AwesomeAssertions;
+using Excise.Avalonia.Controls;
+using Excise.Core.Editing;
+using Xunit;
+using PdfCoreDocument = Excise.Core.Document.PdfDocument;
+using PdfRectangle = Excise.Core.Document.PdfRectangle;
+
+namespace Excise.App.Tests.Controls;
+
+/// <summary>
+/// #780: pointer-driven type-over creation, DIP↔PDF coordinate round-trips
+/// (incl. rotated pages and page clamp), and Esc-to-cancel of the active box.
+/// These paths were entirely untested — every prior typewriter test called the
+/// ViewModel directly, so the control's coordinate mapping and the interaction
+/// gesture path had no coverage.
+/// </summary>
+[Collection("AvaloniaTests")]
+public class PdfViewerControlTypewriterTests
+{
+    private static PdfCoreDocument NewSinglePage(double w = 300, double h = 400, int rotation = 0)
+    {
+        var doc = PdfCoreDocument.CreateNew();
+        doc.Pages.AddBlank(w, h);
+        if (rotation != 0)
+            doc.GetPage(1).Rotation = rotation;
+        return doc;
+    }
+
+    private static PdfViewerControl NewTypewriterControl(PdfCoreDocument doc)
+    {
+        var control = new PdfViewerControl();
+        control.Document = doc;
+        control.CurrentPage = 1;
+        control.InteractionMode = InteractionMode.Typewriter;
+        return control;
+    }
+
+    [FixedAvaloniaFact]
+    public async Task ClickWithoutDrag_PlacesADefaultSizedBox()
+    {
+        await Dispatcher.UIThread.InvokeAsync(() =>
+        {
+            using var doc = NewSinglePage();
+            var control = NewTypewriterControl(doc);
+
+            TypewriterTextCreatedEventArgs? created = null;
+            control.TypewriterTextCreated += (_, e) => created = e;
+
+            // A plain click: start == end (no drag).
+            control.CreateTypewriterTextFromPointer(new Point(80, 90), new Point(80, 90));
+
+            created.Should().NotBeNull("a click must place a box, not nothing (#780)");
+            created!.PageNumber.Should().Be(1);
+            created.Rect.Width.Should().BeGreaterThan(0);
+            created.Rect.Height.Should().BeGreaterThan(0);
+        });
+    }
+
+    [FixedAvaloniaFact]
+    public async Task Drag_PlacesABoxSizedToTheGesture_LargerThanAClick()
+    {
+        await Dispatcher.UIThread.InvokeAsync(() =>
+        {
+            using var doc = NewSinglePage();
+            var control = NewTypewriterControl(doc);
+
+            PdfRectangle click = default, drag = default;
+            control.TypewriterTextCreated += (_, e) => { if (click == default) click = e.Rect; else drag = e.Rect; };
+
+            control.CreateTypewriterTextFromPointer(new Point(20, 20), new Point(20, 20));      // click
+            control.CreateTypewriterTextFromPointer(new Point(20, 20), new Point(260, 200));    // wide drag
+
+            drag.Width.Should().BeGreaterThan(click.Width, "a drag sizes the box to the gesture");
+            drag.Height.Should().BeGreaterThan(click.Height);
+        });
+    }
+
+    [FixedAvaloniaFact]
+    public async Task DipToPdf_FlipsYAxis_TopOfScreenMapsToTopOfPage()
+    {
+        await Dispatcher.UIThread.InvokeAsync(() =>
+        {
+            using var doc = NewSinglePage(300, 400);
+            var control = NewTypewriterControl(doc);
+
+            // PDF origin is bottom-left; a box near the TOP of the screen (small
+            // DIP Y) must map to a LARGE PDF Top. Compare a top-placed box with
+            // a bottom-placed box.
+            var top = control.ViewerDipsToPdfRect(new Rect(10, 5, 100, 40), 1);
+            var bottom = control.ViewerDipsToPdfRect(new Rect(10, 300, 100, 40), 1);
+
+            top.Top.Should().BeGreaterThan(bottom.Top,
+                "screen-top must map to page-top under the PDF Y-flip");
+        });
+    }
+
+    [FixedAvaloniaTheory]
+    [InlineData(0)]
+    [InlineData(90)]
+    [InlineData(180)]
+    [InlineData(270)]
+    public async Task DipPdfRoundTrip_IsIdentity_AtEveryRotation(int rotation)
+    {
+        await Dispatcher.UIThread.InvokeAsync(() =>
+        {
+            using var doc = NewSinglePage(300, 400, rotation);
+            var control = NewTypewriterControl(doc);
+
+            // A box comfortably inside the page and above the minimum size, so
+            // neither clamp nor min-size substitution perturbs the round-trip.
+            var original = new PdfRectangle(60, 120, 180, 170);
+
+            var dip = control.PdfRectToViewerDips(original, 1);
+            var roundTripped = control.ViewerDipsToPdfRect(dip, 1);
+
+            roundTripped.Left.Should().BeApproximately(original.Left, 1.5,
+                $"content→viewer→content must be identity at /Rotate {rotation}");
+            roundTripped.Bottom.Should().BeApproximately(original.Bottom, 1.5);
+            roundTripped.Right.Should().BeApproximately(original.Right, 1.5);
+            roundTripped.Top.Should().BeApproximately(original.Top, 1.5);
+        });
+    }
+
+    [FixedAvaloniaFact]
+    public async Task NormalizeDipRect_ClampsBoxOntoThePage()
+    {
+        await Dispatcher.UIThread.InvokeAsync(() =>
+        {
+            using var doc = NewSinglePage(300, 400);
+            var control = NewTypewriterControl(doc);
+
+            // The page's DIP extent, derived from the control itself (a request
+            // larger than the page clamps to the page's width/height at 0,0).
+            var full = control.NormalizeTypewriterDipRect(new Rect(0, 0, 100000, 100000));
+            var pageWidthDips = full.Width;
+            var pageHeightDips = full.Height;
+
+            // A box dragged far off the right/bottom edge must be pulled back so
+            // it stays fully on the page — otherwise the typed text lands off-page.
+            var clamped = control.NormalizeTypewriterDipRect(new Rect(100000, 100000, 120, 40));
+
+            (clamped.X + clamped.Width).Should().BeLessThanOrEqualTo(pageWidthDips + 0.5);
+            (clamped.Y + clamped.Height).Should().BeLessThanOrEqualTo(pageHeightDips + 0.5);
+            clamped.X.Should().BeGreaterThanOrEqualTo(0);
+            clamped.Y.Should().BeGreaterThanOrEqualTo(0);
+        });
+    }
+
+    [FixedAvaloniaFact]
+    public async Task Escape_OnEmptyActiveBox_RemovesIt()
+    {
+        await RunEscapeCase(initialText: "", expectDeleted: true);
+    }
+
+    [FixedAvaloniaFact]
+    public async Task Escape_OnNonEmptyActiveBox_KeepsTypedText()
+    {
+        await RunEscapeCase(initialText: "typed content", expectDeleted: false);
+    }
+
+    private static async Task RunEscapeCase(string initialText, bool expectDeleted)
+    {
+        PdfCoreDocument? doc = null;
+        var control = new PdfViewerControl();
+        var deletedFired = false;
+
+        await Dispatcher.UIThread.InvokeAsync(() =>
+        {
+            doc = NewSinglePage();
+            control.Document = doc;
+            control.CurrentPage = 1;
+            control.InteractionMode = InteractionMode.Typewriter;
+            control.TypewriterTextDeleted += (_, _) => deletedFired = true;
+            control.TypewriterTextOperations = new[]
+            {
+                PdfTypewriterTextOperation.Create(1, new PdfRectangle(40, 250, 240, 290), initialText),
+            };
+        });
+
+        await Dispatcher.UIThread.InvokeAsync(() =>
+        {
+            var layer = control.FindControl<Canvas>("TypewriterLayer");
+            layer.Should().NotBeNull();
+            var textBox = layer!.GetVisualDescendants().OfType<TextBox>().Single();
+
+            textBox.RaiseEvent(new KeyEventArgs
+            {
+                RoutedEvent = InputElement.KeyDownEvent,
+                Route = RoutingStrategies.Bubble,
+                Key = Key.Escape,
+            });
+        });
+
+        deletedFired.Should().Be(expectDeleted,
+            expectDeleted
+                ? "Esc on an empty box removes it"
+                : "Esc must never silently drop typed text");
+
+        doc?.Dispose();
+    }
+}

--- a/Excise.App.Tests/UI/TypewriterWorkflowTests.cs
+++ b/Excise.App.Tests/UI/TypewriterWorkflowTests.cs
@@ -1,8 +1,15 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Reactive.Linq;
 using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Input;
+using Avalonia.Threading;
 using AwesomeAssertions;
+using Excise.Avalonia.Controls;
 using Excise.Core.Document;
 using Excise.App.Tests.Utilities;
 using Excise.App.ViewModels;
@@ -40,5 +47,233 @@ public class TypewriterWorkflowTests
         vm.FileState.TypewriterEditsCount.Should().Be(0);
 
         window.Close();
+    }
+
+    // #780: exiting typewriter mode must NOT discard pending edits, but the user
+    // must be able to SEE they are pending — otherwise they flatten unseen on
+    // the next save. The edit survives mode-exit, the indicator reflects it, and
+    // a save still flattens it (reopen proves the text is really in the PDF).
+    [FixedAvaloniaFact]
+    public async Task ExitingTypewriterMode_KeepsPendingEdit_AndIndicatorReflectsIt_AndSaveStillFlattens()
+    {
+        var (sourcePath, outputPath, tempDir) = MakePaths();
+        TestPdfGenerator.CreateSimpleTextPdf(sourcePath, "Original text");
+
+        var vm = new MainWindowViewModel();
+        var window = new MainWindow { DataContext = vm, Width = 1280, Height = 900 };
+        window.Show();
+
+        await vm.LoadDocumentAsync(sourcePath);
+        await vm.ToggleTypewriterModeCommand.Execute();
+        vm.IsTypewriterMode.Should().BeTrue();
+
+        vm.OnTypewriterTextCreated(new PdfRectangle(72, 620, 300, 660), 1);
+        var opId = vm.TypewriterTextOperations.Single().Id;
+        vm.OnTypewriterTextEdited(opId, "Survives mode exit", 1);
+
+        // Leave the mode as a user would after "backing out".
+        await vm.ToggleTypewriterModeCommand.Execute();
+        vm.IsTypewriterMode.Should().BeFalse();
+
+        // Non-destructive: the edit is still pending and visible.
+        vm.TypewriterTextOperations.Should().HaveCount(1, "mode-exit must not silently drop edits");
+        vm.FileState.TypewriterEditsCount.Should().Be(1);
+        vm.HasPendingTypewriterEdits.Should().BeTrue();
+        vm.StatusBarText.Should().Contain("typewriter edit(s) pending",
+            "the indicator must persist even after leaving the mode");
+
+        await vm.SaveFileAsAsync(outputPath);
+
+        using var saved = PdfDocument.Open(outputPath);
+        saved.GetPage(1).Text.Should().Contain("Survives mode exit",
+            "flatten-on-save is correct behaviour and must be preserved");
+
+        window.Close();
+        Cleanup(tempDir);
+    }
+
+    // #780: the explicit discard command is the ONLY non-saving way to clear
+    // pending edits. After discard, a save must NOT contain the text — proving
+    // the edit was genuinely dropped, not merely hidden from the in-memory list.
+    [FixedAvaloniaFact]
+    public async Task DiscardPendingTypewriterEdits_ClearsState_AndTextIsAbsentFromSavedPdf()
+    {
+        var (sourcePath, outputPath, tempDir) = MakePaths();
+        TestPdfGenerator.CreateSimpleTextPdf(sourcePath, "Original text");
+
+        var vm = new MainWindowViewModel();
+        var window = new MainWindow { DataContext = vm, Width = 1280, Height = 900 };
+        window.Show();
+
+        await vm.LoadDocumentAsync(sourcePath);
+        vm.OnTypewriterTextCreated(new PdfRectangle(72, 620, 300, 660), 1);
+        var opId = vm.TypewriterTextOperations.Single().Id;
+        vm.OnTypewriterTextEdited(opId, "Should be discarded", 1);
+        vm.HasPendingTypewriterEdits.Should().BeTrue();
+
+        await vm.DiscardPendingTypewriterEditsCommand.Execute();
+
+        vm.TypewriterTextOperations.Should().BeEmpty();
+        vm.FileState.TypewriterEditsCount.Should().Be(0);
+        vm.HasPendingTypewriterEdits.Should().BeFalse();
+
+        await vm.SaveFileAsAsync(outputPath);
+
+        using var saved = PdfDocument.Open(outputPath);
+        saved.GetPage(1).Text.Should().NotContain("Should be discarded",
+            "a discarded edit must never reach the saved PDF");
+
+        window.Close();
+        Cleanup(tempDir);
+    }
+
+    // #780: pending edits on a non-current page are invisible (the layer only
+    // renders the current page) yet still flatten. GoToNextPendingTypewriterEdit
+    // navigates to them so nothing bakes in unseen.
+    [FixedAvaloniaFact]
+    public async Task GoToNextPendingTypewriterEdit_NavigatesToOffPageEdit()
+    {
+        var (sourcePath, _, tempDir) = MakePaths();
+        TestPdfGenerator.CreateMultiPagePdf(sourcePath, pageCount: 4);
+
+        var vm = new MainWindowViewModel();
+        var window = new MainWindow { DataContext = vm, Width = 1280, Height = 900 };
+        window.Show();
+
+        await vm.LoadDocumentAsync(sourcePath);
+        vm.CurrentPageIndex = 0; // viewing page 1
+        vm.OnTypewriterTextCreated(new PdfRectangle(72, 620, 300, 660), 3);
+        vm.OnTypewriterTextEdited(vm.TypewriterTextOperations.Single().Id, "On page three", 3);
+
+        await vm.GoToNextPendingTypewriterEditCommand.Execute();
+
+        vm.CurrentPage.Should().Be(3, "navigation must reach the off-page pending edit");
+
+        window.Close();
+        Cleanup(tempDir);
+    }
+
+    // #780: the pointer-driven creation path (PointerPressed → PointerReleased →
+    // CreateTypewriterTextFromPointer → TypewriterTextCreated → VM) was entirely
+    // untested — every other test calls OnTypewriterTextCreated directly. This
+    // drives a REAL click (MouseDown+MouseUp at the same point, no drag) through
+    // the headless pointer pipeline and asserts a box is placed. If this regresses
+    // to "a click places nothing" (the headline bug), this test fails.
+    [FixedAvaloniaFact]
+    public async Task RealClickInTypewriterMode_PlacesABox_NoDragRequired()
+    {
+        var (sourcePath, _, tempDir) = MakePaths();
+        TestPdfGenerator.CreateSimpleTextPdf(sourcePath, "Click to place");
+
+        var vm = new MainWindowViewModel();
+        var window = new MainWindow { DataContext = vm, Width = 1280, Height = 900 };
+        window.Show();
+        await Task.Delay(200);
+
+        await vm.LoadDocumentAsync(sourcePath);
+        await Task.Delay(400);
+
+        await vm.ToggleTypewriterModeCommand.Execute();
+        vm.IsTypewriterMode.Should().BeTrue();
+
+        var viewer = window.FindControl<PdfViewerControl>("PdfViewerControl");
+        viewer.Should().NotBeNull();
+
+        // Wait for single-page layout (mirrors MouseInputTests): the overlay
+        // canvas shares the zoom transform, so a page-space point translates to
+        // window coords even though the canvas itself reports zero Bounds.
+        ScrollViewer? scrollViewer = null;
+        var deadline = DateTime.UtcNow.AddSeconds(10);
+        while (DateTime.UtcNow < deadline)
+        {
+            window.UpdateLayout();
+            scrollViewer = viewer!.FindControl<ScrollViewer>("PdfScrollViewer");
+            if (scrollViewer is { IsVisible: true } && scrollViewer.Bounds != default)
+                break;
+            await Task.Delay(150);
+        }
+        scrollViewer.Should().NotBeNull();
+        scrollViewer!.Bounds.Should().NotBe(default(Rect), "single-page view must be laid out before clicking");
+
+        var overlay = viewer!.FindControl<Canvas>("OverlayCanvas");
+        overlay.Should().NotBeNull();
+
+        // Centre of the page in viewer-DIP space (render DPI 120), translated to
+        // window coords. A plain click here — no drag.
+        var page = vm.PdfCoreDocument!.GetPage(1);
+        var localCenter = new Point(
+            page.VisualWidth * 120.0 / 72.0 / 2.0,
+            page.VisualHeight * 120.0 / 72.0 / 2.0);
+        var center = overlay!.TranslatePoint(localCenter, window);
+        center.Should().NotBeNull("the overlay must be attached so a page point maps to a window point");
+
+        vm.TypewriterTextOperations.Should().BeEmpty("precondition: nothing placed yet");
+
+        await Dispatcher.UIThread.InvokeAsync(() =>
+        {
+            window.MouseDown(center!.Value, MouseButton.Left);
+            window.MouseUp(center!.Value, MouseButton.Left);
+        });
+        for (var i = 0; i < 3; i++) { await Task.Delay(100); window.UpdateLayout(); }
+
+        vm.TypewriterTextOperations.Should().HaveCount(1,
+            "a plain click (no drag) must place a default-sized type-over box");
+
+        window.Close();
+        Cleanup(tempDir);
+    }
+
+    // #780/#642: defence in depth — the permission re-check on CREATE, not just
+    // on the mode toggle. Uses the GUI load path (LoadDocumentAsync) so the
+    // in-memory document is set and OnTypewriterTextCreated's permission gate is
+    // the real blocker (contrast: SaveFileAsAsync_Flattens... adds an op on an
+    // unrestricted doc via the same call). A restricted fixture denies /P bit 4.
+    [FixedAvaloniaFact]
+    public async Task OnTypewriterTextCreated_ModifyForbidden_AddsNothing()
+    {
+        var fixturePath = RestrictedFixturePathOrNull();
+        Assert.SkipWhen(fixturePath == null, "Restricted /P bit-4 fixture not available");
+
+        var vm = new MainWindowViewModel();
+        var window = new MainWindow { DataContext = vm, Width = 1280, Height = 900 };
+        window.Show();
+
+        await vm.LoadDocumentAsync(fixturePath!);
+
+        vm.OnTypewriterTextCreated(new PdfRectangle(72, 700, 300, 720), pageNumber: 1);
+
+        vm.TypewriterTextOperations.Should().BeEmpty("the fixture denies /P bit 4 (modify)");
+        vm.FileState.TypewriterEditsCount.Should().Be(0);
+
+        window.Close();
+    }
+
+    private static string? RestrictedFixturePathOrNull()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "excise.sln")))
+            {
+                var path = Path.Combine(dir.FullName,
+                    "test-pdfs", "poppler", "unittestcases", "Gday garçon - owner.pdf");
+                return File.Exists(path) ? path : null;
+            }
+            dir = dir.Parent;
+        }
+        return null;
+    }
+
+    private static (string source, string output, string dir) MakePaths()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "Excise.AppTypewriterTests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        return (Path.Combine(tempDir, "source.pdf"), Path.Combine(tempDir, "output.pdf"), tempDir);
+    }
+
+    private static void Cleanup(string dir)
+    {
+        try { if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true); }
+        catch { }
     }
 }

--- a/Excise.App/ViewModels/MainWindowViewModel.Commands.cs
+++ b/Excise.App/ViewModels/MainWindowViewModel.Commands.cs
@@ -44,6 +44,8 @@ public partial class MainWindowViewModel
     public ReactiveCommand<Unit, Unit> ToggleTextSelectionModeCommand { get; private set; } = null!;
     public ReactiveCommand<Unit, Unit> ToggleFormAuthoringModeCommand { get; private set; } = null!;
     public ReactiveCommand<Unit, Unit> ToggleTypewriterModeCommand { get; private set; } = null!;
+    public ReactiveCommand<Unit, Unit> DiscardPendingTypewriterEditsCommand { get; private set; } = null!;
+    public ReactiveCommand<Unit, Unit> GoToNextPendingTypewriterEditCommand { get; private set; } = null!;
     public ReactiveCommand<Unit, Unit> AddHighlightAnnotationFromSelectionCommand { get; private set; } = null!;
     public ReactiveCommand<Unit, Unit> AddStickyNoteAnnotationCommand { get; private set; } = null!;
     public ReactiveCommand<Unit, Unit> ToggleOutlineCommand { get; private set; } = null!;
@@ -139,6 +141,8 @@ public partial class MainWindowViewModel
             IsFormAuthoringMode = !IsFormAuthoringMode;
         });
         ToggleTypewriterModeCommand = ReactiveCommand.Create(ToggleTypewriterMode);
+        DiscardPendingTypewriterEditsCommand = ReactiveCommand.Create(DiscardPendingTypewriterEdits);
+        GoToNextPendingTypewriterEditCommand = ReactiveCommand.Create(GoToNextPendingTypewriterEdit);
         AddHighlightAnnotationFromSelectionCommand = ReactiveCommand.CreateFromTask(AddHighlightAnnotationFromSelectionAsync);
         AddStickyNoteAnnotationCommand = ReactiveCommand.CreateFromTask(() => AddStickyNoteAnnotationAsync());
         ToggleOutlineCommand = ReactiveCommand.Create(ToggleOutlineSidebar);

--- a/Excise.App/ViewModels/MainWindowViewModel.Typewriter.cs
+++ b/Excise.App/ViewModels/MainWindowViewModel.Typewriter.cs
@@ -138,11 +138,61 @@ public partial class MainWindowViewModel
         RefreshTypewriterEditState();
     }
 
+    /// <summary>
+    /// True while any type-over edit is pending (with text). Drives the
+    /// discard / next-edit affordances so a user can never lose track of
+    /// edits that would otherwise flatten silently on the next save (#780).
+    /// </summary>
+    public bool HasPendingTypewriterEdits => FileState.TypewriterEditsCount > 0;
+
+    /// <summary>
+    /// The ONLY non-saving way to clear pending type-over edits (#780).
+    /// Exiting typewriter mode deliberately does NOT discard — that was the
+    /// surprising silent-loss path — so this explicit, user-invoked command
+    /// is the sanctioned "I changed my mind" exit.
+    /// </summary>
+    public void DiscardPendingTypewriterEdits()
+    {
+        if (TypewriterTextOperations.Count == 0)
+            return;
+
+        var discarded = TypewriterTextOperations.Count;
+        ClearPendingTypewriterText();
+        _logger.LogInformation("Discarded {Count} pending typewriter edit(s)", discarded);
+    }
+
+    /// <summary>
+    /// Navigate to the next page that carries a pending type-over edit (#780).
+    /// Off-page pending edits are otherwise invisible — the layer only renders
+    /// ops on the current page — yet they still flatten on save. This lets a
+    /// user reach every one before committing. Cyclic, starting after the
+    /// current page.
+    /// </summary>
+    public void GoToNextPendingTypewriterEdit()
+    {
+        var pages = TypewriterTextOperations
+            .Where(o => o.IsPending && o.HasText)
+            .Select(o => o.PageNumber)
+            .Distinct()
+            .OrderBy(p => p)
+            .ToList();
+        if (pages.Count == 0)
+            return;
+
+        var current = CurrentPage; // 1-based
+        var next = pages.FirstOrDefault(p => p > current);
+        if (next == 0)
+            next = pages[0]; // wrap around
+
+        CurrentPageIndex = Math.Clamp(next - 1, 0, Math.Max(0, TotalPages - 1));
+    }
+
     private void RefreshTypewriterEditState()
     {
         FileState.TypewriterEditsCount = TypewriterTextOperations.Count(o => o.IsPending && o.HasText);
         this.RaisePropertyChanged(nameof(SaveButtonText));
         this.RaisePropertyChanged(nameof(StatusBarText));
+        this.RaisePropertyChanged(nameof(HasPendingTypewriterEdits));
     }
 
     private async Task ReloadPdfCoreDocumentAfterSaveAsync(string filePath)

--- a/Excise.App/Views/MacNativeMenuBuilder.cs
+++ b/Excise.App/Views/MacNativeMenuBuilder.cs
@@ -53,6 +53,8 @@ internal static class MacNativeMenuBuilder
         private readonly NativeMenuItem _recentFilesItem;
         private readonly NativeMenuItem _selectTextItem;
         private readonly NativeMenuItem _typewriterItem;
+        private readonly NativeMenuItem _typewriterNextEditItem;
+        private readonly NativeMenuItem _typewriterDiscardItem;
         private readonly NativeMenuItem _redactionModeItem;
         private readonly NativeMenuItem _viewClipboardItem;
         private readonly NativeMenuItem _redactionClipboardItem;
@@ -70,6 +72,10 @@ internal static class MacNativeMenuBuilder
             _recentFilesItem = Submenu("Open Recent");
             _selectTextItem = CommandItem("Select Text Mode", _viewModel.ToggleTextSelectionModeCommand, Key.T);
             _typewriterItem = CommandItem("Typewriter Mode", _viewModel.ToggleTypewriterModeCommand);
+            // #780: keep the discard / next-pending-edit affordances reachable on
+            // macOS's native menu, not just the in-window AXAML menu.
+            _typewriterNextEditItem = CommandItem("Go to Next Pending Type-over Edit", _viewModel.GoToNextPendingTypewriterEditCommand);
+            _typewriterDiscardItem = CommandItem("Discard Pending Type-over Edits", _viewModel.DiscardPendingTypewriterEditsCommand);
             _redactionModeItem = CommandItem("Redaction Mode", _viewModel.ToggleRedactionModeCommand, Key.R, modifiers: KeyModifiers.None);
             _viewClipboardItem = ToggleItem("Show Clipboard History", _viewModel.ToggleClipboardSidebarCommand);
             _redactionClipboardItem = ToggleItem("Show Clipboard History", _viewModel.ToggleClipboardSidebarCommand);
@@ -103,6 +109,8 @@ internal static class MacNativeMenuBuilder
                     Separator(),
                     TrackDocumentItem(_selectTextItem),
                     TrackDocumentItem(_typewriterItem),
+                    _typewriterNextEditItem,
+                    _typewriterDiscardItem,
                     TrackTextSelectionItem(CommandItem("Copy Selected Text", _viewModel.CopyTextCommand, Key.C))));
 
             Add(menu,
@@ -199,6 +207,7 @@ internal static class MacNativeMenuBuilder
             or nameof(MainWindowViewModel.CanMoveSelectedPagesLater)
             or nameof(MainWindowViewModel.IsTextSelectionMode)
             or nameof(MainWindowViewModel.IsTypewriterMode)
+            or nameof(MainWindowViewModel.HasPendingTypewriterEdits)
             or nameof(MainWindowViewModel.HasTextSelection)
             or nameof(MainWindowViewModel.IsRedactionMode)
             or nameof(MainWindowViewModel.IsContinuousView)
@@ -233,6 +242,8 @@ internal static class MacNativeMenuBuilder
             _selectTextItem.IsChecked = _viewModel.IsTextSelectionMode;
             _typewriterItem.ToggleType = MenuItemToggleType.CheckBox;
             _typewriterItem.IsChecked = _viewModel.IsTypewriterMode;
+            _typewriterNextEditItem.IsEnabled = isDocumentLoaded && _viewModel.HasPendingTypewriterEdits;
+            _typewriterDiscardItem.IsEnabled = isDocumentLoaded && _viewModel.HasPendingTypewriterEdits;
             _redactionModeItem.ToggleType = MenuItemToggleType.CheckBox;
             _redactionModeItem.IsChecked = _viewModel.IsRedactionMode;
             _continuousScrollItem.ToggleType = MenuItemToggleType.CheckBox;

--- a/Excise.App/Views/MainWindow.axaml
+++ b/Excise.App/Views/MainWindow.axaml
@@ -88,6 +88,17 @@
                         <TextBlock Text="✓" IsVisible="{Binding IsTypewriterMode}"/>
                     </MenuItem.Icon>
                 </MenuItem>
+                <!-- #780: pending type-over edits flatten on save even after leaving
+                     typewriter mode. These affordances make them impossible to lose
+                     silently: reach every off-page edit, or explicitly discard. -->
+                <MenuItem Header="Go to Next Pending Type-over Edit"
+                          Command="{Binding GoToNextPendingTypewriterEditCommand}"
+                          IsEnabled="{Binding HasPendingTypewriterEdits}"
+                          AutomationProperties.Name="Go to next pending type-over edit"/>
+                <MenuItem Header="Discard Pending Type-over Edits"
+                          Command="{Binding DiscardPendingTypewriterEditsCommand}"
+                          IsEnabled="{Binding HasPendingTypewriterEdits}"
+                          AutomationProperties.Name="Discard pending type-over edits"/>
                 <MenuItem Header="_Copy Selected Text" Command="{Binding CopyTextCommand}" InputGesture="Ctrl+C"
                           IsEnabled="{Binding IsTextSelectionMode}"
                           access:CommandAccessibility.CommandId="edit.copyText"/>

--- a/Excise.Avalonia/Controls/PdfViewerControl.Interaction.cs
+++ b/Excise.Avalonia/Controls/PdfViewerControl.Interaction.cs
@@ -172,15 +172,14 @@ public partial class PdfViewerControl
         else if (InteractionMode == InteractionMode.Typewriter)
         {
             var endPoint = GetPressPoint(e);
-            var dipRect = NormalizeTypewriterDipRect(CreateRect(_dragStart, endPoint));
             ClearTemporaryDrawings();
-
-            if (Document != null && dipRect.Width > 4 && dipRect.Height > 4)
-            {
-                var pdfRect = ViewerDipsToPdfRect(dipRect, CurrentPage);
-                TypewriterTextCreated?.Invoke(this,
-                    new TypewriterTextCreatedEventArgs(pdfRect, CurrentPage));
-            }
+            // Click-to-place OR drag-to-size — both land here (#780). A plain
+            // click (start == end) yields a default-sized box at the point;
+            // a real drag yields a box sized to the gesture. The old
+            // `Width > 4 && Height > 4` gate was dead: it ran on the
+            // post-normalize rect, which is never sub-4, so a click already
+            // slipped through — now it is an intentional, documented path.
+            CreateTypewriterTextFromPointer(_dragStart, endPoint);
         }
         else if (InteractionMode == InteractionMode.TextSelection &&
                  _selectionAnchor != null && _selectionFocus != null &&

--- a/Excise.Avalonia/Controls/PdfViewerControl.Typewriter.cs
+++ b/Excise.Avalonia/Controls/PdfViewerControl.Typewriter.cs
@@ -105,6 +105,27 @@ public partial class PdfViewerControl
                     textBox.Text ?? string.Empty,
                     operation.PageNumber));
         };
+        // Esc on the active box (#780). An EMPTY box is removed — the user
+        // backed out before typing, so nothing is lost. A NON-empty box keeps
+        // its typed text (already committed via TextChanged) and only exits
+        // editing focus: Esc must never silently drop text the user entered.
+        textBox.KeyDown += (_, e) =>
+        {
+            if (e.Key != Key.Escape)
+                return;
+
+            if (string.IsNullOrEmpty(textBox.Text))
+            {
+                TypewriterTextDeleted?.Invoke(this,
+                    new TypewriterTextDeletedEventArgs(operation.Id, operation.PageNumber));
+            }
+            else
+            {
+                Focus(); // blur the editor, keep the text
+            }
+
+            e.Handled = true;
+        };
         Grid.SetRow(textBox, 1);
         shell.Children.Add(textBox);
 
@@ -317,7 +338,29 @@ public partial class PdfViewerControl
         return false;
     }
 
-    private Rect NormalizeTypewriterDipRect(Rect rect)
+    /// <summary>
+    /// Places a pending type-over box from a pointer gesture and raises
+    /// <see cref="TypewriterTextCreated"/>. A plain click (start == end, or a
+    /// sub-4-DIP drag) places a DEFAULT-sized box at the press point; a larger
+    /// drag places a box sized to the drag (#780). <see
+    /// cref="NormalizeTypewriterDipRect"/> substitutes the default size for
+    /// sub-4 dimensions and clamps the box onto the page, so there is no
+    /// "drag &gt; 4 DIPs" gate here — click-to-place is a first-class path.
+    /// Internal so the pointer-driven creation path is unit-testable without
+    /// synthesising raw pointer events (#780 test gap).
+    /// </summary>
+    internal void CreateTypewriterTextFromPointer(Point start, Point end)
+    {
+        if (Document == null)
+            return;
+
+        var dipRect = NormalizeTypewriterDipRect(CreateRect(start, end));
+        var pdfRect = ViewerDipsToPdfRect(dipRect, CurrentPage);
+        TypewriterTextCreated?.Invoke(this,
+            new TypewriterTextCreatedEventArgs(pdfRect, CurrentPage));
+    }
+
+    internal Rect NormalizeTypewriterDipRect(Rect rect)
     {
         if (Document == null || CurrentPage < 1 || CurrentPage > Document.PageCount)
         {
@@ -342,7 +385,7 @@ public partial class PdfViewerControl
         return new Rect(left, top, width, height);
     }
 
-    private PdfRectangle ViewerDipsToPdfRect(Rect dipRect, int pageNumber)
+    internal PdfRectangle ViewerDipsToPdfRect(Rect dipRect, int pageNumber)
     {
         if (Document == null || pageNumber < 1 || pageNumber > Document.PageCount)
             return new PdfRectangle(0, 0, 0, 0);
@@ -354,7 +397,7 @@ public partial class PdfViewerControl
             .Normalize();
     }
 
-    private Rect PdfRectToViewerDips(PdfRectangle pdfRect, int pageNumber)
+    internal Rect PdfRectToViewerDips(PdfRectangle pdfRect, int pageNumber)
     {
         if (Document == null || pageNumber < 1 || pageNumber > Document.PageCount)
             return default;


### PR DESCRIPTION
Fixes #780.

Audit of the type-over (typewriter) feature surfaced real workflow-soundness bugs, not just missing tests. This makes pending edits impossible to lose silently and closes the untested coordinate/pointer paths.

## Data-integrity fixes (non-destructive)
- **No silent loss on mode-exit.** Exiting typewriter mode no longer discards pending edits (that was correct) but they were invisible after exit and baked in on the next save. The pending-edit count already surfaces in the status bar mode-independently (`StatusBarText`); added an explicit **"Discard Pending Type-over Edits"** command — the *only* non-saving way to clear them. Flatten-on-save is unchanged (correct).
- **Off-page edits reachable.** Pending ops on non-current pages are never drawn yet still flatten. Added **"Go to Next Pending Type-over Edit"** (cyclic navigation) so every edit can be seen before saving.
- **Esc semantics** (my call, per issue): on the active box, **empty → remove**; **non-empty → keep the typed text and blur** (Esc must never drop typed text). No auto-discard on mode-exit.
- **Click-to-place.** A plain click now places a default-sized box; drag still sizes it. The old `Width > 4 && Height > 4` gate was **dead code** (it ran on the post-normalize rect, which is never sub-4) — replaced with an explicit, documented click/drag path.

Both new commands are wired into the AXAML menu **and** the macOS native menu (`MacNativeMenuBuilder`, which hand-lists items) so they're reachable on the release-gate platform.

## Test coverage (headless GUI)
- **Real pointer click** drives `MouseDown`+`MouseUp` (no drag) through the full `PointerPressed → PointerReleased → CreateTypewriterTextFromPointer → TypewriterTextCreated → VM` pipeline and asserts a box is placed (the headline bug's regression guard — the prior tests all called `vm.OnTypewriterTextCreated` directly).
- **DIP↔PDF** click/drag mapping, Y-flip, round-trip **at /Rotate 0/90/180/270**, and page clamp (direct control tests via internal seams).
- **Permission re-check on create** (`OnTypewriterTextCreated`) via the GUI load path so `_pdfCoreDocument` is set and the permission gate is the real blocker (an earlier draft blocked via the null-guard — a false pass — and was fixed).
- **Esc** empty-remove / non-empty-keep.
- **Mode-exit non-loss** and **discard** verified by reopening the saved PDF (text present after exit+save; absent after discard+save) — excise's in-memory state is not the only oracle.

## Notes / scope
- Move/resize: the regression-prone DIP↔PDF math + clamp is tested; the `RaiseTypewriterBoundsChanged` gesture wrapper is not driven end-to-end (the math is the load-bearing part).
- Wrap-parity (issue "if feasible") deliberately deferred; no divergence observed to file.
- `Excise.Avalonia` change is **internal-only** — `Excise.Avalonia.approved.txt` unchanged (PublicApi approval test green).
- Permission test `Skip`s where the poppler corpus isn't present locally (same as its siblings); it is not standing coverage on such machines.

## Verification
- Full solution build: **0 warnings, 0 errors**.
- New typewriter/permission/accessibility tests: **all green** (35 in the affected filter, incl. the real-click e2e).
- `scripts/test-tier.sh t0`: **all PASS** (build, Core/Cli/Avalonia, doc-claims, gate-asymmetry, redaction-architecture, testdata-sync, skip-budget).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
