### PR TITLE
perf: cache per-font extraction state + inline int parse (#600)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ semantic versioning.
 
 ## [Unreleased]
 
+### Performance
+- **Text-extraction hot path: fewer allocations, less CPU** (#600) — the
+  `TextExtractor` content-stream parse now caches all per-font derived state
+  (ToUnicode map, `/Differences`, the Identity / Mac-glyph-order /
+  embedded-CID / symbol-cmap decode tables, and the CID/CMap/`/W` width
+  geometry) keyed by the resolved font dictionary, instead of re-parsing those
+  streams on every `Tf` operator — the dominant repeated cost, since every
+  text block re-issues `Tf`. `ParseNumber` gained an exact inline integer
+  parser for the common operand (TJ kerns, `Td`/`Tm`/`cm` coordinates) that
+  bypasses `int.TryParse`'s culture machinery, and the operand list is
+  pre-sized. Measured over `test-pdfs/smoke` (min-of-3, Release,
+  `scripts/check-perf-budgets.sh`): text-extract allocation **389.7 → 160.7 MB
+  (-59%)** and wall time **230.2 → 164.7 ms (-29%)**; redaction-save
+  allocation also fell ~8% (it shares the extractor). Every change is
+  behavior-preserving: the font cache re-assigns all derived fields on each
+  `Tf` (a snapshot, never a skip-if-same short-circuit, so it still heals the
+  partial state restore in form-XObject parsing) and the integer parser falls
+  back to `int.TryParse` for any non-trivial span. The 332-page
+  extraction-parity gate is **unchanged at 98.7%** — proving extraction output
+  (and therefore redaction reach) did not move. The text-extract allocation
+  budget was tightened to the new floor to lock in the win.
+
 ## [3.3.1] - 2026-07-26
 
 ### Fixed

--- a/Excise.Core/Text/TextExtractor.cs
+++ b/Excise.Core/Text/TextExtractor.cs
@@ -580,7 +580,10 @@ public class TextExtractor
     {
         var content = Encoding.Latin1.GetString(contentBytes);
         var pos = 0;
-        var operands = new List<object>();
+        // Presized: content-stream operators rarely take more than a handful of
+        // operands (Tm's 6 is the common max), so start past the default 4 to
+        // avoid the first grow-and-copy on nearly every operator (#600).
+        var operands = new List<object>(8);
 
         while (pos < content.Length)
         {
@@ -890,7 +893,53 @@ public class TextExtractor
             return double.TryParse(span, System.Globalization.NumberStyles.Float,
                 System.Globalization.CultureInfo.InvariantCulture, out var d) ? d : 0.0;
         }
+        // Fast, exact integer parse for the common operand (TJ kerns, Td/Tm/cm
+        // coordinates): a leading optional sign then ASCII digits. Avoids the
+        // culture/NumberStyles machinery of int.TryParse (System.Number) on the
+        // hot loop (#600). Bit-identical to the previous int.TryParse: a
+        // sign-only, empty, embedded-sign, or out-of-int-range span reports
+        // failure and falls through to int.TryParse (which returns 0), exactly
+        // as before.
+        if (TryParseAsciiInt(span, out var fast))
+            return BoxInt(fast);
         return BoxInt(int.TryParse(span, out var i) ? i : 0);
+    }
+
+    private static bool TryParseAsciiInt(ReadOnlySpan<char> span, out int value)
+    {
+        value = 0;
+        if (span.Length == 0)
+            return false;
+
+        int idx = 0;
+        bool negative = false;
+        var first = span[0];
+        if (first == '+' || first == '-')
+        {
+            negative = first == '-';
+            idx = 1;
+        }
+        if (idx == span.Length)
+            return false; // sign with no digits
+
+        long acc = 0;
+        for (; idx < span.Length; idx++)
+        {
+            uint digit = (uint)(span[idx] - '0');
+            if (digit > 9)
+                return false; // embedded '-', '+', '.', etc. — let int.TryParse decide
+            acc = acc * 10 + digit;
+            if (acc > (long)int.MaxValue + 1)
+                return false; // overflow — fall back (int.TryParse yields 0)
+        }
+
+        if (negative)
+            acc = -acc;
+        if (acc < int.MinValue || acc > int.MaxValue)
+            return false;
+
+        value = (int)acc;
+        return true;
     }
 
     private string ParseKeyword(string content, ref int pos)
@@ -990,13 +1039,7 @@ public class TextExtractor
                     _fontName = operands[0] is string name ? name.TrimStart('/') : "";
                     _fontSize = ToDouble(operands[1]);
                     _currentFont = ResolveFontFromActiveResources(_fontName);
-                    _toUnicodeMap = LoadToUnicodeMap(_currentFont);
-                    (_differencesGlyphNames, _differencesBaseEncoding) = LoadDifferencesEncoding(_currentFont);
-                    _toUnicodeIdentity = _toUnicodeMap == null && ToUnicodeIsIdentity(_currentFont);
-                    _useStandardMacGlyphOrder = _toUnicodeMap == null && UsesStandardMacGlyphOrderFallback(_currentFont);
-                    _embeddedCidToUnicode = _toUnicodeMap == null ? LoadEmbeddedCidToUnicodeMap(_currentFont) : null;
-                    _simpleSymbolCodeToUnicode = _toUnicodeMap == null ? LoadSimpleSymbolTrueTypeMap(_currentFont) : null;
-                    LoadFontGeometry();
+                    LoadFontDerivedState();
                 }
                 break;
 
@@ -1558,6 +1601,100 @@ public class TextExtractor
                 Fonts.CidFontWidths.SpecDefaultVerticalDisplacement,
                 GetCharWidth(cid) / 2,
                 Fonts.CidFontWidths.SpecDefaultVerticalOriginY);
+
+    // Every derived field below (ToUnicode map, /Differences, the Identity /
+    // Mac-order / embedded-CID / symbol flags, and all of LoadFontGeometry's
+    // CID/CMap/width state) is a pure function of the resolved font dictionary.
+    // But Tf recurs constantly — every text block re-issues it — so
+    // recomputing them per call (re-parsing ToUnicode/CMap streams and the /W
+    // width table, which is the LoadFontGeometry inclusive hotspot and the
+    // source of the Double[] growth inside those parsers) was a large share of
+    // extraction cost. Cache the computed state keyed by font-dict reference —
+    // PdfDocument.Resolve returns a stable instance per object number, so the
+    // same font hits — and re-ASSIGN every field on each Tf via a snapshot.
+    //
+    // Deliberately a snapshot/restore, NOT a "skip reload if same font"
+    // short-circuit: ExtractFormXObjectContent saves/restores only a SUBSET of
+    // these fields (not /Differences, the Identity/Mac-order/embedded/symbol
+    // flags, _isCidFont, or the registered CMap/CID→Unicode maps), and the
+    // unconditional reload at the next Tf is what HEALS that partial restore.
+    // Re-assigning all fields from the cached snapshot reproduces that exactly;
+    // a skip-if-same would leave the un-restored fields stale after any form
+    // XObject and change output. #600.
+    private readonly Dictionary<PdfDictionary, FontState> _fontStateCache =
+        new(ReferenceEqualityComparer.Instance);
+
+    private void LoadFontDerivedState()
+    {
+        if (_currentFont != null && _fontStateCache.TryGetValue(_currentFont, out var cached))
+        {
+            ApplyFontState(cached);
+            return;
+        }
+
+        // Cache miss (or a null font, which is never cached): run the exact
+        // original compute sequence, writing the instance fields directly.
+        _toUnicodeMap = LoadToUnicodeMap(_currentFont);
+        (_differencesGlyphNames, _differencesBaseEncoding) = LoadDifferencesEncoding(_currentFont);
+        _toUnicodeIdentity = _toUnicodeMap == null && ToUnicodeIsIdentity(_currentFont);
+        _useStandardMacGlyphOrder = _toUnicodeMap == null && UsesStandardMacGlyphOrderFallback(_currentFont);
+        _embeddedCidToUnicode = _toUnicodeMap == null ? LoadEmbeddedCidToUnicodeMap(_currentFont) : null;
+        _simpleSymbolCodeToUnicode = _toUnicodeMap == null ? LoadSimpleSymbolTrueTypeMap(_currentFont) : null;
+        LoadFontGeometry();
+
+        if (_currentFont != null)
+            _fontStateCache[_currentFont] = CaptureFontState();
+    }
+
+    private FontState CaptureFontState() => new(
+        _toUnicodeMap,
+        _differencesGlyphNames,
+        _differencesBaseEncoding,
+        _toUnicodeIdentity,
+        _useStandardMacGlyphOrder,
+        _embeddedCidToUnicode,
+        _simpleSymbolCodeToUnicode,
+        _is2ByteFont,
+        _isCidFont,
+        _isVerticalWriting,
+        _cidMetrics,
+        _registeredEncodingCMap,
+        _registeredCidToUnicode);
+
+    private void ApplyFontState(in FontState s)
+    {
+        _toUnicodeMap = s.ToUnicodeMap;
+        _differencesGlyphNames = s.DifferencesGlyphNames;
+        _differencesBaseEncoding = s.DifferencesBaseEncoding;
+        _toUnicodeIdentity = s.ToUnicodeIdentity;
+        _useStandardMacGlyphOrder = s.UseStandardMacGlyphOrder;
+        _embeddedCidToUnicode = s.EmbeddedCidToUnicode;
+        _simpleSymbolCodeToUnicode = s.SimpleSymbolCodeToUnicode;
+        _is2ByteFont = s.Is2ByteFont;
+        _isCidFont = s.IsCidFont;
+        _isVerticalWriting = s.IsVerticalWriting;
+        _cidMetrics = s.CidMetrics;
+        _registeredEncodingCMap = s.RegisteredEncodingCMap;
+        _registeredCidToUnicode = s.RegisteredCidToUnicode;
+    }
+
+    // Snapshot of the size-independent per-font state derived from one font
+    // dictionary (#600). _fontName/_fontSize are the only genuinely per-Tf
+    // fields and are set by the Tf handler, not stored here.
+    private readonly record struct FontState(
+        Dictionary<int, string>? ToUnicodeMap,
+        Dictionary<int, string>? DifferencesGlyphNames,
+        string? DifferencesBaseEncoding,
+        bool ToUnicodeIdentity,
+        bool UseStandardMacGlyphOrder,
+        Dictionary<int, string>? EmbeddedCidToUnicode,
+        Dictionary<int, string>? SimpleSymbolCodeToUnicode,
+        bool Is2ByteFont,
+        bool IsCidFont,
+        bool IsVerticalWriting,
+        Fonts.CidFontWidths? CidMetrics,
+        CidCMap? RegisteredEncodingCMap,
+        IReadOnlyDictionary<int, string>? RegisteredCidToUnicode);
 
     /// <summary>
     /// After Tf loads a font, update Type 0 / CID-specific state: 2-byte stride,

--- a/tests/perf-budgets/workflow-budgets.json
+++ b/tests/perf-budgets/workflow-budgets.json
@@ -188,48 +188,48 @@
       "hotPath": "Excise.Core TextExtractor: content parse + letter accumulators + font/XObject resource materialization (#600; #597 report s3.3)",
       "baseline": {
         "totalMs": 198.2,
-        "totalAllocatedMB": 389.4
+        "totalAllocatedMB": 160.7
       },
       "perPdf": {
         "cdc-vis-covid-19.pdf": {
           "ms": 10.09,
-          "mb": 4.152
+          "mb": 2.117
         },
         "irs-1040-instructions.pdf": {
           "ms": 18.1,
-          "mb": 17.5
+          "mb": 8.625
         },
         "irs-1040.pdf": {
           "ms": 5.58,
-          "mb": 2.492
+          "mb": 2.511
         },
         "irs-pub509-2026.pdf": {
           "ms": 32.01,
-          "mb": 40.895
+          "mb": 12.488
         },
         "irs-w4.pdf": {
           "ms": 6.76,
-          "mb": 4.435
+          "mb": 4.471
         },
         "irs-w9.pdf": {
           "ms": 6.58,
-          "mb": 5.392
+          "mb": 5.438
         },
         "scotus-trump-v-anderson.pdf": {
           "ms": 7.17,
-          "mb": 10.565
+          "mb": 3.72
         },
         "scotus-trump-v-us.pdf": {
           "ms": 8.76,
-          "mb": 12.26
+          "mb": 4.865
         },
         "state-ds11-passport.pdf": {
           "ms": 65.13,
-          "mb": 179.188
+          "mb": 58.857
         },
         "state-ds82-passport-renewal.pdf": {
           "ms": 37.99,
-          "mb": 112.489
+          "mb": 57.636
         }
       }
     },


### PR DESCRIPTION
## Summary
Continues the #600 text-extraction hot-path work (prior PR #747 handled per-token allocation churn). Targets the remaining measured hotspots: `LoadFontGeometry` (15.5% inclusive, recomputed on every `Tf`), `ParseNumber` routing through `Number.TryParse*`, `Double[].Resize` (inside the font/CMap/width parsers), and an under-sized operand list.

## What changed (all in `Excise.Core/Text/TextExtractor.cs`)
- **Per-font state cache.** All size-independent derived state (ToUnicode map, `/Differences`, the Identity / Mac-glyph-order / embedded-CID / symbol-cmap decode tables, and the CID/CMap/`/W` width geometry) is cached keyed by the **resolved font dictionary** (`Resolve` returns a stable instance per object). Every text block re-issues `Tf`, so this was the dominant repeated cost, and it also removes the `Double[].Resize` churn inside the width/CMap parsers (they now run once per font, not once per `Tf`).
  - Implemented as **snapshot/restore that re-assigns all 13 derived fields on every `Tf`**, deliberately NOT a skip-if-same short-circuit: `ExtractFormXObjectContent` only partially save/restores font state, and the unconditional reload at the next `Tf` is what heals that — a cache that reassigns every field reproduces today's behavior exactly.
- **Exact inline integer parse** in `ParseNumber` for the common operand (TJ kerns, `Td`/`Tm`/`cm` coords), bypassing `int.TryParse`'s culture machinery. Bit-identical: accumulates in `long`, and any sign-only / embedded-sign / out-of-int-range span falls back to `int.TryParse` (which returns 0), exactly as before. Reals stay on `double.TryParse`.
- **Pre-sized operand list** (past the default 4).

## Measured delta — `test-pdfs/smoke`, min-of-3, Release (`scripts/check-perf-budgets.sh`)
| metric | before | after | delta |
|---|--:|--:|--:|
| text-extract allocation | 389.7 MB | 160.7 MB | **-58.8%** |
| text-extract time | 230.2 ms | 164.7 ms | **-28.5%** |
| redaction-save allocation | 1214.7 MB | 1115.3 MB | -8.2% (shares extractor) |

## Correctness (redaction-adjacent — extraction bounds redaction)
- **`scripts/check-extraction-parity.sh`: unchanged at 98.7% / 332 pages** — every change is behavior-preserving, so extraction output (and therefore redaction reach) did not move. This is the oracle that proves it.
- `scripts/test-tier.sh t0` green (build 0-warning, full `Excise.Core.Tests`, `verify-true-redaction`, doc-claims).
- `scripts/check-perf-budgets.sh`: PASS. The text-extract **allocation** budget was tightened to the new measured floor to lock in the win (allocation is the machine-stable hard gate; `ms` and all other workflows left untouched).

No public API change (all new members private, incl. a nested `record struct`); no `approved.txt` regen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)