### PR TITLE
test: type-over move/resize-handle and wrap-parity coverage (#780)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ semantic versioning.
 
 ## [Unreleased]
 
+### Added
+- **Type-over tool: move/resize-handle and wrap-parity test coverage** (#780) —
+  closed the two coverage gaps left after the type-over workflow work. A
+  control-level headless test drives a real routed pointer gesture
+  (press → move → release) on the editor's move handle and resize grip and
+  asserts the `TypewriterTextBoundsChanged` PDF bounds reflect the drag (move:
+  position shifts, size preserved; resize: size grows, the anchored corner is
+  fixed). A wrap-parity test compares the on-screen editor `TextBox` wrapping
+  (Avalonia `TextWrapping.Wrap`) against the flattened PDF output (Skia +
+  base-14 metrics) via save/reopen/extract, asserting both wrap to multiple
+  lines, all words survive in reading order, and the line counts agree within
+  ±1 (observed 4 vs 4 exactly).
+
 ### Fixed
 - **Typewriter (type-over) workflow: pending edits can no longer be lost or
   flattened unseen** (#780) — pending type-over edits used to persist silently

--- a/Excise.App.Tests/Controls/PdfViewerControlTypewriterTests.cs
+++ b/Excise.App.Tests/Controls/PdfViewerControlTypewriterTests.cs
@@ -168,6 +168,168 @@ public class PdfViewerControlTypewriterTests
         await RunEscapeCase(initialText: "typed content", expectDeleted: false);
     }
 
+    // #780: the move-handle and resize-grip pointer gestures raise
+    // TypewriterTextBoundsChanged with PDF-mapped bounds, but the whole
+    // handler → RaiseTypewriterBoundsChanged → DIP↔PDF path had no coverage.
+    // These drive a real routed pointer gesture (press → move → release) on the
+    // handle Border found in the visual tree and assert the reported PDF bounds
+    // reflect the drag. The move/resize handlers report pointer positions
+    // relative to the TypewriterLayer, so we raise the events with
+    // rootVisual == that same Canvas: GetPosition(layer) is then an identity
+    // transform and the handlers observe exactly the delta we inject. The
+    // control must be hosted in a shown Window first — an identity transform
+    // still requires the Canvas to be attached to a visual root, or
+    // GetPosition collapses to (0,0) and no gesture is seen.
+    [FixedAvaloniaFact]
+    public async Task DragMoveHandle_ShiftsPdfPosition_AndPreservesSize()
+    {
+        // Drag the move handle by (+30, +24) DIP. The exact DIP→PDF scale
+        // depends on the preview render DPI/zoom the control chose for the host
+        // window, so the precise magnitude is checked against `expected` —
+        // computed at gesture time by mapping the shell's actual moved DIP
+        // position through the same conversion the event uses. Independently, we
+        // assert the box really shifted (right + down, PDF Y flipped) and kept
+        // its size — neither of which depends on the scale.
+        var (original, changed, expected) = await RunHandleDragCase(
+            pick: shell => FindBorder(shell, b => Math.Abs(b.Height - 10) < 0.5),
+            deltaDip: new Point(30, 24));
+
+        changed.Should().NotBeNull("releasing the move handle must raise TypewriterTextBoundsChanged");
+        var r = changed!.Rect;
+
+        r.Width.Should().BeApproximately(original.Width, 2.0, "a move preserves the box size");
+        r.Height.Should().BeApproximately(original.Height, 2.0);
+        r.Left.Should().BeGreaterThan(original.Left + 10, "a rightward drag moves the PDF box right");
+        r.Bottom.Should().BeLessThan(original.Bottom - 8, "a downward DIP drag lowers PDF Y (flip)");
+        r.Left.Should().BeApproximately(expected.Left, 1.0, "the reported bounds equal the mapped moved position");
+        r.Bottom.Should().BeApproximately(expected.Bottom, 1.0);
+    }
+
+    [FixedAvaloniaFact]
+    public async Task DragResizeGrip_ChangesPdfSize_AndPreservesAnchoredCorner()
+    {
+        // Grow via the bottom-right grip by (+40, +40) DIP = (+24, +24) PDF pts.
+        // The DIP top-left corner is anchored, which in PDF is (Left, Top).
+        var (original, changed, expected) = await RunHandleDragCase(
+            pick: shell => FindBorder(shell, b => Math.Abs(b.Width - 12) < 0.5 && Math.Abs(b.Height - 12) < 0.5),
+            deltaDip: new Point(40, 40));
+
+        changed.Should().NotBeNull("releasing the resize grip must raise TypewriterTextBoundsChanged");
+        var r = changed!.Rect;
+
+        r.Left.Should().BeApproximately(original.Left, 3.0, "the anchored top-left corner's Left is fixed");
+        r.Top.Should().BeApproximately(original.Top, 3.0, "the anchored top-left corner's Top is fixed");
+        r.Width.Should().BeGreaterThan(original.Width + 15, "growing the grip widens the PDF box");
+        r.Height.Should().BeGreaterThan(original.Height + 15, "growing the grip heightens the PDF box");
+        r.Width.Should().BeApproximately(expected.Width, 1.0, "the reported bounds equal the mapped resized box");
+        r.Height.Should().BeApproximately(expected.Height, 1.0);
+    }
+
+    // Hosts the control in a shown Window (so the overlay Canvas is attached and
+    // GetPosition resolves), seeds one on-page pending box, runs the pointer
+    // gesture on the picked handle, and returns the seeded bounds plus the
+    // bounds-changed event raised on release.
+    private static async Task<(PdfRectangle original, TypewriterTextBoundsChangedEventArgs? changed, PdfRectangle expected)> RunHandleDragCase(
+        Func<Control, Border> pick, Point deltaDip)
+    {
+        var original = new PdfRectangle(60, 150, 200, 250); // w=140, h=100, on a 300x400 page
+        PdfCoreDocument? doc = null;
+        PdfViewerControl control = null!;
+        Window window = null!;
+        TypewriterTextBoundsChangedEventArgs? changed = null;
+        PdfRectangle expected = default;
+
+        await Dispatcher.UIThread.InvokeAsync(() =>
+        {
+            doc = NewSinglePage(300, 400);
+            control = NewTypewriterControl(doc);
+            control.TypewriterTextBoundsChanged += (_, e) => changed = e;
+            window = new Window { Content = control, Width = 700, Height = 800 };
+            window.Show();
+        });
+
+        // Wait for the overlay Canvas to attach and lay out before injecting the
+        // gesture (the identity transform needs a live visual root).
+        Canvas? layer = null;
+        var deadline = DateTime.UtcNow.AddSeconds(10);
+        while (DateTime.UtcNow < deadline)
+        {
+            await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                window.UpdateLayout();
+                layer = control.FindControl<Canvas>("TypewriterLayer");
+            });
+            if (layer is not null && layer.IsAttachedToVisualTree())
+                break;
+            await Task.Delay(100);
+        }
+
+        await Dispatcher.UIThread.InvokeAsync(() =>
+        {
+            control.TypewriterTextOperations = new[]
+            {
+                PdfTypewriterTextOperation.Create(1, original, "handle"),
+            };
+            window.UpdateLayout();
+
+            var currentLayer = control.FindControl<Canvas>("TypewriterLayer")!;
+            currentLayer.IsAttachedToVisualTree().Should().BeTrue("the overlay must be attached for the gesture");
+
+            var shell = currentLayer.GetVisualDescendants().OfType<Grid>().First();
+            var handle = pick(shell);
+            RaiseHandleDrag(currentLayer, handle, deltaDip);
+
+            // The gesture leaves the shell at its final DIP geometry; map it the
+            // same way RaiseTypewriterBoundsChanged does so the reported bounds
+            // can be checked without hard-coding the preview DPI/zoom scale.
+            var finalRect = new Rect(
+                Canvas.GetLeft(shell), Canvas.GetTop(shell), shell.Width, shell.Height);
+            expected = control.ViewerDipsToPdfRect(
+                control.NormalizeTypewriterDipRect(finalRect), 1);
+        });
+
+        await Dispatcher.UIThread.InvokeAsync(() =>
+        {
+            window.Close();
+            doc?.Dispose();
+        });
+
+        return (original, changed, expected);
+    }
+
+    private static Border FindBorder(Control shell, Func<Border, bool> predicate)
+    {
+        var border = shell.GetVisualDescendants().OfType<Border>().FirstOrDefault(predicate);
+        border.Should().NotBeNull("the target handle Border must be in the editor visual tree");
+        return border!;
+    }
+
+    // Press → move → release on <paramref name="handle"/>, reporting pointer
+    // positions relative to <paramref name="layer"/>. rootVisual == layer makes
+    // GetPosition(layer) an identity, so the injected delta is exactly what the
+    // move/resize handlers observe (they are delta-based off the press point, so
+    // the absolute press position is irrelevant).
+    private static void RaiseHandleDrag(Canvas layer, Border handle, Point deltaDip)
+    {
+        var pointer = new Pointer(Pointer.GetNextFreeId(), PointerType.Mouse, isPrimary: true);
+        var pressProps = new PointerPointProperties(RawInputModifiers.LeftMouseButton, PointerUpdateKind.LeftButtonPressed);
+        var start = new Point(100, 100);
+        var end = start + deltaDip;
+
+        handle.RaiseEvent(new PointerPressedEventArgs(
+            handle, pointer, layer, start, 0, pressProps, KeyModifiers.None));
+
+        handle.RaiseEvent(new PointerEventArgs(
+            InputElement.PointerMovedEvent, handle, pointer, layer, end, 0,
+            new PointerPointProperties(RawInputModifiers.LeftMouseButton, PointerUpdateKind.Other),
+            KeyModifiers.None));
+
+        handle.RaiseEvent(new PointerReleasedEventArgs(
+            handle, pointer, layer, end, 0,
+            new PointerPointProperties(RawInputModifiers.None, PointerUpdateKind.LeftButtonReleased),
+            KeyModifiers.None, MouseButton.Left));
+    }
+
     private static async Task RunEscapeCase(string initialText, bool expectDeleted)
     {
         PdfCoreDocument? doc = null;

--- a/Excise.App.Tests/Controls/TypewriterWrapParityTests.cs
+++ b/Excise.App.Tests/Controls/TypewriterWrapParityTests.cs
@@ -1,0 +1,137 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Avalonia.Headless.XUnit;
+using Avalonia.Media;
+using Avalonia.Media.TextFormatting;
+using Avalonia.Threading;
+using AwesomeAssertions;
+using Excise.Core.Editing;
+using Xunit;
+using PdfCoreDocument = Excise.Core.Document.PdfDocument;
+using PdfRectangle = Excise.Core.Document.PdfRectangle;
+
+namespace Excise.App.Tests.Controls;
+
+/// <summary>
+/// #780: wrap parity between what the user sees in the editor TextBox
+/// (Avalonia's <see cref="TextWrapping.Wrap"/> at the box width) and the
+/// flattened PDF output (Skia + base-14 metrics inside
+/// <see cref="PdfTypewriterTextApplier"/> → DrawText). The two use DIFFERENT
+/// layout engines and DIFFERENT fonts (the editor TextBox is the default UI
+/// typeface; the flattened text is Helvetica AFM), so this is deliberately a
+/// robust parity check (±1 line), not brittle pixel matching. It exists to
+/// catch a GROSS divergence — text the user saw on 3 lines baking in on 1, or
+/// words dropped — not sub-line differences.
+/// </summary>
+[Collection("AvaloniaTests")]
+public class TypewriterWrapParityTests
+{
+    // A block wide enough to wrap several times at the chosen box width, and
+    // distinct words so reading-order preservation is meaningfully asserted.
+    private static readonly string[] Words =
+    {
+        "alpha", "bravo", "charlie", "delta", "echo", "foxtrot", "golf", "hotel",
+        "india", "juliet", "kilo", "lima", "mike", "november", "oscar", "papa",
+        "quebec", "romeo", "sierra", "tango",
+    };
+
+    private const double FontSizePt = 12.0;
+    private const double LineSpacing = 1.2;
+    private const double ViewerUnitsPerPoint = 120.0 / 72.0; // DefaultRenderDpi / 72
+    private const double EditorPaddingDip = 8.0;             // TextBox Padding 4 + 4
+
+    [FixedAvaloniaFact]
+    public async Task EditorWrap_AndFlattenedWrap_AgreeWithinOneLine_AndPreserveWordsInOrder()
+    {
+        var text = string.Join(' ', Words);
+
+        // A box 180pt wide, 400pt tall — tall enough that DrawText never clips a
+        // wrapped line into overflow (its vertical-room guard drops lines that
+        // fall below Bottom), so line counts reflect wrapping only.
+        var bounds = new PdfRectangle(40, 60, 220, 460); // w=180, h=400, on a 300x500 page
+
+        // ---- On-screen side: the editor TextBox layout the user sees ----
+        // Same width/font-size/wrapping the editor applies (font size and box
+        // width both scale by ViewerUnitsPerPoint; the TextBox loses 8 DIP to
+        // padding). Measured with Typeface.Default — the typeface the TextBox
+        // actually uses (no FontFamily is set on it).
+        int screenLines = 0;
+        await Dispatcher.UIThread.InvokeAsync(() =>
+        {
+            var boxWidthDip = bounds.Width * ViewerUnitsPerPoint;
+            var fontSizeDip = FontSizePt * ViewerUnitsPerPoint;
+            var layout = new TextLayout(
+                text,
+                Typeface.Default,
+                fontSize: fontSizeDip,
+                foreground: Brushes.Black,
+                textAlignment: TextAlignment.Left,
+                textWrapping: TextWrapping.Wrap,
+                maxWidth: boxWidthDip - EditorPaddingDip);
+            screenLines = layout.TextLines.Count;
+        });
+
+        // ---- Flattened side: apply → save → reopen → extract ----
+        var tempDir = Path.Combine(Path.GetTempPath(), "Excise.TypewriterWrap", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        var outputPath = Path.Combine(tempDir, "wrapped.pdf");
+
+        try
+        {
+            using (var doc = PdfCoreDocument.CreateNew())
+            {
+                doc.Pages.AddBlank(300, 500);
+                var op = PdfTypewriterTextOperation.Create(
+                    1, bounds, text,
+                    new PdfTypewriterTextStyle(fontSize: FontSizePt, lineSpacing: LineSpacing));
+                PdfTypewriterTextApplier.Apply(doc, op);
+                doc.Save(outputPath);
+            }
+
+            using var saved = PdfCoreDocument.Open(outputPath);
+            var page = saved.GetPage(1);
+            var letters = page.Letters;
+
+            letters.Should().NotBeEmpty("the flattened typewriter text must be in the content stream");
+
+            // Group letter baselines into lines (bands ~half a lineHeight apart;
+            // lines are 14.4pt apart so 7pt cleanly separates them).
+            var bands = new System.Collections.Generic.List<double>();
+            foreach (var y in letters.Select(l => l.StartY).OrderByDescending(v => v))
+            {
+                if (!bands.Any(b => Math.Abs(b - y) < 7.0))
+                    bands.Add(y);
+            }
+            int flattenedLines = bands.Count;
+
+            // Words in reading order: top-of-page first (higher PDF Y), then L→R.
+            var flattenedWords = page.GetWords()
+                .Where(w => w.Letters.Count > 0)
+                .OrderByDescending(w => Math.Round(w.Letters[0].StartY / 7.0))
+                .ThenBy(w => w.Letters[0].StartX)
+                .Select(w => w.Text)
+                .ToList();
+
+            // (a) Both engines actually wrapped.
+            screenLines.Should().BeGreaterThan(1, "the on-screen editor must wrap this block");
+            flattenedLines.Should().BeGreaterThan(1, "the flattened output must wrap this block");
+
+            // (b) Every word survives, in reading order.
+            flattenedWords.Should().Equal(Words,
+                "flattening must preserve every word in reading order (screen lines={0}, flattened lines={1})",
+                screenLines, flattenedLines);
+
+            // (c) Line counts agree within one line. A larger divergence is a
+            // genuine fidelity bug, not a tolerance to loosen.
+            Math.Abs(screenLines - flattenedLines).Should().BeLessThanOrEqualTo(1,
+                "editor wrap ({0} lines) and flattened wrap ({1} lines) must agree within ±1",
+                screenLines, flattenedLines);
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { /* best effort */ }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Closes the two automated GUI-test coverage gaps left after #783/#780 for the type-over (typewriter) tool. **Test-only** — no production code changed.

## Test 1 — move/resize handle drag (`PdfViewerControlTypewriterTests.cs`)
- `DragMoveHandle_ShiftsPdfPosition_AndPreservesSize`
- `DragResizeGrip_ChangesPdfSize_AndPreservesAnchoredCorner`

Drives a real routed pointer gesture (`PointerPressed` → `PointerMoved` → `PointerReleased`) on the editor's **dragHandle** / **resizeGrip** `Border` found in the `TypewriterLayer` visual tree, and asserts the resulting `TypewriterTextBoundsChanged` PDF bounds reflect the drag: move → position shifts, size preserved; resize → size grows, anchored top-left corner fixed.

**Pointer-simulation approach that worked:** constructed routed `PointerEventArgs` with `rootVisual == the TypewriterLayer Canvas`, so `GetPosition(layer)` is an identity transform and the handlers observe exactly the injected delta. This required hosting the control in a **shown `Window`** first — a detached control has no visual root, so `GetPosition` collapses to (0,0) and no gesture is seen. The exact DIP→PDF magnitude depends on the preview render DPI/zoom the control picks for the host window, so precise magnitude is checked against a value mapped from the shell's final DIP geometry through the same conversion the event uses, while direction + size-preservation are asserted against the seeded bounds (scale-independent).

## Test 2 — wrap parity (`TypewriterWrapParityTests.cs`)
- `EditorWrap_AndFlattenedWrap_AgreeWithinOneLine_AndPreserveWordsInOrder`

Compares on-screen editor `TextBox` wrapping (Avalonia `TextWrapping.Wrap`, `Typeface.Default`) against the flattened PDF output (Skia + base-14 metrics via `PdfTypewriterTextApplier` → `DrawText`), through save → reopen → letter extraction. Asserts: (a) both wrap to >1 line; (b) all words preserved in reading order; (c) line counts agree within ±1. Box height chosen tall enough that `DrawText`'s vertical-room guard never clips a wrapped line.

**Wrap parity held:** on-screen **4 lines** vs flattened **4 lines** (difference 0).

## Results
- Build: 0 warnings, 0 errors.
- `dotnet test --filter FullyQualifiedName~Typewriter`: **25 passed, 2 skipped** (pre-existing permission-fixture skips), 0 failed.
- No real bug found — production behaviour is correct on both paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)