### PR TITLE
fix(#791): decode simple symbolic TrueType (3,0) symbol cmap in text extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ semantic versioning.
 
 ## [Unreleased]
 
+### Fixed
+- **Symbolic TrueType with a (3,0) symbol cmap: text extraction mis-decode**
+  (#791) — a simple (non-Type0) symbolic TrueType font that carries a
+  Microsoft-Symbol `(3,0)` cmap subtable and ships no `/ToUnicode` addresses
+  glyphs through an F000-based Private Use offset. excise rendered such fonts
+  correctly but text EXTRACTION echoed the raw content byte through
+  WinAnsi — e.g. a page reading "Redaction" extracted as `¡¢£¤¥¦§¨©`. Because
+  extraction bounds redaction, `RedactText` then removed **0** occurrences and
+  reported success: a silent redaction leak (CLAUDE.md, #637/#645). Extraction
+  now resolves such fonts through the embedded program's `(3,0)` cmap
+  (code→glyph, ISO 32000-2 §9.6.6.4) and recovers Unicode from the program's
+  `post` glyph names (or a Unicode cmap subtable), matching the independent
+  oracle (mutool). Scoped strictly to symbolic simple TrueType with an embedded
+  `(3,0)` cmap and no `/ToUnicode` / no `/Encoding`, so every other simple font
+  keeps its existing decode — the 332-page extraction-parity gate stays at
+  98.7%. A purpose-built fixture (`SymbolCmapTtfBuilder`, patches DejaVu Sans to
+  a `(3,0)` symbol cmap) proves render parity, extraction parity, and — the
+  redaction-relevance made concrete — that excise now removes the text and
+  mutool confirms it is gone.
+
 ## [3.3.0] - 2026-07-26
 
 ### Added

--- a/Excise.Core/Fonts/TrueTypeFontFile.cs
+++ b/Excise.Core/Fonts/TrueTypeFontFile.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using Excise.Core.Text;
 
 namespace Excise.Core.Fonts;
 
@@ -30,18 +31,50 @@ internal sealed class TrueTypeFontFile
 
     private readonly ushort[] _advanceWidths;          // per glyph id, font units
     private readonly Dictionary<int, int> _cmap;       // unicode codepoint -> gid
+    // Microsoft-Symbol (3,0) subtable, RAW keys (0xF0NN), or null when absent.
+    private readonly Dictionary<int, int>? _symbolCmap;
+    // Macintosh (1,0) subtable, RAW keys (0xNN), or null when absent.
+    private readonly Dictionary<int, int>? _macCmap;
+    // gid -> PostScript glyph name (from the 'post' table), or empty.
+    private readonly Dictionary<int, string> _glyphNames;
 
     private TrueTypeFontFile(byte[] data, ushort unitsPerEm, int glyphCount, string psName,
         short xMin, short yMin, short xMax, short yMax, short ascent, short descent,
-        bool bold, bool italic, bool isCff, ushort[] advanceWidths, Dictionary<int, int> cmap)
+        bool bold, bool italic, bool isCff, ushort[] advanceWidths, Dictionary<int, int> cmap,
+        Dictionary<int, int>? symbolCmap, Dictionary<int, int>? macCmap, Dictionary<int, string> glyphNames)
     {
         Data = data; UnitsPerEm = unitsPerEm; GlyphCount = glyphCount; PostScriptName = psName;
         XMin = xMin; YMin = yMin; XMax = xMax; YMax = yMax; Ascent = ascent; Descent = descent;
         IsBold = bold; IsItalic = italic; IsCff = isCff; _advanceWidths = advanceWidths; _cmap = cmap;
+        _symbolCmap = symbolCmap; _macCmap = macCmap; _glyphNames = glyphNames;
     }
 
     /// <summary>Glyph id for a Unicode codepoint, or 0 (.notdef) if unmapped.</summary>
     public int GidForCodepoint(int codepoint) => _cmap.TryGetValue(codepoint, out var g) ? g : 0;
+
+    /// <summary>True when the font carries a Microsoft-Symbol <c>(3,0)</c> cmap subtable.</summary>
+    public bool HasSymbolCmap => _symbolCmap != null;
+
+    /// <summary>
+    /// Glyph id for a one-byte content code under the symbolic-TrueType cmap
+    /// selection order (ISO 32000-2 §9.6.6.4): the Microsoft-Symbol <c>(3,0)</c>
+    /// subtable first — trying the F000-offset key (<c>0xF000 | code</c>) then the
+    /// bare code — then the Macintosh <c>(1,0)</c> subtable. Returns 0 (.notdef)
+    /// when no symbolic subtable resolves the code.
+    /// </summary>
+    public int GidForSymbolByte(int code)
+    {
+        if (_symbolCmap != null)
+        {
+            if (_symbolCmap.TryGetValue(0xF000 | (code & 0xFF), out var g) && g != 0) return g;
+            if (_symbolCmap.TryGetValue(code & 0xFF, out g) && g != 0) return g;
+        }
+        if (_macCmap != null && _macCmap.TryGetValue(code & 0xFF, out var mg) && mg != 0) return mg;
+        return 0;
+    }
+
+    /// <summary>PostScript glyph name for a gid (from the 'post' table), or null.</summary>
+    public string? GlyphName(int gid) => _glyphNames.TryGetValue(gid, out var n) ? n : null;
 
     /// <summary>Advance width of a glyph in font units (clamped to the table).</summary>
     public int AdvanceWidth(int gid)
@@ -122,14 +155,105 @@ internal sealed class TrueTypeFontFile
             adv[i] = last;
         }
 
-        var cmap = ParseCmap(r, Req("cmap").off);
+        int cmapOff = Req("cmap").off;
+        var cmap = ParseCmap(r, cmapOff);
+        // Symbolic-TrueType extraction (#791) needs the raw (3,0)/(1,0) subtables
+        // and the 'post' glyph names, which the best-scored Unicode cmap discards.
+        // These run for EVERY font load (rendering included), so a malformed post
+        // or subtable must NOT fail the whole parse — it degrades to an empty map,
+        // leaving a font that previously parsed fine unaffected.
+        Dictionary<int, int>? symbolCmap = null, macCmap = null;
+        var glyphNames = new Dictionary<int, string>();
+        try
+        {
+            symbolCmap = ParseSubtableByPlatform(r, cmapOff, 3, 0);
+            macCmap = ParseSubtableByPlatform(r, cmapOff, 1, 0);
+            if (tables.TryGetValue("post", out var postTbl))
+                glyphNames = ParsePostGlyphNames(r, postTbl.off, postTbl.len, numGlyphs);
+        }
+        catch (Exception ex) when (ex is not OutOfMemoryException)
+        {
+            symbolCmap = null; macCmap = null; glyphNames = new Dictionary<int, string>();
+        }
         string psName = tables.TryGetValue("name", out var nameTbl)
             ? (ReadPostScriptName(r, nameTbl.off) ?? "EmbeddedFont")
             : "EmbeddedFont";
 
         return new TrueTypeFontFile(data, unitsPerEm, numGlyphs, psName,
             xMin, yMin, xMax, yMax, ascent, descent,
-            (macStyle & 0x1) != 0, (macStyle & 0x2) != 0, isCff, adv, cmap);
+            (macStyle & 0x1) != 0, (macStyle & 0x2) != 0, isCff, adv, cmap,
+            symbolCmap, macCmap, glyphNames);
+    }
+
+    /// <summary>
+    /// Parses the cmap subtable for an exact (platformID, encodingID), returning
+    /// its RAW code→gid map (no F000 offset stripped), or null when absent.
+    /// Used for symbolic-TrueType code resolution where the (3,0)/(1,0) subtable
+    /// — not the best-scored Unicode one — is authoritative (#791).
+    /// </summary>
+    private static Dictionary<int, int>? ParseSubtableByPlatform(BE r, int cmapOff, int wantPlat, int wantEnc)
+    {
+        ushort numSub = r.U16(cmapOff + 2);
+        for (int i = 0; i < numSub; i++)
+        {
+            int rec = cmapOff + 4 + i * 8;
+            if (r.U16(rec) != wantPlat || r.U16(rec + 2) != wantEnc) continue;
+            int sub = cmapOff + (int)r.U32(rec + 4);
+            var map = new Dictionary<int, int>();
+            ParseSubtableInto(r, sub, map);
+            return map.Count > 0 ? map : null;
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Reads the 'post' table (format 1.0 / 2.0) into gid→glyph-name. Format 3.0
+    /// (and anything else) carries no names and yields an empty map. Names bridge
+    /// gid→Unicode via the Adobe Glyph List for symbolic fonts with no /ToUnicode.
+    /// </summary>
+    private static Dictionary<int, string> ParsePostGlyphNames(BE r, int postOff, int postLen, int numGlyphs)
+    {
+        var names = new Dictionary<int, string>();
+        if (postLen < 4) return names;
+        uint version = r.U32(postOff);
+        if (version == 0x00010000) // 1.0: the 258 standard Macintosh names, in order
+        {
+            for (int gid = 0; gid < numGlyphs && gid < 258; gid++)
+                if (StandardMacGlyphOrder.TryGetName(gid, out var n)) names[gid] = n;
+            return names;
+        }
+        if (version != 0x00020000) return names; // 2.5/3.0/unknown: no usable names
+
+        int p = postOff + 32;
+        int count = r.U16(p);
+        p += 2;
+        if (count > numGlyphs) count = numGlyphs;
+        var indices = new int[count];
+        for (int i = 0; i < count; i++, p += 2) indices[i] = r.U16(p);
+
+        // Custom Pascal-string names follow the index array (for indices >= 258).
+        var custom = new List<string>();
+        int end = postOff + postLen;
+        while (p < end)
+        {
+            int slen = r.Data[p++];
+            if (p + slen > end) break;
+            custom.Add(Encoding.ASCII.GetString(r.Data, p, slen));
+            p += slen;
+        }
+        for (int gid = 0; gid < count; gid++)
+        {
+            int idx = indices[gid];
+            if (idx < 258)
+            {
+                if (StandardMacGlyphOrder.TryGetName(idx, out var n)) names[gid] = n;
+            }
+            else if (idx - 258 < custom.Count)
+            {
+                names[gid] = custom[idx - 258];
+            }
+        }
+        return names;
     }
 
     private static Dictionary<int, int> ParseCmap(BE r, int cmapOff)
@@ -223,6 +347,74 @@ internal sealed class TrueTypeFontFile
             }
         }
         return map;
+    }
+
+    /// <summary>
+    /// Parses a single cmap subtable (format 0/4/6/12) at <paramref name="sub"/>
+    /// into <paramref name="map"/> with its RAW code keys — no platform-specific
+    /// offset applied. Shares the decode with <see cref="ParseCmap"/> but keeps
+    /// the raw keys the symbolic path needs.
+    /// </summary>
+    private static void ParseSubtableInto(BE r, int sub, Dictionary<int, int> map)
+    {
+        ushort format = r.U16(sub);
+        if (format == 4)
+        {
+            ushort segX2 = r.U16(sub + 6);
+            int segCount = segX2 / 2;
+            int endP = sub + 14;
+            int startP = endP + segX2 + 2;
+            int deltaP = startP + segX2;
+            int rangeP = deltaP + segX2;
+            for (int s = 0; s < segCount; s++)
+            {
+                ushort end = r.U16(endP + s * 2);
+                ushort start = r.U16(startP + s * 2);
+                short delta = r.S16(deltaP + s * 2);
+                ushort rangeOff = r.U16(rangeP + s * 2);
+                for (int c = start; c <= end && c != 0xFFFF; c++)
+                {
+                    int gid;
+                    if (rangeOff == 0) gid = (c + delta) & 0xFFFF;
+                    else
+                    {
+                        int giAddr = rangeP + s * 2 + rangeOff + (c - start) * 2;
+                        ushort g = r.U16(giAddr);
+                        gid = g == 0 ? 0 : (g + delta) & 0xFFFF;
+                    }
+                    if (gid != 0) map[c] = gid;
+                }
+            }
+        }
+        else if (format == 6)
+        {
+            ushort first = r.U16(sub + 6), count = r.U16(sub + 8);
+            for (int i = 0; i < count; i++)
+            {
+                int gid = r.U16(sub + 10 + i * 2);
+                if (gid != 0) map[first + i] = gid;
+            }
+        }
+        else if (format == 0)
+        {
+            for (int c = 0; c < 256; c++)
+            {
+                int gid = r.Data[sub + 6 + c];
+                if (gid != 0) map[c] = gid;
+            }
+        }
+        else if (format == 12)
+        {
+            uint nGroups = r.U32(sub + 12);
+            int gp = sub + 16;
+            for (uint g = 0; g < nGroups; g++, gp += 12)
+            {
+                uint startC = r.U32(gp), endC = r.U32(gp + 4), startG = r.U32(gp + 8);
+                if (endC < startC || endC - startC > 0x10FFFF) continue;
+                for (uint c = startC; c <= endC; c++)
+                    map[(int)c] = (int)(startG + (c - startC));
+            }
+        }
     }
 
     private static string? ReadPostScriptName(BE r, int nameOff)

--- a/Excise.Core/Text/TextExtractor.cs
+++ b/Excise.Core/Text/TextExtractor.cs
@@ -42,6 +42,15 @@ public class TextExtractor
     // program yields nothing. Recomputed on each /Tf (cached per font dict).
     private Dictionary<int, string>? _embeddedCidToUnicode;
     private readonly Dictionary<PdfDictionary, Dictionary<int, string>?> _embeddedCidToUnicodeCache = new(ReferenceEqualityComparer.Instance);
+    // #791: simple (non-Type0) SYMBOLIC TrueType with a Microsoft-Symbol (3,0)
+    // cmap subtable and no /ToUnicode / no /Encoding. Such fonts address glyphs
+    // through an F000-based PUA offset; without this map extraction echoes the
+    // raw content byte through WinAnsi (¡¢£… for R,e,d…) — the silent mis-decode
+    // that bounds redaction (excise cannot redact what it cannot read). Built
+    // from the embedded program's (3,0) cmap (code→gid) + post glyph names /
+    // Unicode cmap (gid→Unicode). Null when out of scope; cached per font dict.
+    private Dictionary<int, string>? _simpleSymbolCodeToUnicode;
+    private readonly Dictionary<PdfDictionary, Dictionary<int, string>?> _simpleSymbolCodeToUnicodeCache = new(ReferenceEqualityComparer.Instance);
     // True when /ToUnicode is the predefined-CMap NAME /Identity-H or /Identity-V
     // (not a stream): the 2-byte code IS the UTF-16BE Unicode scalar, so it must
     // be decoded directly rather than left to the WinAnsi fallback (which is only
@@ -986,6 +995,7 @@ public class TextExtractor
                     _toUnicodeIdentity = _toUnicodeMap == null && ToUnicodeIsIdentity(_currentFont);
                     _useStandardMacGlyphOrder = _toUnicodeMap == null && UsesStandardMacGlyphOrderFallback(_currentFont);
                     _embeddedCidToUnicode = _toUnicodeMap == null ? LoadEmbeddedCidToUnicodeMap(_currentFont) : null;
+                    _simpleSymbolCodeToUnicode = _toUnicodeMap == null ? LoadSimpleSymbolTrueTypeMap(_currentFont) : null;
                     LoadFontGeometry();
                 }
                 break;
@@ -1842,6 +1852,19 @@ public class TextExtractor
                 return macUnicode;
         }
 
+        // Simple symbolic TrueType with a (3,0) symbol cmap and no ToUnicode/no
+        // Encoding (#791): the content byte selects a glyph through the embedded
+        // font's (3,0)/F000 cmap, and that glyph's Unicode is recovered from its
+        // post name / Unicode cmap. Consulted last so any explicit encoding above
+        // still wins; only fires when the embedded program actually resolves this
+        // code to a real (non-PUA) Unicode. Without it the byte is echoed through
+        // WinAnsi below — the silent mis-decode that bounds redaction.
+        if (_simpleSymbolCodeToUnicode != null
+            && _simpleSymbolCodeToUnicode.TryGetValue(charCode, out var symbolUnicode))
+        {
+            return symbolUnicode;
+        }
+
         // Default: assume WinAnsiEncoding for Type1 fonts with standard base fonts
         return DecodeWinAnsi(charCode);
     }
@@ -1974,6 +1997,84 @@ public class TextExtractor
             map = null;
         _embeddedCidToUnicodeCache[font] = map;
         return map;
+    }
+
+    /// <summary>
+    /// Builds code→Unicode for a SIMPLE (non-Type0) SYMBOLIC TrueType font that
+    /// carries a Microsoft-Symbol <c>(3,0)</c> cmap subtable and no
+    /// <c>/ToUnicode</c> / no <c>/Encoding</c> (#791). The content byte selects a
+    /// glyph through the embedded program's (3,0) cmap (F000-offset per ISO
+    /// 32000-2 §9.6.6.4); that glyph's Unicode is recovered from the program's
+    /// <c>post</c> glyph names (or a Unicode cmap subtable, if present). Returns
+    /// null when out of scope, so the existing WinAnsi fallback is untouched for
+    /// every other simple font — keeping the change off the extraction-parity
+    /// corpus except where a real (3,0) symbol font would otherwise mis-decode.
+    /// </summary>
+    private Dictionary<int, string>? LoadSimpleSymbolTrueTypeMap(PdfDictionary? font)
+    {
+        if (font == null || font.GetNameOrNull("Subtype") != "TrueType")
+            return null;
+        // Scope to symbolic fonts with no producer-declared encoding — those are
+        // the fonts the WinAnsi fallback silently mis-decodes. A present
+        // /ToUnicode or /Encoding is the producer's own map and is handled above.
+        if (font.GetOptional("ToUnicode") != null || font.GetOptional("Encoding") != null)
+            return null;
+
+        if (_simpleSymbolCodeToUnicodeCache.TryGetValue(font, out var cached))
+            return cached;
+
+        Dictionary<int, string>? map = null;
+        try
+        {
+            if (_page.Document.Resolve(font.GetOptional("FontDescriptor") ?? PdfNull.Instance)
+                    is PdfDictionary fd
+                && (fd.GetInt("Flags", 0) & 0x4) != 0 // bit 3: Symbolic
+                && _page.Document.Resolve(fd.GetOptional("FontFile2") ?? PdfNull.Instance) is PdfStream ff2)
+            {
+                var ttf = TrueTypeFontFile.Parse(ff2.DecodedData);
+                if (ttf.HasSymbolCmap)
+                    map = BuildSymbolCodeToUnicode(ttf);
+            }
+        }
+        catch (Exception ex) when (ex is not OutOfMemoryException)
+        {
+            map = null; // malformed embedded program — keep existing behavior
+        }
+
+        if (map is { Count: 0 })
+            map = null;
+        _simpleSymbolCodeToUnicodeCache[font] = map;
+        return map;
+    }
+
+    /// <summary>
+    /// code (0..255) → Unicode for a symbolic TrueType: symbol-cmap code→gid, then
+    /// gid→Unicode from the program's own Unicode cmap (non-PUA) or post glyph
+    /// names. Skips codes whose only recovery is a Private-Use scalar — those are
+    /// genuinely unrecoverable and must fall through rather than emit PUA garbage.
+    /// </summary>
+    private static Dictionary<int, string> BuildSymbolCodeToUnicode(TrueTypeFontFile ttf)
+    {
+        // gid → non-PUA Unicode from a Unicode cmap subtable, if the font has one.
+        var gidToCp = ReverseCmap(ttf.Cmap);
+        var result = new Dictionary<int, string>();
+        for (int code = 0; code <= 0xFF; code++)
+        {
+            int gid = ttf.GidForSymbolByte(code);
+            if (gid == 0) continue;
+
+            string? unicode = null;
+            if (gidToCp.TryGetValue(gid, out var cp) && !IsPrivateUse(cp))
+                unicode = char.ConvertFromUtf32(cp);
+            if (unicode == null)
+            {
+                var name = ttf.GlyphName(gid);
+                if (name != null) unicode = GlyphNameToUnicode(name);
+            }
+            if (unicode is { Length: > 0 } && !IsPrivateUse(char.ConvertToUtf32(unicode, 0)))
+                result[code] = unicode;
+        }
+        return result;
     }
 
     /// <summary>

--- a/Excise.Rendering.Tests/Fonts/SymbolCmapTtfBuilder.cs
+++ b/Excise.Rendering.Tests/Fonts/SymbolCmapTtfBuilder.cs
@@ -1,0 +1,262 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Excise.Rendering.Tests.Fonts;
+
+/// <summary>
+/// Test-only surgery on a real TrueType font (DejaVu Sans) that REPLACES its
+/// cmap table with a single Microsoft-Symbol <c>(3,0)</c> subtable, keeping
+/// every other table — including the real <c>glyf</c> outlines and the
+/// <c>post</c> (v2.0) glyph names — byte-for-byte.
+///
+/// A <c>(3,0)</c> symbol cmap addresses glyphs through an F000-based Private Use
+/// offset: content-stream code <c>0xNN</c> is looked up in the cmap at
+/// <c>0xF0NN</c>. This builder maps <c>0xF000 | code =&gt; gid</c> for each
+/// caller-supplied (contentCode, intendedLetter) pair, resolving the letter's
+/// glyph id through DejaVu's own Unicode cmap.
+///
+/// Why keep <c>post</c>: it names each glyph (e.g. gid → "R"), so an independent
+/// extractor (mutool) can recover Unicode via glyph-name → AdobeGlyphList even
+/// though there is no /ToUnicode and no Unicode cmap. That makes the fixture a
+/// RECOVERABLE symbol font — the oracle can read it, so a excise mis-decode is a
+/// real, assertable divergence rather than genuinely-unrecoverable text (#791).
+/// </summary>
+internal static class SymbolCmapTtfBuilder
+{
+    /// <summary>
+    /// Returns a DejaVu-derived TrueType with a single (3,0) symbol cmap mapping
+    /// (0xF000 | code) → glyph(letter) for each pair. Codes must be 0x00..0xFF.
+    /// </summary>
+    public static byte[] BuildSymbolCmapFont(byte[] dejaVu, IReadOnlyList<(int Code, char Letter)> mapping)
+    {
+        var dir = ReadTableDirectory(dejaVu);
+        var unicodeToGid = ParseUnicodeCmap(dejaVu, dir["cmap"]);
+
+        var symbolEntries = new List<(int SymbolCode, int Gid)>();
+        foreach (var (code, letter) in mapping)
+        {
+            if (code < 0 || code > 0xFF)
+                throw new ArgumentOutOfRangeException(nameof(mapping), $"code 0x{code:X} out of byte range");
+            if (!unicodeToGid.TryGetValue(letter, out var gid) || gid == 0)
+                throw new InvalidOperationException($"DejaVu has no glyph for '{letter}' (U+{(int)letter:X4})");
+            symbolEntries.Add((0xF000 | code, gid));
+        }
+
+        var newCmap = BuildSymbolCmapTable(symbolEntries);
+
+        // Reassemble: every original table verbatim except 'cmap'.
+        var tables = new List<(string Tag, byte[] Data)>();
+        foreach (var kv in dir)
+        {
+            var (off, len) = kv.Value;
+            var data = kv.Key == "cmap" ? newCmap : dejaVu.AsSpan(off, len).ToArray();
+            tables.Add((kv.Key, data));
+        }
+        return AssembleSfnt(dejaVu, tables);
+    }
+
+    // ---- table directory -----------------------------------------------------
+
+    private static Dictionary<string, (int Off, int Len)> ReadTableDirectory(byte[] d)
+    {
+        int num = U16(d, 4);
+        var dir = new Dictionary<string, (int, int)>(StringComparer.Ordinal);
+        for (int i = 0; i < num; i++)
+        {
+            int rec = 12 + i * 16;
+            string tag = System.Text.Encoding.ASCII.GetString(d, rec, 4);
+            int off = (int)U32(d, rec + 8);
+            int len = (int)U32(d, rec + 12);
+            dir[tag] = (off, len);
+        }
+        return dir;
+    }
+
+    // ---- parse DejaVu's Unicode cmap ((3,1) format 4) → char→gid --------------
+
+    private static Dictionary<int, int> ParseUnicodeCmap(byte[] d, (int Off, int Len) cmap)
+    {
+        int co = cmap.Off;
+        int n = U16(d, co + 2);
+        int best = -1;
+        foreach (var i in Enumerable.Range(0, n))
+        {
+            int rec = co + 4 + i * 8;
+            int plat = U16(d, rec), enc = U16(d, rec + 2);
+            int sub = co + (int)U32(d, rec + 4);
+            int fmt = U16(d, sub);
+            if (plat == 3 && enc == 1 && fmt == 4) { best = sub; break; }
+        }
+        if (best < 0) throw new InvalidOperationException("DejaVu has no (3,1) format-4 cmap");
+
+        var map = new Dictionary<int, int>();
+        int segX2 = U16(d, best + 6);
+        int segCount = segX2 / 2;
+        int endP = best + 14;
+        int startP = endP + segX2 + 2;
+        int deltaP = startP + segX2;
+        int rangeP = deltaP + segX2;
+        for (int s = 0; s < segCount; s++)
+        {
+            int end = U16(d, endP + s * 2);
+            int start = U16(d, startP + s * 2);
+            short delta = (short)U16(d, deltaP + s * 2);
+            int rangeOff = U16(d, rangeP + s * 2);
+            for (int c = start; c <= end && c != 0xFFFF; c++)
+            {
+                int gid;
+                if (rangeOff == 0) gid = (c + delta) & 0xFFFF;
+                else
+                {
+                    int giAddr = rangeP + s * 2 + rangeOff + (c - start) * 2;
+                    int g = U16(d, giAddr);
+                    gid = g == 0 ? 0 : (g + delta) & 0xFFFF;
+                }
+                if (gid != 0) map[c] = gid;
+            }
+        }
+        return map;
+    }
+
+    // ---- build a (3,0) symbol cmap table -------------------------------------
+
+    private static byte[] BuildSymbolCmapTable(List<(int SymbolCode, int Gid)> entries)
+    {
+        entries = entries.OrderBy(e => e.SymbolCode).ToList();
+        // One format-4 segment per code, plus the mandatory 0xFFFF terminator.
+        var segStart = new List<int>();
+        var segEnd = new List<int>();
+        var segDelta = new List<int>();
+        foreach (var (code, gid) in entries)
+        {
+            segStart.Add(code);
+            segEnd.Add(code);
+            segDelta.Add((gid - code) & 0xFFFF);
+        }
+        segStart.Add(0xFFFF); segEnd.Add(0xFFFF); segDelta.Add(1);
+
+        int segCount = segStart.Count;
+        int segX2 = segCount * 2;
+        int entrySelector = (int)Math.Floor(Math.Log2(segCount));
+        int searchRange = 2 * (1 << entrySelector);
+        int rangeShift = segX2 - searchRange;
+
+        using var sub = new MemoryStream();
+        void S16(int v) { sub.WriteByte((byte)(v >> 8)); sub.WriteByte((byte)v); }
+        S16(4);                       // format
+        int lenPos = (int)sub.Position; S16(0); // length placeholder
+        S16(0);                       // language
+        S16(segX2);
+        S16(searchRange);
+        S16(entrySelector);
+        S16(rangeShift);
+        foreach (var e in segEnd) S16(e);
+        S16(0);                       // reservedPad
+        foreach (var s in segStart) S16(s);
+        foreach (var dlt in segDelta) S16(dlt);
+        foreach (var _ in segStart) S16(0); // idRangeOffset all zero
+        var subBytes = sub.ToArray();
+        subBytes[lenPos] = (byte)(subBytes.Length >> 8);
+        subBytes[lenPos + 1] = (byte)subBytes.Length;
+
+        using var ms = new MemoryStream();
+        void W16(int v) { ms.WriteByte((byte)(v >> 8)); ms.WriteByte((byte)v); }
+        void W32(long v) { ms.WriteByte((byte)(v >> 24)); ms.WriteByte((byte)(v >> 16)); ms.WriteByte((byte)(v >> 8)); ms.WriteByte((byte)v); }
+        W16(0);                       // cmap version
+        W16(1);                       // numTables
+        W16(3);                       // platformID = Microsoft
+        W16(0);                       // encodingID = Symbol
+        W32(12);                      // offset to subtable
+        ms.Write(subBytes, 0, subBytes.Length);
+        return ms.ToArray();
+    }
+
+    // ---- reassemble sfnt with recomputed directory + checksums ---------------
+
+    private static byte[] AssembleSfnt(byte[] original, List<(string Tag, byte[] Data)> tables)
+    {
+        // Preserve the original sfnt version ('true'/0x00010000/'OTTO').
+        uint sfntVersion = U32(original, 0);
+        tables.Sort((a, b) => string.CompareOrdinal(a.Tag, b.Tag));
+        int numTables = tables.Count;
+        int headerSize = 12;
+        int directorySize = numTables * 16;
+
+        int offset = headerSize + directorySize;
+        var offsets = new int[numTables];
+        for (int i = 0; i < numTables; i++)
+        {
+            offsets[i] = offset;
+            offset += AlignUp(tables[i].Data.Length, 4);
+        }
+        int total = offset;
+        var buf = new byte[total];
+        int p = 0;
+
+        int entrySelector = (int)Math.Floor(Math.Log2(numTables));
+        int searchRange = (1 << entrySelector) * 16;
+        int rangeShift = numTables * 16 - searchRange;
+        WriteU32(buf, ref p, sfntVersion);
+        WriteU16(buf, ref p, (ushort)numTables);
+        WriteU16(buf, ref p, (ushort)searchRange);
+        WriteU16(buf, ref p, (ushort)entrySelector);
+        WriteU16(buf, ref p, (ushort)rangeShift);
+
+        int headOffset = -1;
+        for (int i = 0; i < numTables; i++)
+        {
+            var (tag, data) = tables[i];
+            WriteU32(buf, ref p, TagToU32(tag));
+            WriteU32(buf, ref p, Checksum(data));
+            WriteU32(buf, ref p, (uint)offsets[i]);
+            WriteU32(buf, ref p, (uint)data.Length);
+            if (tag == "head") headOffset = offsets[i];
+        }
+        for (int i = 0; i < numTables; i++)
+            Array.Copy(tables[i].Data, 0, buf, offsets[i], tables[i].Data.Length);
+
+        if (headOffset >= 0)
+        {
+            // Zero checkSumAdjustment, then set it to 0xB1B0AFBA - fileChecksum.
+            int adjPos = headOffset + 8;
+            buf[adjPos] = buf[adjPos + 1] = buf[adjPos + 2] = buf[adjPos + 3] = 0;
+            uint fileSum = Checksum(buf);
+            int pa = adjPos;
+            WriteU32(buf, ref pa, 0xB1B0AFBAu - fileSum);
+        }
+        return buf;
+    }
+
+    // ---- primitives ----------------------------------------------------------
+
+    private static int AlignUp(int v, int a) => (v + a - 1) / a * a;
+
+    private static uint Checksum(byte[] data)
+    {
+        uint sum = 0;
+        int i = 0;
+        for (; i + 4 <= data.Length; i += 4)
+            sum += (uint)((data[i] << 24) | (data[i + 1] << 16) | (data[i + 2] << 8) | data[i + 3]);
+        if (i < data.Length)
+        {
+            uint last = 0;
+            for (int j = 0; j < 4; j++)
+                last = (last << 8) | (i + j < data.Length ? data[i + j] : (uint)0);
+            sum += last;
+        }
+        return sum;
+    }
+
+    private static uint TagToU32(string tag) =>
+        ((uint)tag[0] << 24) | ((uint)tag[1] << 16) | ((uint)tag[2] << 8) | tag[3];
+
+    private static int U16(byte[] d, int o) => (d[o] << 8) | d[o + 1];
+    private static uint U32(byte[] d, int o) =>
+        ((uint)d[o] << 24) | ((uint)d[o + 1] << 16) | ((uint)d[o + 2] << 8) | d[o + 3];
+
+    private static void WriteU16(byte[] b, ref int p, ushort v) { b[p++] = (byte)(v >> 8); b[p++] = (byte)v; }
+    private static void WriteU32(byte[] b, ref int p, uint v)
+    { b[p++] = (byte)(v >> 24); b[p++] = (byte)(v >> 16); b[p++] = (byte)(v >> 8); b[p++] = (byte)v; }
+}

--- a/Excise.Rendering.Tests/Fonts/SymbolicTrueTypeSymbolCmapExtractionTests.cs
+++ b/Excise.Rendering.Tests/Fonts/SymbolicTrueTypeSymbolCmapExtractionTests.cs
@@ -1,0 +1,250 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using AwesomeAssertions;
+using Excise.Core.Document;
+using Excise.Core.Text;
+using Excise.Core.Text.Segmentation;
+using Excise.Rendering;
+using Excise.Rendering.Differential;
+using SkiaSharp;
+using Xunit;
+
+namespace Excise.Rendering.Tests.Fonts;
+
+/// <summary>
+/// #791 — simple SYMBOLIC TrueType with a Microsoft-Symbol <c>(3,0)</c> cmap
+/// subtable and NO /ToUnicode. This is the one font class the #790 audit could
+/// not probe: DejaVu ships no (3,0) subtable, so the fixture is built by
+/// <see cref="SymbolCmapTtfBuilder"/> (patches DejaVu's cmap to (3,0), keeps the
+/// real glyf outlines and the v2.0 post glyph names).
+///
+/// The content stream addresses glyphs with NON-ASCII bytes (0xA1..0xA9) whose
+/// WinAnsi decode (¡¢£…) is NOT the intended letter — so an extractor that
+/// echoes the raw byte through WinAnsi (excise's simple-font fallback) is caught,
+/// unlike an ASCII fixture where the byte already equals the letter (#790 lines
+/// 88-99). The (3,0) cmap maps 0xF0A1→glyph(R) … 0xF0A9→glyph(n): intended
+/// "Redaction".
+///
+/// Oracle: mutool. It can recover "Redaction" from the post glyph names, so a
+/// divergence is a real redaction-relevant mis-decode (extraction bounds
+/// redaction — CLAUDE.md, #637/#645), not genuinely-unrecoverable symbol text.
+/// The renderer (glyph selection) and the extractor (code→Unicode) are asserted
+/// SEPARATELY because they fail independently.
+/// </summary>
+public sealed class SymbolicTrueTypeSymbolCmapExtractionTests
+{
+    private const int Dpi = 150;
+    private const string Intended = "Redaction";
+    private readonly ITestOutputHelper _out;
+
+    public SymbolicTrueTypeSymbolCmapExtractionTests(ITestOutputHelper output) => _out = output;
+
+    // code -> intended letter; codes are non-ASCII so WinAnsi(code) != letter.
+    private static readonly (int Code, char Letter)[] Mapping =
+    {
+        (0xA1, 'R'), (0xA2, 'e'), (0xA3, 'd'), (0xA4, 'a'), (0xA5, 'c'),
+        (0xA6, 't'), (0xA7, 'i'), (0xA8, 'o'), (0xA9, 'n'),
+    };
+
+    // ---- render: excise paints the right glyphs, and so does the oracle ------
+
+    [Fact]
+    public void SymbolCmap_Render_BothPaintInk()
+    {
+        var pdf = BuildFixture();
+        double exciseInk;
+        using (var doc = PdfDocument.Open(pdf))
+        using (var bmp = new SkiaRenderer().RenderPage(
+                   doc.GetPage(1), new RenderOptions { Dpi = Dpi, BackgroundColor = SKColors.White }))
+            exciseInk = InkFraction(bmp);
+        _out.WriteLine($"excise ink = {exciseInk:P3}");
+        exciseInk.Should().BeGreaterThan(0.002, "excise must paint the (3,0) symbol-cmap glyphs");
+
+        WithTempPdf(pdf, path =>
+        {
+            Assert.SkipWhen(!MutoolReferenceRenderer.IsAvailable, "mutool not installed.");
+            using var refBmp = MutoolReferenceRenderer.RenderPage(path, 1, Dpi);
+            Assert.SkipWhen(refBmp == null, "mutool declined to render.");
+            var refInk = InkFraction(refBmp!);
+            _out.WriteLine($"mutool ink = {refInk:P3}");
+            refInk.Should().BeGreaterThan(0.002, "the oracle must also paint the symbol-cmap glyphs");
+        });
+    }
+
+    // ---- extraction: excise vs mutool (the redaction-relevant crux) ----------
+
+    [Fact]
+    public void SymbolCmap_Extraction_RecoversIntendedText_NotRawWinAnsi()
+    {
+        var pdf = BuildFixture();
+        string exciseText;
+        using (var doc = PdfDocument.Open(pdf))
+            exciseText = new TextExtractor(doc.GetPage(1)).ExtractText();
+        _out.WriteLine($"excise extracted raw: '{exciseText.Trim()}'");
+
+        WithTempPdf(pdf, path =>
+        {
+            Assert.SkipWhen(!MutoolReferenceRenderer.IsAvailable, "mutool not installed.");
+            var mutoolText = MutoolTextExtractor.ExtractPage(path, 1);
+            Assert.SkipWhen(mutoolText == null, "mutool declined to extract.");
+            _out.WriteLine($"mutool extracted raw: '{mutoolText!.Trim()}'");
+
+            // The oracle must recover the intended letters — otherwise the fixture
+            // is genuinely unrecoverable and proves nothing (#619).
+            mutoolText.Should().Contain(Intended,
+                "the oracle must recover the intended text from the (3,0) symbol font " +
+                "(via post glyph names); if it can't, there is no recoverable Unicode to assert");
+
+            // Redaction-relevant: excise must recover the SAME letters, not echo the
+            // raw content byte through WinAnsi (¡¢£…). Echoing the byte is the silent
+            // mis-decode that bounds redaction (#637/#645).
+            exciseText.Should().Contain(Intended,
+                $"excise must decode the (3,0) symbol cmap to '{Intended}', not the raw " +
+                $"WinAnsi bytes; got '{exciseText.Trim()}'");
+        });
+    }
+
+    // ---- redaction: the mis-decode made concrete -----------------------------
+    // If excise can read the text it must be able to redact it, and an
+    // independent oracle must confirm it is gone.
+    [Fact]
+    public void SymbolCmap_Redaction_RemovesText_OracleConfirms()
+    {
+        Assert.SkipWhen(!MutoolReferenceRenderer.IsAvailable, "mutool not installed.");
+        var pdf = BuildFixture();
+
+        byte[] redacted;
+        using (var doc = PdfDocument.Open(pdf))
+        {
+            var removed = doc.RedactText(Intended);
+            _out.WriteLine($"redaction removed {removed} occurrence(s)");
+            removed.Should().BeGreaterThan(0, "excise must locate and redact the symbol-cmap text");
+            using var ms = new MemoryStream();
+            doc.Save(ms);
+            redacted = ms.ToArray();
+        }
+
+        WithTempPdf(redacted, path =>
+        {
+            var mutoolText = MutoolTextExtractor.ExtractPage(path, 1);
+            Assert.SkipWhen(mutoolText == null, "mutool declined to extract.");
+            _out.WriteLine($"mutool after redaction: '{mutoolText!.Trim()}'");
+            mutoolText.Should().NotContain(Intended,
+                "the independent oracle must confirm the redacted text is gone from the file");
+        });
+    }
+
+    // ==== fixture =============================================================
+
+    private static byte[] BuildFixture()
+    {
+        var dejaVu = LoadFixtureFont("DejaVuSans.ttf")
+            ?? throw new InvalidOperationException("DejaVuSans.ttf fixture missing.");
+        var program = SymbolCmapTtfBuilder.BuildSymbolCmapFont(dejaVu, Mapping);
+
+        // Content stream: raw non-ASCII code bytes inside a literal string.
+        var content = new List<byte>();
+        content.AddRange(Encoding.ASCII.GetBytes("BT /F1 48 Tf 20 40 Td ("));
+        foreach (var (code, _) in Mapping) content.Add((byte)code);
+        content.AddRange(Encoding.ASCII.GetBytes(") Tj ET"));
+
+        int first = Mapping.Min(m => m.Code);
+        int last = Mapping.Max(m => m.Code);
+        var widths = string.Join(' ', Enumerable.Range(first, last - first + 1).Select(_ => 600));
+
+        var pdf = new MinimalPdf();
+        pdf.Add("<< /Type /Catalog /Pages 2 0 R >>");
+        pdf.Add("<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+        pdf.Add("<< /Type /Page /Parent 2 0 R /MediaBox [0 0 340 120] /Contents 4 0 R "
+              + "/Resources << /Font << /F1 5 0 R >> >> >>");
+        pdf.Add("<< >>", content.ToArray());
+        // Symbolic simple TrueType: /Flags 4, NO /Encoding, NO /ToUnicode.
+        pdf.Add($"<< /Type /Font /Subtype /TrueType /BaseFont /SymFont /FirstChar {first} /LastChar {last} "
+              + $"/Widths [{widths}] /FontDescriptor 6 0 R >>");
+        pdf.Add("<< /Type /FontDescriptor /FontName /SymFont /Flags 4 "
+              + "/FontBBox [-1200 -500 2500 1200] /ItalicAngle 0 /Ascent 900 /Descent -250 "
+              + "/CapHeight 700 /StemV 90 /MissingWidth 600 /FontFile2 7 0 R >>");
+        pdf.Add("<< >>", program);
+        return pdf.Build(1);
+    }
+
+    // ==== helpers ============================================================
+
+    private static void WithTempPdf(byte[] pdf, Action<string> body)
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"excise-791-symcmap-{Guid.NewGuid():N}.pdf");
+        File.WriteAllBytes(path, pdf);
+        try { body(path); }
+        finally { try { File.Delete(path); } catch (IOException) { } }
+    }
+
+    private static bool IsInk(SKColor p) => p.Red < 200 || p.Green < 200 || p.Blue < 200;
+
+    private static double InkFraction(SKBitmap b)
+    {
+        long ink = 0;
+        for (int y = 0; y < b.Height; y++)
+            for (int x = 0; x < b.Width; x++)
+                if (IsInk(b.GetPixel(x, y))) ink++;
+        return (double)ink / (b.Width * (long)b.Height);
+    }
+
+    private static byte[]? LoadFixtureFont(string name)
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null)
+        {
+            var candidate = Path.Combine(dir.FullName, "Excise.Core.Tests", "Fixtures", "Fonts", name);
+            if (File.Exists(candidate)) return File.ReadAllBytes(candidate);
+            dir = dir.Parent;
+        }
+        return null;
+    }
+
+    private sealed class MinimalPdf
+    {
+        private readonly List<(string Dict, byte[]? Stream)> _objs = new();
+
+        public int Add(string dict, byte[]? stream = null)
+        {
+            _objs.Add((dict, stream));
+            return _objs.Count;
+        }
+
+        public byte[] Build(int rootObj)
+        {
+            using var ms = new MemoryStream();
+            void W(string s) { var b = Encoding.ASCII.GetBytes(s); ms.Write(b, 0, b.Length); }
+            W("%PDF-1.7\n");
+            var offsets = new long[_objs.Count + 1];
+            for (int i = 0; i < _objs.Count; i++)
+            {
+                int n = i + 1;
+                offsets[n] = ms.Position;
+                var (dict, stream) = _objs[i];
+                if (stream != null)
+                {
+                    int close = dict.LastIndexOf(">>", StringComparison.Ordinal);
+                    dict = dict.Substring(0, close) + $" /Length {stream.Length} " + dict.Substring(close);
+                }
+                W($"{n} 0 obj\n{dict}\n");
+                if (stream != null)
+                {
+                    W("stream\n");
+                    ms.Write(stream, 0, stream.Length);
+                    W("\nendstream\n");
+                }
+                W("endobj\n");
+            }
+            long xref = ms.Position;
+            W($"xref\n0 {_objs.Count + 1}\n0000000000 65535 f \n");
+            for (int n = 1; n <= _objs.Count; n++)
+                W($"{offsets[n]:D10} 00000 n \n");
+            W($"trailer\n<< /Root {rootObj} 0 R /Size {_objs.Count + 1} >>\nstartxref\n{xref}\n%%EOF");
+            return ms.ToArray();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Closes the one redaction-relevant gap the #512/#790 font-class audit could not probe: a **simple (non-Type0) symbolic TrueType** font that carries a Microsoft-Symbol **`(3,0)`** cmap subtable and no `/ToUnicode`.

Such fonts address glyphs through an F000-based Private Use offset. excise **rendered** them correctly but text **EXTRACTION** echoed the raw content byte through WinAnsi. Because extraction bounds redaction, `RedactText` then removed the text **incompletely and reported success** — a silent redaction leak (CLAUDE.md, #637/#645).

## Measured before/after (purpose-built fixture, non-ASCII codes so WinAnsi != intended)
| | before | after |
|---|---|---|
| excise render ink | 6.633% | 6.633% (always correct) |
| mutool render ink | 6.574% | 6.574% |
| **excise extraction** | `¡¢£¤¥¦§¨©` | **`Redaction`** |
| mutool extraction (oracle) | `Redaction` | `Redaction` |
| **`RedactText` occurrences removed** | **0** | **2** |
| mutool after redaction | — | *(empty)* |

The independent oracle (mutool) defines "correct" throughout — no self-oracle.

## Fix (scoped, extraction-side)
- **`TrueTypeFontFile`** (internal): additively parse the raw `(3,0)`/`(1,0)` cmap subtables and the `post` glyph names; add `GidForSymbolByte` (symbolic cmap selection, ISO 32000-2 §9.6.6.4) and `GlyphName` accessors. Existing behavior untouched.
- **`TextExtractor`**: `LoadSimpleSymbolTrueTypeMap` builds code->Unicode via the `(3,0)` cmap (code->glyph) + post names / Unicode cmap (glyph->Unicode). Consulted **only as a last resort before the WinAnsi fallback**, gated to `symbolic AND embedded (3,0) cmap AND no /ToUnicode AND no /Encoding`, and only overrides when it yields a real non-PUA Unicode.

## Gates
- Extraction-parity (#645): **98.7%, 332 pages at/above baseline** — unchanged.
- `test-tier.sh t0`: all PASS (incl. `verify-true-redaction.sh`).
- Core redaction/font/extraction tests: 826 passed. Rendering redaction + font + new symbol tests: 72 passed.
- Public API: unchanged (no `approved.txt` diff).
- Build: 0 warnings.

## Tests / fixture
`SymbolCmapTtfBuilder` patches DejaVu Sans to a `(3,0)` symbol cmap (keeps real glyf outlines + post names). `SymbolicTrueTypeSymbolCmapExtractionTests` asserts render parity, extraction parity, and the redaction-relevance made concrete (excise removes; mutool confirms gone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
