### PR TITLE
perf(gui): index search matches by page to cut page-navigation cost (#601)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,25 @@ semantic versioning.
 
 ## [Unreleased]
 
-## [3.3.1] - 2026-07-26
+### Performance
+- **GUI interaction latency: per-page search-highlight index (#601).** Page
+  navigation recomputed the current page's search highlights with a linear
+  `O(total matches)` scan over every match on *every* page flip, so the cost
+  grew with document size (a dense search on a large book — thousands of
+  matches — made each page change scan all of them). Matches are now indexed by
+  page once when results publish, making the per-navigation lookup
+  `O(matches on the target page)`. Measured (new `GuiLatencyBenchmarkTests`,
+  400-page document, 2,000-match active search, 2 runs): the per-navigation
+  match lookup dropped from **~22 µs to ~0.05 µs** (~400×), and — being now
+  independent of match count — no longer scales with the document (the old scan
+  was linear in total matches, so ~2 ms at 200k matches).
+  **User-visible latency was already sub-frame and is unchanged within
+  measurement noise** — every direct interaction averaged well under one 60 Hz
+  input frame both before and after (end-to-end page navigation ≈ 0.5–0.7 ms,
+  its run-to-run baseline jitter larger than the change). The value is removing
+  the one per-interaction cost that scaled with document content, plus the new
+  benchmark that gates each profiled interaction under a 16 ms budget going
+  forward.
 
 ### Fixed
 - **Symbolic TrueType with a (3,0) symbol cmap: text extraction mis-decode**

--- a/Excise.App.Tests/UI/GuiLatencyBenchmarkTests.cs
+++ b/Excise.App.Tests/UI/GuiLatencyBenchmarkTests.cs
@@ -1,0 +1,212 @@
+using System;
+using System.Diagnostics;
+using System.Text.Json;
+using Avalonia;
+using Avalonia.Controls;
+using AwesomeAssertions;
+using Excise.Avalonia.Controls;
+using Excise.Core.Document;
+using Excise.App.Tests.Utilities;
+using Excise.App.ViewModels;
+using Excise.App.Views;
+
+namespace Excise.App.Tests.UI;
+
+/// <summary>
+/// Repeatable interaction-latency benchmark for #601. Unlike
+/// <see cref="GuiWorkflowPerformanceReportTests"/> (single pass, whole-ms
+/// resolution on a 12-page synthetic doc — which floors most interactions at
+/// 0 ms), this drives each pure ViewModel interaction MANY times on a LARGE
+/// document and reports the AVERAGE in sub-millisecond resolution, so an O(n)
+/// per-interaction cost that a single 0-ms sample hides becomes visible.
+///
+/// The measured phases are the UI-thread work a real interaction triggers
+/// (property-change fan-out, highlight/selection recomputation, scroll-offset
+/// lookup) — NOT the async render/raster that follows, which belongs to
+/// Excise.Rendering (#598/#599) and is out of scope here.
+///
+/// Budgets are the "measurable budget" restatement requested on #601: each
+/// direct interaction must average well under one input frame (16 ms) even on
+/// a large document with an active many-match search. They are intentionally
+/// generous versus the measured numbers so the gate flags a real regression,
+/// not machine jitter.
+/// </summary>
+[Collection("AvaloniaTests")]
+public class GuiLatencyBenchmarkTests
+{
+    private const int LargePageCount = 400;
+    private const int Iterations = 40;
+
+    // Per-interaction average must stay under one 60 Hz input frame.
+    private const double DirectInputFrameBudgetMs = 16.0;
+
+    [FixedAvaloniaFact]
+    public async Task DirectInteractions_StayWithinInputFrameBudget_OnLargeDocument()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"excise-gui-latency-{Guid.NewGuid():N}.pdf");
+        TestPdfGenerator.CreateMultiPagePdf(path, pageCount: LargePageCount);
+
+        try
+        {
+            var vm = new MainWindowViewModel();
+            var window = new MainWindow { DataContext = vm, Width = 1280, Height = 900 };
+            window.Show();
+            await vm.LoadDocumentAsync(path);
+
+            var results = new List<BenchResult>();
+
+            // Page navigation with NO active search (baseline fan-out cost).
+            results.Add(BenchToggle("page-navigation.no-search", vm, 10, 20));
+
+            // Populate a many-match search: "e" appears several times on every
+            // page, so SearchMatches grows into the thousands — the worst case
+            // for the per-navigation highlight recomputation.
+            vm.SearchText = "e";
+            vm.FindNow();
+            await WaitForAsync(() => vm.SearchMatches.Count > 0 && !vm.IsSearching, TimeSpan.FromSeconds(60));
+            var matchCount = vm.SearchMatches.Count;
+
+            // Page navigation WITH the active many-match search.
+            results.Add(BenchToggle("page-navigation.active-search", vm, 10, 20));
+
+            // Focused A/B of the exact operation the #601 fix changed, free of
+            // dispatcher/navigation fixed costs: resolving "which matches are on
+            // the current page" via the OLD linear scan over all matches vs the
+            // NEW per-page index. This isolates the O(total matches) → O(matches
+            // on page) improvement so it reads as signal, not sub-ms jitter.
+            // Each sample resolves the matches for ONE page, so the reported
+            // avg is the cost of a SINGLE per-navigation lookup (a real page
+            // flip does one, not many).
+            var matches = vm.SearchMatches;
+            var index = vm.MatchesByPageIndexForBenchmark;
+            results.Add(BenchLookup("highlight-lookup.old-linear-scan", i =>
+            {
+                int p = (i * 37) % LargePageCount;
+                return matches.Where(m => m.PageIndex == p).ToList().Count;
+            }));
+            results.Add(BenchLookup("highlight-lookup.new-indexed", i =>
+            {
+                int p = (i * 37) % LargePageCount;
+                return index.TryGetValue(p, out var onPage) ? onPage.Count : 0;
+            }));
+
+            results.Add(Bench("zoom-in", () => vm.ZoomInCommand.Execute().Subscribe()));
+            results.Add(Bench("zoom-fit-width", () => vm.ZoomFitWidthCommand.Execute().Subscribe()));
+
+            // Continuous scroll-offset lookup (cached slot binary search).
+            vm.ViewMode = PdfViewMode.Continuous;
+            var viewer = window.FindControl<PdfViewerControl>("PdfViewerControl");
+            var scroll = viewer?.FindControl<ScrollViewer>("ContinuousScrollViewer");
+            if (scroll != null)
+            {
+                double y = 0;
+                results.Add(Bench("continuous-scroll-offset", () =>
+                {
+                    y = (y + 1_800) % 40_000;
+                    scroll.Offset = new Vector(0, y);
+                }));
+            }
+            vm.ViewMode = PdfViewMode.SinglePage;
+
+            results.Add(Bench("redaction-preview-state", () =>
+            {
+                vm.IsRedactionMode = true;
+                vm.CurrentRedactionArea = new Rect(20, 40, 160, 48);
+                vm.CurrentRedactionPageArea = PdfPageRect.ViewerDips(
+                    vm.CurrentPage, 20, 40, 160, 48, MainWindowViewModel.DefaultViewerRenderDpi);
+            }));
+
+            WriteReport(results, matchCount);
+
+            foreach (var r in results)
+            {
+                // The highlight-lookup.* probes are diagnostic A/B measurements
+                // of the changed operation, not direct interactions — they are
+                // reported but not gated.
+                if (r.Name.StartsWith("highlight-lookup.", StringComparison.Ordinal))
+                    continue;
+
+                r.AvgMs.Should().BeLessThan(DirectInputFrameBudgetMs,
+                    $"interaction '{r.Name}' averaged {r.AvgMs:F3} ms/iter over {Iterations} iterations " +
+                    $"on a {LargePageCount}-page document ({matchCount} active search matches); " +
+                    "direct interactions must stay under one 60 Hz input frame");
+            }
+        }
+        finally
+        {
+            TestPdfGenerator.CleanupTestFile(path);
+        }
+    }
+
+    private static BenchResult BenchToggle(string name, MainWindowViewModel vm, int a, int b)
+    {
+        var toggle = false;
+        return Bench(name, () =>
+        {
+            vm.CurrentPageIndex = toggle ? a : b;
+            toggle = !toggle;
+        });
+    }
+
+    private static BenchResult Bench(string name, Action action)
+    {
+        // Warm up so JIT / first-touch allocation isn't charged to the average.
+        for (int i = 0; i < 5; i++) action();
+
+        var sw = Stopwatch.StartNew();
+        for (int i = 0; i < Iterations; i++) action();
+        sw.Stop();
+
+        return new BenchResult(name, sw.Elapsed.TotalMilliseconds / Iterations);
+    }
+
+    // High-sample-count measurement of a single-page match lookup. Each call
+    // does exactly one lookup, so the reported avg is per-navigation cost.
+    // The sample count is large because the indexed path is sub-microsecond.
+    private const int LookupSamples = 20_000;
+
+    private static BenchResult BenchLookup(string name, Func<int, int> lookup)
+    {
+        for (int i = 0; i < 200; i++) _ = lookup(i); // warm up
+
+        long sink = 0;
+        var sw = Stopwatch.StartNew();
+        for (int i = 0; i < LookupSamples; i++) sink += lookup(i);
+        sw.Stop();
+        GC.KeepAlive(sink);
+
+        return new BenchResult(name, sw.Elapsed.TotalMilliseconds / LookupSamples);
+    }
+
+    private static async Task WaitForAsync(Func<bool> predicate, TimeSpan timeout)
+    {
+        var deadline = Stopwatch.StartNew();
+        while (!predicate())
+        {
+            if (deadline.Elapsed > timeout)
+                throw new TimeoutException($"Condition was not met within {timeout.TotalSeconds:0.0}s.");
+            await Task.Delay(25);
+        }
+    }
+
+    private static void WriteReport(IReadOnlyList<BenchResult> results, int matchCount)
+    {
+        var outputDir = Path.Combine(AppContext.BaseDirectory, "UI", "test-output");
+        Directory.CreateDirectory(outputDir);
+        var path = Path.Combine(outputDir, "gui-latency-benchmark.json");
+        var report = new
+        {
+            schemaVersion = 1,
+            generatedUtc = DateTimeOffset.UtcNow,
+            suite = "gui-latency-benchmark",
+            pageCount = LargePageCount,
+            iterations = Iterations,
+            searchMatchCount = matchCount,
+            budgetMs = DirectInputFrameBudgetMs,
+            results = results.Select(r => new { r.Name, avgMs = r.AvgMs }),
+        };
+        File.WriteAllText(path, JsonSerializer.Serialize(report, new JsonSerializerOptions { WriteIndented = true }));
+    }
+
+    private sealed record BenchResult(string Name, double AvgMs);
+}

--- a/Excise.App.Tests/UI/SearchHighlightIndexTests.cs
+++ b/Excise.App.Tests/UI/SearchHighlightIndexTests.cs
@@ -1,0 +1,98 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using AwesomeAssertions;
+using Excise.App.Tests.Utilities;
+using Excise.App.ViewModels;
+using Xunit;
+
+namespace Excise.App.Tests.UI;
+
+/// <summary>
+/// Behaviour-preservation guard for the #601 per-page search-match index.
+/// UpdateSearchHighlights used to scan all SearchMatches on every page
+/// navigation (SearchMatches.Where(m => m.PageIndex == current)); it now reads
+/// a per-page index. These tests pin that the index returns EXACTLY the same
+/// matches, per page, that the linear scan would — the optimization must not
+/// change which highlights a page shows.
+/// </summary>
+[Collection("AvaloniaTests")]
+public class SearchHighlightIndexTests
+{
+    [FixedAvaloniaFact]
+    public async Task PerPageIndex_MatchesLinearScan_ForEveryPage()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"excise-search-index-{Guid.NewGuid():N}.pdf");
+        TestPdfGenerator.CreateMultiPagePdf(path, pageCount: 20);
+
+        try
+        {
+            var vm = new MainWindowViewModel();
+            await vm.LoadDocumentAsync(path);
+
+            vm.SearchText = "Page";
+            vm.FindNow();
+
+            var deadline = DateTime.UtcNow.AddSeconds(30);
+            while (DateTime.UtcNow < deadline && (vm.SearchMatches.Count == 0 || vm.IsSearching))
+                await Task.Delay(50);
+
+            vm.SearchMatches.Should().NotBeEmpty("the generated pages all contain 'Page'");
+
+            var index = vm.MatchesByPageIndexForBenchmark;
+
+            // Every page's indexed set must equal the linear-scan set.
+            for (int page = 0; page < vm.TotalPages; page++)
+            {
+                var expected = vm.SearchMatches.Where(m => m.PageIndex == page).ToList();
+                index.TryGetValue(page, out var actual);
+                (actual ?? new System.Collections.Generic.List<Excise.App.Services.PdfSearchService.SearchMatch>())
+                    .Should().Equal(expected,
+                        $"the per-page index for page {page} must contain exactly the matches a linear scan finds");
+            }
+
+            // The index must account for every match exactly once, no extras.
+            index.Values.Sum(v => v.Count).Should().Be(vm.SearchMatches.Count);
+            index.Keys.Should().OnlyContain(k => k >= 0 && k < vm.TotalPages);
+        }
+        finally
+        {
+            TestPdfGenerator.CleanupTestFile(path);
+        }
+    }
+
+    [FixedAvaloniaFact]
+    public async Task ClearingSearch_EmptiesPerPageIndex()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"excise-search-index-clear-{Guid.NewGuid():N}.pdf");
+        TestPdfGenerator.CreateMultiPagePdf(path, pageCount: 8);
+
+        try
+        {
+            var vm = new MainWindowViewModel();
+            await vm.LoadDocumentAsync(path);
+
+            vm.SearchText = "Page";
+            vm.FindNow();
+            var deadline = DateTime.UtcNow.AddSeconds(30);
+            while (DateTime.UtcNow < deadline && (vm.SearchMatches.Count == 0 || vm.IsSearching))
+                await Task.Delay(50);
+            vm.MatchesByPageIndexForBenchmark.Count.Should().BeGreaterThan(0);
+
+            // Clearing the search text schedules ClearSearch on the debounce path.
+            vm.SearchText = string.Empty;
+            deadline = DateTime.UtcNow.AddSeconds(10);
+            while (DateTime.UtcNow < deadline && vm.SearchMatches.Count > 0)
+                await Task.Delay(50);
+
+            vm.SearchMatches.Should().BeEmpty();
+            vm.MatchesByPageIndexForBenchmark.Count.Should().Be(0,
+                "clearing the search must also empty the per-page index so stale highlights cannot appear");
+        }
+        finally
+        {
+            TestPdfGenerator.CleanupTestFile(path);
+        }
+    }
+}

--- a/Excise.App/ViewModels/MainWindowViewModel.Search.cs
+++ b/Excise.App/ViewModels/MainWindowViewModel.Search.cs
@@ -143,10 +143,41 @@ public partial class MainWindowViewModel
         });
     }
 
+    // Per-page index of the current SearchMatches, rebuilt whenever the
+    // collection is reassigned. UpdateSearchHighlights runs on every page
+    // navigation; a linear SearchMatches.Where(m => m.PageIndex == ...) scan
+    // there is O(total matches) per page flip, which grows with document size
+    // (a dense search on a large book — thousands of matches — turns each page
+    // flip into a scan of all of them). The index makes the per-navigation
+    // lookup O(matches on the target page). See #601.
+    private readonly System.Collections.Generic.Dictionary<int, System.Collections.Generic.List<PdfSearchService.SearchMatch>> _matchesByPage = new();
+
     public ObservableCollection<PdfSearchService.SearchMatch> SearchMatches
     {
         get => _searchMatches;
-        set => this.RaiseAndSetIfChanged(ref _searchMatches, value);
+        set
+        {
+            this.RaiseAndSetIfChanged(ref _searchMatches, value);
+            RebuildMatchesByPageIndex();
+        }
+    }
+
+    /// <summary>Test hook (#601 benchmark): the per-page match index.</summary>
+    internal System.Collections.Generic.IReadOnlyDictionary<int, System.Collections.Generic.List<PdfSearchService.SearchMatch>> MatchesByPageIndexForBenchmark
+        => _matchesByPage;
+
+    private void RebuildMatchesByPageIndex()
+    {
+        _matchesByPage.Clear();
+        foreach (var match in _searchMatches)
+        {
+            if (!_matchesByPage.TryGetValue(match.PageIndex, out var list))
+            {
+                list = new System.Collections.Generic.List<PdfSearchService.SearchMatch>();
+                _matchesByPage[match.PageIndex] = list;
+            }
+            list.Add(match);
+        }
     }
 
     public int CurrentSearchMatchIndex
@@ -488,10 +519,10 @@ public partial class MainWindowViewModel
             if (SearchMatches.Count == 0 || _documentService == null)
                 return;
 
-            // Get matches for current page
-            var pageMatches = SearchMatches.Where(m => m.PageIndex == CurrentPageIndex).ToList();
-
-            if (pageMatches.Count == 0)
+            // Get matches for current page from the per-page index (#601):
+            // O(matches on this page) rather than an O(total matches) scan on
+            // every page navigation.
+            if (!_matchesByPage.TryGetValue(CurrentPageIndex, out var pageMatches) || pageMatches.Count == 0)
                 return;
 
             foreach (var match in pageMatches)
@@ -516,6 +547,7 @@ public partial class MainWindowViewModel
     private void ClearSearch()
     {
         SearchMatches.Clear();
+        _matchesByPage.Clear();
         CurrentSearchMatchIndex = -1;
         ClearSearchStatus();
         this.RaisePropertyChanged(nameof(SearchResultText));


### PR DESCRIPTION
## Summary

Optimizes GUI interaction latency for #601, measuring from a repeatable
baseline rather than guessing.

**Finding (measured):** the GUI is already responsive — on a 400-page document
every profiled interaction averages well under one 60 Hz input frame, both
before and after this change. This matches the issue owner's earlier profile.
Per the acceptance criteria ("before/after improvement **or justify no
change**"), user-visible latency is **unchanged within measurement noise**.

**What this change does:** it removes the one per-interaction cost that
*scaled with document content*. `UpdateSearchHighlights` (run on every page
navigation) recomputed the current page's highlights with a linear
`O(total matches)` scan over every `SearchMatch`. Matches are now indexed by
page once when results publish, so the per-navigation lookup is
`O(matches on the target page)` and independent of total match count.

## Measured (new `GuiLatencyBenchmarkTests`, 400-page doc, 2,000-match search, 2 runs)

| Metric | Before | After |
|---|---:|---:|
| per-navigation highlight lookup | **~20–22 µs** | **~0.01–0.05 µs** (~400×) |
| end-to-end page navigation | ~0.3–0.9 ms | ~0.3–0.9 ms (within noise) |

The old scan was linear in total matches (~2 ms at 200k matches); the indexed
lookup is flat. The benchmark is checked in and gates each profiled
interaction under a 16 ms budget going forward — the "restate as a measurable
budget" the issue asked for.

## Behavior preservation
`SearchHighlightIndexTests` pins that the per-page index returns exactly the
matches a linear scan would, for every page, and that clearing search empties
the index. Change is confined to `Excise.App` (+ one `internal` test hook);
`_matchesByPage` is UI-thread-only, mirroring `SearchMatches`.

## Tests
- `scripts/test-tier.sh t0`: PASS (build, core, cli, avalonia, doc-claims, redaction-architecture, gate-asymmetry).
- Full `Excise.App.Tests` (serial): **1072 passed, 0 failed, 26 skipped** — display sweep intact.
- `Excise.Avalonia.Tests`: PASS (via t0).
- Build: 0 warnings.
- `Excise.Avalonia.approved.txt`: no change (no Avalonia public API touched).

## Scope
App/Avalonia interaction layer only. Renderer hot paths (#598/#599) untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)