### PR TITLE
Verify Type0/Identity-H RTL redaction with independent oracles (#632)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,24 @@ semantic versioning.
   logical order (segments reverse, the number stays put), so RTL content that
   contains numbers is searchable and redactable. Verified against the Unicode
   Bidi Algorithm (UAX #9) reference, not against excise itself.
+
+### Security
+- **RTL redaction in Type0/Identity-H (CID) Arabic/Hebrew fonts verified with
+  independent oracles** (#632) — the redaction-critical case where the content
+  stream carries the word only as 2-byte CIDs (glyph indices), so the Unicode
+  string never appears in the file and a saved-bytes search — even UTF-16BE —
+  is structurally blind to it. Added fixtures embedding a real font that paint
+  the word in visual (reversed) order and drive `RedactText` with a
+  logical-order needle, asserted with the two mandated non-excise oracles:
+  mutool independent extraction (word present before, unrecoverable after) and
+  a Ghostscript ink differential over the word's region (blank after removal,
+  not merely covered). Confirms logical→visual matching and true glyph removal
+  in the CID path; a keep-word guards against blanking the page. Also pins, as
+  a measured limitation, the whole-line bidi gap for mixed-direction lines
+  (per-word RTL redaction works; a phrase spanning a direction change on an
+  RTL-base line is not matched) — split to #785. No engine behaviour changed;
+  the existing bidi reorder already covered these cases and this locks them
+  under independent verification.
 - **Type0/CID horizontal advance now scales `Tc`/`Tw` by `Th`** (#734) — for
   Type0 fonts the character/word-spacing contributions were applied outside the
   horizontal-scaling factor (`Th`), drifting extracted glyph positions on text

--- a/Excise.Core.Tests/Text/RtlType0ExtractionTests.cs
+++ b/Excise.Core.Tests/Text/RtlType0ExtractionTests.cs
@@ -1,0 +1,232 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using AwesomeAssertions;
+using Excise.Core.Document;
+using Excise.Core.Fonts;
+using Excise.Core.Text.Segmentation;
+using Excise.Core.Tests.Fixtures;
+using Xunit;
+
+namespace Excise.Core.Tests.Text;
+
+/// <summary>
+/// RTL (Arabic/Hebrew) extraction and redaction in <b>Type0 / Identity-H</b>
+/// fonts, where the content-stream operands are 2-byte CIDs (glyph indices of
+/// an embedded font), NOT character codes (#632).
+///
+/// This is the redaction-critical CID case CLAUDE.md calls out: a saved-bytes
+/// search — even UTF-16BE — is BLIND to the Arabic string, because the string
+/// never appears in the file as Unicode; only CIDs do. Correctness here can
+/// therefore only be asserted by an extractor (excise's, cross-checked against
+/// mutool in <c>Excise.Rendering.Tests.Differential.RtlType0RedactionDifferentialTests</c>)
+/// and by the glyph-removal render — never by grepping the bytes.
+///
+/// The fixtures embed the real, checked-in DejaVu Sans TTF (which covers both
+/// Hebrew and Arabic base letters) and paint the word's GIDs in VISUAL order
+/// (reversed — the common producer encoding). Expected logical strings are
+/// spec-derived (UAX #9) and corroborated by the python-bidi reference and by
+/// mutool in the differential suite.
+/// </summary>
+public class RtlType0ExtractionTests
+{
+    private const string ArabicWord = "سلام"; // logical
+    private const string HebrewWord = "שלום"; // logical
+
+    private static readonly int[] ArabicScalars = { 0x0633, 0x0644, 0x0627, 0x0645 };
+    private static readonly int[] HebrewScalars = { 0x05E9, 0x05DC, 0x05D5, 0x05DD };
+
+    [Fact]
+    public void Type0IdentityH_VisualOrderArabic_ExtractsLogicalOrder()
+    {
+        var pdf = Type0RtlFixtures.SingleLineVisualOrder(ArabicScalars);
+        using var doc = PdfDocument.Open(pdf);
+
+        doc.GetPage(1).Text.Should().Be(ArabicWord,
+            "a Type0/Identity-H visual-order run must reorder to logical order, exactly as the " +
+            "single-byte path does — the CID encoding must not defeat the bidi reorder");
+    }
+
+    [Fact]
+    public void Type0IdentityH_VisualOrderHebrew_ExtractsLogicalOrder()
+    {
+        var pdf = Type0RtlFixtures.SingleLineVisualOrder(HebrewScalars);
+        using var doc = PdfDocument.Open(pdf);
+
+        doc.GetPage(1).Text.Should().Be(HebrewWord);
+    }
+
+    [Fact]
+    public void Type0IdentityH_DigitIslandLine_ExtractsLogicalOrder()
+    {
+        // Logical "عمر 30 سنة" carried in visual order in a CID font. The
+        // digit-island rule (UAX #9 W4) must survive the CID encoding.
+        int[] visual = { 0x0629, 0x0646, 0x0633, 0x0020, '3', '0', 0x0020, 0x0631, 0x0645, 0x0639 };
+        int[] logical = { 0x0639, 0x0645, 0x0631, 0x0020, '3', '0', 0x0020, 0x0633, 0x0646, 0x0629 };
+        var pdf = Type0RtlFixtures.SingleLine(visual);
+        using var doc = PdfDocument.Open(pdf);
+
+        doc.GetPage(1).Text.Should().Be(Str(logical));
+    }
+
+    [Fact]
+    public void Type0IdentityH_RedactLogicalNeedle_RemovesVisualOrderWord()
+    {
+        var pdf = Type0RtlFixtures.SingleLineVisualOrder(ArabicScalars);
+        using var doc = PdfDocument.Open(pdf);
+
+        var removed = doc.RedactText(ArabicWord);
+
+        removed.Should().BeGreaterThan(0,
+            "a logical-order needle must match the visual-order CID run; 0 matches is the " +
+            "silent-failure mode (excise cannot redact what excise cannot read)");
+        using var reopened = PdfDocument.Open(doc.SaveToBytes());
+        reopened.GetPage(1).Text.Should().NotContain(ArabicWord);
+    }
+
+    /// <summary>
+    /// A line whose paragraph direction is LTR (a Latin label followed by an
+    /// Arabic name) is handled correctly TODAY: the Latin prefix is logically
+    /// and visually first, so within-run RTL reversal alone yields full logical
+    /// order, and a phrase needle spanning the direction change matches.
+    /// Regression guard for that working case.
+    /// </summary>
+    [Fact]
+    public void LtrLabelThenRtlName_ExtractsLogicalOrder_AndSpanningPhraseRedacts()
+    {
+        int[] khalid = { 0x062E, 0x0627, 0x0644, 0x062F }; // خالد
+        var visual = "Name ".Select(c => (int)c).Concat(khalid.Reverse()).ToArray();
+
+        using (var doc = PdfDocument.Open(Type0RtlFixtures.SingleLine(visual)))
+            doc.GetPage(1).Text.Should().Be("Name " + Str(khalid));
+
+        using (var doc = PdfDocument.Open(Type0RtlFixtures.SingleLine(visual)))
+            doc.RedactText(Str(khalid)).Should().BeGreaterThan(0, "per-word redaction");
+
+        using (var doc = PdfDocument.Open(Type0RtlFixtures.SingleLine(visual)))
+            doc.RedactText("Name " + Str(khalid)).Should().BeGreaterThan(0,
+                "a phrase spanning the LTR->RTL boundary matches on an LTR-base line");
+    }
+
+    /// <summary>
+    /// MEASURED LIMITATION (not a silent gap) — whole-line UAX #9 reordering,
+    /// split to #785. On an RTL-BASE line whose logical order ends with an LTR
+    /// word ("عربى hello"), the within-run reorder produces "hello عربى": each
+    /// word is individually logical, but the run order across the line is not
+    /// re-derived (the paragraph-direction resolution UAX #9 P2/P3 + L2 would
+    /// require, and which is genuinely ambiguous from the stream — the two
+    /// logical orders share one visual stream).
+    ///
+    /// The redaction consequence is BOUNDED and pinned here: the individual
+    /// RTL word STILL redacts; only a phrase needle spanning the direction
+    /// change does not match. This test documents the exact boundary so the
+    /// limitation is measured, not discovered later as a surprise.
+    /// </summary>
+    [Fact]
+    public void Limitation_WholeLineUba_RtlBaseTrailingLtr_PerWordRedactsButSpanningPhraseDoesNot()
+    {
+        int[] arabic = { 0x0639, 0x0631, 0x0628, 0x0649 }; // logical first word
+        var visual = "hello ".Select(c => (int)c).Concat(arabic.Reverse()).ToArray();
+        var word = Str(arabic);
+
+        // Extraction is per-run logical, not whole-line logical (see #785).
+        using (var doc = PdfDocument.Open(Type0RtlFixtures.SingleLine(visual)))
+            doc.GetPage(1).Text.Should().Be("hello " + word,
+                "documents the current within-run behaviour; full logical is '" + word + " hello' (#785)");
+
+        // The redaction-critical unit — the individual RTL word — still works.
+        using (var doc = PdfDocument.Open(Type0RtlFixtures.SingleLine(visual)))
+            doc.RedactText(word).Should().BeGreaterThan(0,
+                "per-word RTL redaction is unaffected by the whole-line gap");
+
+        // Only the direction-spanning phrase is missed (bounded, tracked #785).
+        using (var doc = PdfDocument.Open(Type0RtlFixtures.SingleLine(visual)))
+            doc.RedactText(word + " hello").Should().Be(0,
+                "a phrase spanning the RTL->LTR direction change is not matched on an RTL-base " +
+                "line — the whole-line UAX #9 gap tracked as #785; per-word redaction above still works");
+    }
+
+    private static string Str(int[] scalars) =>
+        string.Concat(scalars.Select(c => char.ConvertFromUtf32(c)));
+}
+
+/// <summary>
+/// Builds single-page PDFs with a Type0 / Identity-H CIDFontType2 font that
+/// embeds the checked-in DejaVu Sans TTF. The content stream shows 2-byte GIDs
+/// (looked up from the font's own cmap), and a /ToUnicode CMap maps each GID
+/// back to its scalar — so extraction order is driven purely by the stream's
+/// glyph order and the expected text is known exactly. Binary-safe.
+/// </summary>
+internal static class Type0RtlFixtures
+{
+    private static readonly byte[] Font = TestFontFixtures.LoadDejaVuSansBytes();
+    private static readonly TrueTypeFontFile Ttf = TrueTypeFontFile.Parse(Font);
+
+    /// <summary>The word's scalars are reversed (visual order) then embedded.</summary>
+    public static byte[] SingleLineVisualOrder(int[] logicalScalars) =>
+        SingleLine(logicalScalars.Reverse().ToArray());
+
+    /// <summary>Embed <paramref name="scalarsInStreamOrder"/> as GIDs in exactly that order.</summary>
+    public static byte[] SingleLine(int[] scalarsInStreamOrder)
+    {
+        var gids = scalarsInStreamOrder.Select(GidFor).ToArray();
+        return Build(gids, scalarsInStreamOrder);
+    }
+
+    private static int GidFor(int scalar)
+    {
+        var gid = Ttf.GidForCodepoint(scalar);
+        gid.Should().BeGreaterThan(0, $"DejaVu Sans must map U+{scalar:X4}");
+        return gid;
+    }
+
+    private static byte[] Build(int[] gids, int[] scalars)
+    {
+        var ms = new MemoryStream();
+        var offsets = new long[11];
+        void Ascii(string s) { var b = Encoding.ASCII.GetBytes(s); ms.Write(b, 0, b.Length); }
+        void Obj(int n) => offsets[n] = ms.Length;
+
+        var hex = string.Concat(gids.Select(c => c.ToString("X4")));
+        var content = $"BT /F0 24 Tf 72 700 Td <{hex}> Tj ET";
+
+        var seen = new HashSet<int>();
+        var bf = new StringBuilder();
+        int count = 0;
+        for (int i = 0; i < gids.Length; i++)
+        {
+            if (!seen.Add(gids[i])) continue;
+            bf.Append($"<{gids[i]:X4}> <{scalars[i]:X4}>\n");
+            count++;
+        }
+        var toUni = "/CIDInit /ProcSet findresource begin\n12 dict begin\nbegincmap\n" +
+            "1 begincodespacerange\n<0000> <FFFF>\nendcodespacerange\n" +
+            $"{count} beginbfchar\n{bf}endbfchar\nendcmap\nend end";
+
+        Ascii("%PDF-1.7\n");
+        Obj(1); Ascii("1 0 obj <</Type/Catalog/Pages 2 0 R>> endobj\n");
+        Obj(2); Ascii("2 0 obj <</Type/Pages/Count 1/Kids[3 0 R]>> endobj\n");
+        Obj(3); Ascii("3 0 obj <</Type/Page/Parent 2 0 R/MediaBox[0 0 612 792]" +
+                      "/Resources<</Font<</F0 4 0 R>>>>/Contents 9 0 R>> endobj\n");
+        Obj(4); Ascii("4 0 obj <</Type/Font/Subtype/Type0/BaseFont/Test" +
+                      "/Encoding/Identity-H/DescendantFonts[5 0 R]/ToUnicode 10 0 R>> endobj\n");
+        Obj(5); Ascii("5 0 obj <</Type/Font/Subtype/CIDFontType2/BaseFont/Test" +
+                      "/CIDSystemInfo<</Registry(Adobe)/Ordering(Identity)/Supplement 0>>" +
+                      "/FontDescriptor 6 0 R/DW 1000>> endobj\n");
+        Obj(6); Ascii("6 0 obj <</Type/FontDescriptor/FontName/Test/Flags 4" +
+                      "/FontBBox[0 0 1000 1000]/ItalicAngle 0/Ascent 800/Descent -200" +
+                      "/CapHeight 700/StemV 80/FontFile2 7 0 R>> endobj\n");
+        Obj(7); Ascii($"7 0 obj <</Length {Font.Length}/Length1 {Font.Length}>>\nstream\n");
+        ms.Write(Font, 0, Font.Length); Ascii("\nendstream endobj\n");
+        Obj(9); Ascii($"9 0 obj <</Length {content.Length}>>\nstream\n{content}\nendstream endobj\n");
+        Obj(10); Ascii($"10 0 obj <</Length {toUni.Length}>>\nstream\n{toUni}\nendstream endobj\n");
+
+        var xref = ms.Length;
+        Ascii("xref\n0 11\n0000000000 65535 f \n");
+        for (int i = 1; i <= 10; i++)
+            Ascii(offsets[i] == 0 ? "0000000000 65535 f \n" : offsets[i].ToString("D10") + " 00000 n \n");
+        Ascii($"trailer <</Size 11/Root 1 0 R>>\nstartxref\n{xref}\n%%EOF\n");
+        return ms.ToArray();
+    }
+}

--- a/Excise.Rendering.Tests/Differential/RtlType0RedactionDifferentialTests.cs
+++ b/Excise.Rendering.Tests/Differential/RtlType0RedactionDifferentialTests.cs
@@ -1,0 +1,274 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using AwesomeAssertions;
+using Excise.Core.Document;
+using Excise.Core.Fonts;
+using Excise.Core.Text.Segmentation;
+using Excise.Rendering.Differential;
+using SkiaSharp;
+using Xunit;
+
+namespace Excise.Rendering.Tests.Differential;
+
+/// <summary>
+/// RTL redaction in <b>Type0 / Identity-H</b> (CID) Arabic/Hebrew fonts,
+/// verified with the two INDEPENDENT oracles CLAUDE.md mandates — never with a
+/// saved-bytes search (#632, #606).
+///
+/// This is the case the task singled out: in Identity-H the content-stream
+/// operands are 2-byte CIDs (glyph indices), so the Arabic/Hebrew string is
+/// NEVER present in the file as Unicode — a saved-bytes grep, even UTF-16BE, is
+/// structurally BLIND to it and would report a false green. So correctness is
+/// asserted only by:
+///
+///   1. mutool as an INDEPENDENT EXTRACTOR — it reads the word (via /ToUnicode)
+///      BEFORE redaction (anti-vacuity) and cannot recover it AFTER, in either
+///      order.
+///   2. Ghostscript as an INDEPENDENT RENDERER — an ink differential over the
+///      word's region. Redaction is driven with drawBlackRect:false, so the
+///      region must come back BLANK (glyphs REMOVED), not black (merely
+///      covered) — the strictly stronger result.
+///
+/// The redaction is driven through RedactText(logicalWord) — the logical→visual
+/// bidi MATCHING is the deliverable, and RedactArea(box) would sidestep it.
+///
+/// Fixtures embed the checked-in DejaVu Sans TTF (covers Hebrew + Arabic base
+/// letters) and paint the word's GIDs in visual (reversed) order.
+/// </summary>
+public class RtlType0RedactionDifferentialTests : IDisposable
+{
+    private const string ArabicWord = "سلام"; // logical
+    private const string HebrewWord = "שלום"; // logical
+    private const string Keep = "KEEP";
+
+    private static readonly int[] ArabicScalars = { 0x0633, 0x0644, 0x0627, 0x0645 };
+    private static readonly int[] HebrewScalars = { 0x05E9, 0x05DC, 0x05D5, 0x05DD };
+
+    private readonly List<string> _temp = new();
+
+    [Theory]
+    [InlineData("arabic")]
+    [InlineData("hebrew")]
+    public void Type0Rtl_Redaction_LeavesNoTextForAnIndependentExtractor(string which)
+    {
+        Assert.SkipUnless(MutoolReferenceRenderer.IsAvailable, "mutool not installed");
+        var (scalars, word) = which == "arabic"
+            ? (ArabicScalars, ArabicWord) : (HebrewScalars, HebrewWord);
+
+        var beforePath = SaveTemp(Type0RtlFixture.VisualOrderWithKeep(scalars));
+
+        // Oracle sanity / anti-vacuity: mutool reads the word from the CID
+        // fixture BEFORE we redact — so its absence afterwards means something.
+        var before = MutoolTextExtractor.ExtractPage(beforePath, 1);
+        before.Should().NotBeNull("mutool must read the fixture");
+        before!.Should().Contain(word,
+            "anti-vacuity: an independent extractor recovers the word from the unredacted CID fixture");
+        before.Should().Contain(Keep, "the keep word is present too");
+
+        using var doc = PdfDocument.Open(Type0RtlFixture.VisualOrderWithKeep(scalars));
+        var removed = doc.RedactText(word, drawBlackRect: false);
+        removed.Should().BeGreaterThan(0,
+            "a logical-order needle must match the visual-order CID run");
+
+        var afterPath = SaveTemp(doc.SaveToBytes());
+        var after = MutoolTextExtractor.ExtractPage(afterPath, 1);
+        after.Should().NotBeNull("mutool must still read the redacted file");
+        after!.Should().NotContain(word, "the word must be gone from every text carrier mutool reads");
+        after.Should().NotContain(Reverse(word), "nor in visual (reversed) order");
+        after.Should().Contain(Keep, "only the targeted word may be removed, not the whole page");
+    }
+
+    [Theory]
+    [InlineData("arabic")]
+    [InlineData("hebrew")]
+    public void Type0Rtl_Redaction_RemovesInk_NotMerelyCoversIt(string which)
+    {
+        Assert.SkipUnless(GhostscriptReferenceRenderer.IsAvailable, "ghostscript not installed");
+        var (scalars, word) = which == "arabic"
+            ? (ArabicScalars, ArabicWord) : (HebrewScalars, HebrewWord);
+
+        using var doc = PdfDocument.Open(Type0RtlFixture.VisualOrderWithKeep(scalars));
+        var page = doc.GetPage(1);
+        var wordBox = BoundsOf(page, word);
+        var keepBox = BoundsOf(page, Keep);
+
+        var beforePath = SaveTemp(doc);
+        using var before = GhostscriptReferenceRenderer.RenderPage(beforePath, 1, dpi: 150);
+        before.Should().NotBeNull();
+        InkFractionIn(before!, wordBox, page.Height).Should().BeGreaterThan(0.02,
+            "fixture sanity — the RTL word must actually be inked before redaction");
+
+        // drawBlackRect:false ⇒ structural removal only. The region must come
+        // back BLANK, proving the glyphs are GONE, not covered by a box.
+        var removed = doc.RedactText(word, drawBlackRect: false);
+        removed.Should().BeGreaterThan(0);
+
+        var afterPath = SaveTemp(doc);
+        using var after = GhostscriptReferenceRenderer.RenderPage(afterPath, 1, dpi: 150);
+        after.Should().NotBeNull();
+
+        InkFractionIn(after!, wordBox, page.Height).Should().BeLessThan(0.001,
+            "an independent renderer must draw NO ink where the CID word was — blank, not a black " +
+            "box; surviving ink would mean the glyphs were covered, not removed");
+        InkFractionIn(after!, keepBox, page.Height).Should().BeGreaterThan(0.02,
+            "the untargeted word must still be inked — a blanked page would satisfy the assertion above");
+    }
+
+    // ---- ink helper (PDF content coords, bottom-left origin) ----
+    private static double InkFractionIn(SKBitmap bmp, PdfRectangle box, double pageHeight)
+    {
+        const double scale = 150.0 / 72.0;
+        int x0 = Math.Max(0, (int)(box.Left * scale));
+        int x1 = Math.Min(bmp.Width - 1, (int)(box.Right * scale));
+        int y0 = Math.Max(0, (int)((pageHeight - box.Top) * scale));
+        int y1 = Math.Min(bmp.Height - 1, (int)((pageHeight - box.Bottom) * scale));
+        if (x1 <= x0 || y1 <= y0) return 0;
+
+        int ink = 0, total = 0;
+        for (int y = y0; y <= y1; y++)
+        for (int x = x0; x <= x1; x++)
+        {
+            var p = bmp.GetPixel(x, y);
+            total++;
+            if (p.Red < 200 || p.Green < 200 || p.Blue < 200) ink++;
+        }
+        return total == 0 ? 0 : (double)ink / total;
+    }
+
+    private static PdfRectangle BoundsOf(PdfPage page, string word)
+    {
+        // The word's letters, on its own line; union their glyph rectangles.
+        var run = page.Letters
+            .Where(l => word.Contains(l.Value, StringComparison.Ordinal))
+            .ToList();
+        run.Should().NotBeEmpty($"fixture must render '{word}'");
+        var y = run[0].GlyphRectangle.Bottom;
+        var line = page.Letters
+            .Where(l => Math.Abs(l.GlyphRectangle.Bottom - y) < 2.0 &&
+                        word.Contains(l.Value, StringComparison.Ordinal))
+            .ToList();
+        return new PdfRectangle(
+            line.Min(l => l.GlyphRectangle.Left) - 1,
+            line.Min(l => l.GlyphRectangle.Bottom) - 1,
+            line.Max(l => l.GlyphRectangle.Right) + 1,
+            line.Max(l => l.GlyphRectangle.Top) + 1).Normalize();
+    }
+
+    private static string Reverse(string s)
+    {
+        var c = s.ToCharArray();
+        Array.Reverse(c);
+        return new string(c);
+    }
+
+    private string SaveTemp(PdfDocument doc) => SaveTemp(doc.SaveToBytes());
+    private string SaveTemp(byte[] bytes)
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"rtl-type0-{Guid.NewGuid():N}.pdf");
+        File.WriteAllBytes(path, bytes);
+        _temp.Add(path);
+        return path;
+    }
+
+    public void Dispose()
+    {
+        foreach (var p in _temp)
+            try { File.Delete(p); } catch (IOException) { }
+    }
+}
+
+/// <summary>
+/// Type0 / Identity-H CIDFontType2 fixture embedding the checked-in DejaVu Sans
+/// TTF. Line 1 carries the RTL word's GIDs in visual (reversed) order; line 2
+/// carries an LTR "KEEP" word. A /ToUnicode CMap maps each GID back to its
+/// scalar. The Arabic/Hebrew string appears in the file ONLY as CIDs — never as
+/// Unicode — which is exactly why saved-bytes search cannot verify redaction.
+/// </summary>
+internal static class Type0RtlFixture
+{
+    private static readonly byte[] FontBytes = LoadDejaVu();
+    private static readonly TrueTypeFontFile Ttf = TrueTypeFontFile.Parse(FontBytes);
+
+    private static byte[] LoadDejaVu()
+    {
+        // Resolve the checked-in font by walking up from the test bin directory
+        // to the repo root and reading the shared Core.Tests fixture copy.
+        var dir = AppContext.BaseDirectory;
+        for (var d = new DirectoryInfo(dir); d != null; d = d.Parent)
+        {
+            var candidate = Path.Combine(d.FullName, "Excise.Core.Tests", "Fixtures", "Fonts", "DejaVuSans.ttf");
+            if (File.Exists(candidate)) return File.ReadAllBytes(candidate);
+        }
+        throw new FileNotFoundException("DejaVuSans.ttf fixture not found by walking up from " + dir);
+    }
+
+    public static byte[] VisualOrderWithKeep(int[] logicalRtlScalars)
+    {
+        var rtlVisual = logicalRtlScalars.Reverse().ToArray();
+        int[] keep = "KEEP".Select(c => (int)c).ToArray();
+
+        var rtlGids = rtlVisual.Select(GidFor).ToArray();
+        var keepGids = keep.Select(GidFor).ToArray();
+
+        var line1 = $"BT /F0 24 Tf 72 700 Td <{Hex(rtlGids)}> Tj ET";
+        var line2 = $"BT /F0 24 Tf 72 600 Td <{Hex(keepGids)}> Tj ET";
+        var content = line1 + "\n" + line2;
+
+        var pairs = new List<(int gid, int scalar)>();
+        for (int i = 0; i < rtlGids.Length; i++) pairs.Add((rtlGids[i], rtlVisual[i]));
+        for (int i = 0; i < keepGids.Length; i++) pairs.Add((keepGids[i], keep[i]));
+
+        var seen = new HashSet<int>();
+        var bf = new StringBuilder();
+        int count = 0;
+        foreach (var (gid, scalar) in pairs)
+        {
+            if (!seen.Add(gid)) continue;
+            bf.Append($"<{gid:X4}> <{scalar:X4}>\n");
+            count++;
+        }
+        var toUni = "/CIDInit /ProcSet findresource begin\n12 dict begin\nbegincmap\n" +
+            "1 begincodespacerange\n<0000> <FFFF>\nendcodespacerange\n" +
+            $"{count} beginbfchar\n{bf}endbfchar\nendcmap\nend end";
+
+        var ms = new MemoryStream();
+        var offsets = new long[11];
+        void Ascii(string s) { var b = Encoding.ASCII.GetBytes(s); ms.Write(b, 0, b.Length); }
+        void Obj(int n) => offsets[n] = ms.Length;
+
+        Ascii("%PDF-1.7\n");
+        Obj(1); Ascii("1 0 obj <</Type/Catalog/Pages 2 0 R>> endobj\n");
+        Obj(2); Ascii("2 0 obj <</Type/Pages/Count 1/Kids[3 0 R]>> endobj\n");
+        Obj(3); Ascii("3 0 obj <</Type/Page/Parent 2 0 R/MediaBox[0 0 612 792]" +
+                      "/Resources<</Font<</F0 4 0 R>>>>/Contents 9 0 R>> endobj\n");
+        Obj(4); Ascii("4 0 obj <</Type/Font/Subtype/Type0/BaseFont/Test" +
+                      "/Encoding/Identity-H/DescendantFonts[5 0 R]/ToUnicode 10 0 R>> endobj\n");
+        Obj(5); Ascii("5 0 obj <</Type/Font/Subtype/CIDFontType2/BaseFont/Test" +
+                      "/CIDSystemInfo<</Registry(Adobe)/Ordering(Identity)/Supplement 0>>" +
+                      "/FontDescriptor 6 0 R/DW 1000>> endobj\n");
+        Obj(6); Ascii("6 0 obj <</Type/FontDescriptor/FontName/Test/Flags 4" +
+                      "/FontBBox[0 0 1000 1000]/ItalicAngle 0/Ascent 800/Descent -200" +
+                      "/CapHeight 700/StemV 80/FontFile2 7 0 R>> endobj\n");
+        Obj(7); Ascii($"7 0 obj <</Length {FontBytes.Length}/Length1 {FontBytes.Length}>>\nstream\n");
+        ms.Write(FontBytes, 0, FontBytes.Length); Ascii("\nendstream endobj\n");
+        Obj(9); Ascii($"9 0 obj <</Length {content.Length}>>\nstream\n{content}\nendstream endobj\n");
+        Obj(10); Ascii($"10 0 obj <</Length {toUni.Length}>>\nstream\n{toUni}\nendstream endobj\n");
+
+        var xref = ms.Length;
+        Ascii("xref\n0 11\n0000000000 65535 f \n");
+        for (int i = 1; i <= 10; i++)
+            Ascii(offsets[i] == 0 ? "0000000000 65535 f \n" : offsets[i].ToString("D10") + " 00000 n \n");
+        Ascii($"trailer <</Size 11/Root 1 0 R>>\nstartxref\n{xref}\n%%EOF\n");
+        return ms.ToArray();
+    }
+
+    private static int GidFor(int scalar)
+    {
+        var gid = Ttf.GidForCodepoint(scalar);
+        if (gid <= 0) throw new InvalidOperationException($"DejaVu Sans lacks U+{scalar:X4}");
+        return gid;
+    }
+
+    private static string Hex(int[] gids) => string.Concat(gids.Select(g => g.ToString("X4")));
+}


### PR DESCRIPTION
## Summary
Narrowed core of #632 (RTL/bidi redaction-**correctness**). Method was fixtures-first: build the required Arabic/Hebrew fixtures, run them against the current engine, implement only what fails.

**Finding: the redaction-critical core already works.** Prior slices (#766 digit islands, #373 RTL selection, earlier #632 per-run reorder + Arabic presentation-form folding) already give correct logical-order extraction, search, and glyph removal — including in the **Type0/Identity-H (CID)** path and on LTR-base mixed lines. So no `BidiReorderer`/`TextExtractor` change was needed. What was **missing was independent-oracle coverage of the CID case**, which this PR adds.

Why the CID case matters (task's crux): in Identity-H the content-stream operands are 2-byte glyph indices, so the Arabic/Hebrew string never appears in the file as Unicode — a saved-bytes search (even UTF-16BE) is structurally **blind** to it and would give a false green. Correctness can only be asserted by a non-excise extractor and a non-excise renderer.

## What's added (tests only)
- **`RtlType0ExtractionTests`** (Core) — logical-order extraction + `RedactText` matching for Arabic, Hebrew, and a digit-island line in an embedded `CIDFontType2`/Identity-H font (real DejaVu Sans, GIDs painted visual-order). Plus a regression guard for the working LTR-label+RTL-name case.
- **`RtlType0RedactionDifferentialTests`** (Rendering.Differential) — the two CLAUDE.md oracles: **mutool** independent extraction (word present before, unrecoverable after) and a **Ghostscript** ink differential (region **blank** after removal, not merely covered), driving `RedactText(logicalWord, drawBlackRect:false)`. A keep-word guards against blanking the page.

## Split to follow-up (#785)
Whole-line UAX #9 reordering (paragraph direction P2/P3 + L2) for mixed-direction lines — genuinely ambiguous from the stream (logical `"عربى hello"` and `"hello عربى"` share one visual stream) and the multi-week UBA the task said to avoid. **Per-word RTL redaction is unaffected**; only a phrase spanning a direction change on an RTL-base line is missed. Pinned as a *measured* limitation in `RtlType0ExtractionTests.Limitation_WholeLineUba_*`.

## Verification
- Reordering expectations cross-checked against the **python-bidi** UAX #9 reference.
- `check-extraction-parity.sh`: **green, 332 pages, 98.7%** (extraction untouched).
- `test-tier.sh t0`: all PASS. `verify-true-redaction.sh`: PASS. Core `~Redaction` suite: 190 passed / 4 skipped.
- No public API added — `Excise.Core.approved.txt` unchanged. Build 0 warnings.

Closes part of #632; follow-up #785.

🤖 Generated with [Claude Code](https://claude.com/claude-code)