### PR TITLE
perf: cache glyph outlines on the renderer text hot path (#598)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ semantic versioning.
 
 ## [Unreleased]
 
+### Performance
+- **Renderer glyph-outline caching on the text hot path** (#598) — glyph
+  outlines are now tessellated once per (typeface, size, glyph) and reused for
+  the rest of the page instead of re-decoding the same outline on every draw.
+  The dominant win is the embedded-subset-font path (Type0/CID and byte-cmap
+  simple fonts drawn glyph-by-glyph via `SKFont.GetGlyphPath` in
+  `BuildGlyphIdTextPath`), where real-world body text recurs the same glyph IDs
+  thousands of times per page: on the smoke corpus the outline cache serves
+  94.6% of glyph lookups (≈917k hits / 970k lookups; ≈561k avoided
+  tessellations on `irs-1040-instructions.pdf` alone). Measured back-to-back in
+  Release on the smoke corpus (`scripts/check-perf-budgets.sh`, min-of-3, with
+  the non-rendering `text-extract` workflow flat as a machine-stability
+  control): `all-page-render` managed allocation 206→197 MB (-4.4%) and render
+  time 794→749 ms (-5.7%); `navigation-rerender` 271→258 ms (-4.8%). The caches
+  hold only the UNPOSITIONED outline; every draw still transforms a fresh copy
+  to its own cursor/scale, so output is byte-identical — verified by the Visual
+  PNG baselines (63/0 unchanged) and the mutool differential smoke suite (49/0)
+  on the embedded-font corpus. Cache lifetime is one page render; keys compare
+  the typeface by reference.
+
 ## [3.3.1] - 2026-07-26
 
 ### Fixed

--- a/Excise.Rendering.Tests/GlyphOutlineCacheTests.cs
+++ b/Excise.Rendering.Tests/GlyphOutlineCacheTests.cs
@@ -1,0 +1,56 @@
+using System;
+using System.IO;
+using AwesomeAssertions;
+using Excise.Core.Document;
+using Xunit;
+
+namespace Excise.Rendering.Tests;
+
+/// <summary>
+/// Guards the glyph-outline caches on the render text hot path (#598).
+/// SKFont.GetGlyphPath / GetTextPath drive the platform font scaler to
+/// tessellate a glyph outline on every call; the same glyph recurs thousands
+/// of times per page of body text, so the caches must serve the repeats. The
+/// caches hold the UNPOSITIONED outline only — every draw still transforms a
+/// fresh copy to its own cursor/scale, which is what keeps the raster
+/// byte-identical (see the pixel-identity Visual/Differential suites).
+/// </summary>
+public class GlyphOutlineCacheTests
+{
+    [Fact]
+    public void RepeatedGlyphsAreTessellatedOnceAndReused()
+    {
+        var fixture = Path.Combine(
+            FindRepoRoot(), "test-pdfs", "sample-pdfs", "multilingual-noto-cjk.pdf");
+        if (!File.Exists(fixture))
+            return; // fixture not present in this checkout — nothing to guard
+
+        using var doc = PdfDocument.Open(File.ReadAllBytes(fixture));
+        var renderer = new SkiaRenderer();
+
+        RenderContext.GlyphOutlineCacheHits = 0;
+        RenderContext.GlyphOutlineCacheMisses = 0;
+
+        for (int p = 1; p <= doc.PageCount; p++)
+            using (renderer.RenderPage(doc.GetPage(p), new RenderOptions { Dpi = 96 })) { }
+
+        long hits = RenderContext.GlyphOutlineCacheHits;
+        long misses = RenderContext.GlyphOutlineCacheMisses;
+
+        misses.Should().BeGreaterThan(0,
+            "the glyph-outline path must be exercised by this embedded-font fixture");
+        hits.Should().BeGreaterThan(0,
+            "recurring glyphs must be served from the outline cache, not re-tessellated");
+        // This is a mechanism guard, not a pixel or ratio assertion: hit rate is
+        // fixture-dependent (this multilingual sample has many unique CJK
+        // glyphs). On Latin body text corpus-wide it exceeds 90% (#598).
+    }
+
+    private static string FindRepoRoot()
+    {
+        var d = new DirectoryInfo(AppContext.BaseDirectory);
+        while (d != null && !File.Exists(Path.Combine(d.FullName, "excise.sln")))
+            d = d.Parent;
+        return d?.FullName ?? AppContext.BaseDirectory;
+    }
+}

--- a/Excise.Rendering/SkiaRenderer.Images.cs
+++ b/Excise.Rendering/SkiaRenderer.Images.cs
@@ -566,6 +566,12 @@ internal partial class RenderContext
     private void DisposeOwnedResources()
     {
         DisposeImageBitmapCache();
+        foreach (var glyphPath in _glyphOutlineCache.Values)
+            glyphPath?.Dispose();
+        _glyphOutlineCache.Clear();
+        foreach (var glyphPath in _glyphOutlineByIdCache.Values)
+            glyphPath?.Dispose();
+        _glyphOutlineByIdCache.Clear();
         foreach (var typeface in _embeddedTypefaces.Values)
             typeface.Dispose();
         _embeddedTypefaces.Clear();

--- a/Excise.Rendering/SkiaRenderer.Text.cs
+++ b/Excise.Rendering/SkiaRenderer.Text.cs
@@ -1559,14 +1559,14 @@ internal partial class RenderContext
                     {
                         if (fillWithPattern)
                         {
-                            using var glyphPath = font.GetTextPath(glyphText, SKPoint.Empty);
+                            var glyphPath = GetCachedGlyphOutline(font, currentFont.Typeface!, glyphText);
                             AddScaledGlyphPath(localFillPatternPath, glyphPath, cursor, fallbackGlyphScale);
                         }
                         else
                         {
                             // #710: fill from the outline path, not the
                             // platform glyph mask (see FillTextUsingGlyphPath).
-                            using var fillGlyphPath = BuildScaledGlyphPath(font, glyphText, cursor, fallbackGlyphScale);
+                            using var fillGlyphPath = BuildScaledGlyphPath(font, currentFont.Typeface!, glyphText, cursor, fallbackGlyphScale);
                             FillTextUsingGlyphPath(
                                 fillGlyphPath, fillPaint,
                                 () => DrawFallbackGlyph(glyphText, cursor, fallbackGlyphScale, font, fillPaint));
@@ -1578,7 +1578,7 @@ internal partial class RenderContext
                             strokePaint);
                     if (localClipPath != null)
                     {
-                        using var glyphPath = font.GetTextPath(glyphText, SKPoint.Empty);
+                        var glyphPath = GetCachedGlyphOutline(font, currentFont.Typeface!, glyphText);
                         if (glyphPath != null && !glyphPath.IsEmpty)
                         {
                             using var transformedGlyphPath = new SKPath();
@@ -1670,8 +1670,8 @@ internal partial class RenderContext
                     if (fillText && fillWithPattern)
                     {
                         using var localPath = positions != null
-                            ? BuildGlyphIdTextPath(gids, positions, font)
-                            : BuildGlyphIdTextPath(gids, font, measurePaint);
+                            ? BuildGlyphIdTextPath(gids, positions, currentFont.Typeface!, font)
+                            : BuildGlyphIdTextPath(gids, currentFont.Typeface!, font, measurePaint);
                         if (localPath != null && !localPath.IsEmpty)
                             localFillPatternPath!.AddPath(localPath, SKPathAddMode.Append);
                     }
@@ -1680,8 +1680,8 @@ internal partial class RenderContext
                         // #710: fill from the outline path, not the platform
                         // glyph mask (see FillTextUsingGlyphPath).
                         using var fillGlyphPath = positions != null
-                            ? BuildGlyphIdTextPath(gids, positions, font)
-                            : BuildGlyphIdTextPath(gids, font, measurePaint);
+                            ? BuildGlyphIdTextPath(gids, positions, currentFont.Typeface!, font)
+                            : BuildGlyphIdTextPath(gids, currentFont.Typeface!, font, measurePaint);
                         var blobToFill = blob;
                         FillTextUsingGlyphPath(
                             fillGlyphPath, fillPaint,
@@ -1696,8 +1696,8 @@ internal partial class RenderContext
                 if (clipText)
                 {
                     using var localClipPath = positions != null
-                        ? BuildGlyphIdTextPath(gids, positions, font)
-                        : BuildGlyphIdTextPath(gids, font, measurePaint);
+                        ? BuildGlyphIdTextPath(gids, positions, currentFont.Typeface!, font)
+                        : BuildGlyphIdTextPath(gids, currentFont.Typeface!, font, measurePaint);
                     AddPendingTextClipPath(localClipPath, x, y, th, ySign);
                 }
             }
@@ -1705,7 +1705,7 @@ internal partial class RenderContext
             {
                 if (fillText && fillWithPattern)
                 {
-                    using var localPath = font.GetTextPath(text, SKPoint.Empty);
+                    var localPath = GetCachedGlyphOutline(font, currentFont.Typeface!, text);
                     if (localPath != null && !localPath.IsEmpty)
                         localFillPatternPath!.AddPath(localPath, SKPathAddMode.Append);
                 }
@@ -1713,7 +1713,7 @@ internal partial class RenderContext
                 {
                     // #710: fill from the outline path, not the platform
                     // glyph mask (see FillTextUsingGlyphPath).
-                    using var fillGlyphPath = font.GetTextPath(text, SKPoint.Empty);
+                    var fillGlyphPath = GetCachedGlyphOutline(font, currentFont.Typeface!, text);
                     FillTextUsingGlyphPath(
                         fillGlyphPath, fillPaint,
                         () => _canvas.DrawText(text, 0, 0, font, fillPaint));
@@ -1724,7 +1724,7 @@ internal partial class RenderContext
                         strokePaint);
                 if (clipText)
                 {
-                    using var localClipPath = font.GetTextPath(text, SKPoint.Empty);
+                    var localClipPath = GetCachedGlyphOutline(font, currentFont.Typeface!, text);
                     AddPendingTextClipPath(localClipPath, x, y, th, ySign);
                 }
             }
@@ -1909,12 +1909,14 @@ internal partial class RenderContext
     /// has no outline (bitmap-only face) and the caller must fall back to
     /// <see cref="DrawFallbackGlyph"/>.
     /// </summary>
-    private static SKPath? BuildScaledGlyphPath(SKFont font, string glyphText, float cursor, float horizontalScale)
+    private SKPath? BuildScaledGlyphPath(SKFont font, SKTypeface typeface, string glyphText, float cursor, float horizontalScale)
     {
-        using var glyphPath = font.GetTextPath(glyphText, SKPoint.Empty);
+        var glyphPath = GetCachedGlyphOutline(font, typeface, glyphText);
         if (glyphPath == null || glyphPath.IsEmpty)
             return null;
 
+        // Two-arg Transform reads the cached outline and writes a fresh path;
+        // the cached path is never mutated (#598).
         var positioned = new SKPath();
         var glyphMatrix = new SKMatrix(
             horizontalScale, 0, cursor,
@@ -1922,6 +1924,31 @@ internal partial class RenderContext
             0, 0, 1);
         glyphPath.Transform(glyphMatrix, positioned);
         return positioned;
+    }
+
+    /// <summary>
+    /// Return the UNPOSITIONED glyph outline for <paramref name="glyphText"/>
+    /// at the current font size, reusing a cached <see cref="SKPath"/> when the
+    /// same (typeface, size, text) has been tessellated before on this page
+    /// (#598). The returned path is owned by <see cref="_glyphOutlineCache"/>
+    /// and disposed in DisposeOwnedResources — callers must treat it as
+    /// immutable and only ever use the two-arg <c>Transform(matrix, dest)</c>
+    /// or <c>dest.AddPath(cached)</c> forms, never an in-place transform. May
+    /// be null (whitespace / bitmap-only faces), matching SKFont.GetTextPath.
+    /// </summary>
+    private SKPath? GetCachedGlyphOutline(SKFont font, SKTypeface typeface, string glyphText)
+    {
+        var key = (typeface, BitConverter.SingleToInt32Bits(font.Size), glyphText);
+        if (_glyphOutlineCache.TryGetValue(key, out var cached))
+        {
+            GlyphOutlineCacheHits++;
+            return cached;
+        }
+
+        GlyphOutlineCacheMisses++;
+        var path = font.GetTextPath(glyphText, SKPoint.Empty);
+        _glyphOutlineCache[key] = path;
+        return path;
     }
 
     private SKPaint CreateTextPaint(SKPaintStyle style, SKColor color, float alpha)
@@ -2015,7 +2042,31 @@ internal partial class RenderContext
         _pendingTextClipPath = null;
     }
 
-    private static SKPath BuildGlyphIdTextPath(ushort[] gids, SKFont font, SKPaint measurePaint)
+    /// <summary>
+    /// Glyph-ID counterpart of <see cref="GetCachedGlyphOutline"/> (#598):
+    /// returns the UNPOSITIONED outline for a single glyph ID at the current
+    /// font size, reusing a cached <see cref="SKPath"/> across the page. The
+    /// returned path is owned by <see cref="_glyphOutlineByIdCache"/> and must
+    /// be treated as immutable — callers only ever use the offset/scale
+    /// <c>AddPath</c> or two-arg <c>Transform</c> forms. May be null for glyphs
+    /// with no outline, matching SKFont.GetGlyphPath.
+    /// </summary>
+    private SKPath? GetCachedGlyphOutlineById(SKFont font, SKTypeface typeface, ushort gid)
+    {
+        var key = (typeface, BitConverter.SingleToInt32Bits(font.Size), gid);
+        if (_glyphOutlineByIdCache.TryGetValue(key, out var cached))
+        {
+            GlyphOutlineCacheHits++;
+            return cached;
+        }
+
+        GlyphOutlineCacheMisses++;
+        var path = font.GetGlyphPath(gid);
+        _glyphOutlineByIdCache[key] = path;
+        return path;
+    }
+
+    private SKPath BuildGlyphIdTextPath(ushort[] gids, SKTypeface typeface, SKFont font, SKPaint measurePaint)
     {
         var path = new SKPath();
         if (gids.Length == 0)
@@ -2025,7 +2076,7 @@ internal partial class RenderContext
         float cursor = 0f;
         for (int i = 0; i < gids.Length; i++)
         {
-            using var glyphPath = font.GetGlyphPath(gids[i]);
+            var glyphPath = GetCachedGlyphOutlineById(font, typeface, gids[i]);
             if (glyphPath != null && !glyphPath.IsEmpty)
                 path.AddPath(glyphPath, cursor, 0, SKPathAddMode.Append);
             if (i < widths.Length)
@@ -2035,13 +2086,13 @@ internal partial class RenderContext
         return path;
     }
 
-    private static SKPath BuildGlyphIdTextPath(ushort[] gids, SKPoint[] positions, SKFont font)
+    private SKPath BuildGlyphIdTextPath(ushort[] gids, SKPoint[] positions, SKTypeface typeface, SKFont font)
     {
         var path = new SKPath();
         var count = Math.Min(gids.Length, positions.Length);
         for (int i = 0; i < count; i++)
         {
-            using var glyphPath = font.GetGlyphPath(gids[i]);
+            var glyphPath = GetCachedGlyphOutlineById(font, typeface, gids[i]);
             if (glyphPath != null && !glyphPath.IsEmpty)
                 path.AddPath(glyphPath, positions[i].X, positions[i].Y, SKPathAddMode.Append);
         }
@@ -2049,13 +2100,13 @@ internal partial class RenderContext
         return path;
     }
 
-    private static SKPath BuildGlyphIdTextPath(ushort[] gids, SKPoint[] positions, float[] horizontalScales, SKFont font)
+    private SKPath BuildGlyphIdTextPath(ushort[] gids, SKPoint[] positions, float[] horizontalScales, SKTypeface typeface, SKFont font)
     {
         var path = new SKPath();
         var count = Math.Min(Math.Min(gids.Length, positions.Length), horizontalScales.Length);
         for (int i = 0; i < count; i++)
         {
-            using var glyphPath = font.GetGlyphPath(gids[i]);
+            var glyphPath = GetCachedGlyphOutlineById(font, typeface, gids[i]);
             if (glyphPath == null || glyphPath.IsEmpty)
                 continue;
 
@@ -2663,7 +2714,7 @@ internal partial class RenderContext
             {
                 if (fillText && fillWithPattern)
                 {
-                    using var localPath = BuildGlyphIdTextPath(gids, positions, fallbackGlyphScales, font);
+                    using var localPath = BuildGlyphIdTextPath(gids, positions, fallbackGlyphScales, currentFont.Typeface!, font);
                     if (localPath != null && !localPath.IsEmpty)
                         localFillPatternPath!.AddPath(localPath, SKPathAddMode.Append);
                 }
@@ -2671,7 +2722,7 @@ internal partial class RenderContext
                 {
                     // #710: fill from the outline path, not the platform
                     // glyph mask (see FillTextUsingGlyphPath).
-                    using var fillGlyphPath = BuildGlyphIdTextPath(gids, positions, fallbackGlyphScales, font);
+                    using var fillGlyphPath = BuildGlyphIdTextPath(gids, positions, fallbackGlyphScales, currentFont.Typeface!, font);
                     FillTextUsingGlyphPath(
                         fillGlyphPath, fillPaint,
                         () => DrawPositionedGlyphIds(gids, positions, fallbackGlyphScales, font, fillPaint));
@@ -2688,7 +2739,7 @@ internal partial class RenderContext
                 {
                     if (fillText && fillWithPattern)
                     {
-                        using var localPath = BuildGlyphIdTextPath(gids, positions, font);
+                        using var localPath = BuildGlyphIdTextPath(gids, positions, currentFont.Typeface!, font);
                         if (localPath != null && !localPath.IsEmpty)
                             localFillPatternPath!.AddPath(localPath, SKPathAddMode.Append);
                     }
@@ -2696,7 +2747,7 @@ internal partial class RenderContext
                     {
                         // #710: fill from the outline path, not the platform
                         // glyph mask (see FillTextUsingGlyphPath).
-                        using var fillGlyphPath = BuildGlyphIdTextPath(gids, positions, font);
+                        using var fillGlyphPath = BuildGlyphIdTextPath(gids, positions, currentFont.Typeface!, font);
                         var blobToFill = blob;
                         FillTextUsingGlyphPath(
                             fillGlyphPath, fillPaint,
@@ -2712,8 +2763,8 @@ internal partial class RenderContext
             if (clipText)
             {
                 using var localClipPath = fallbackGlyphScales != null
-                    ? BuildGlyphIdTextPath(gids, positions, fallbackGlyphScales, font)
-                    : BuildGlyphIdTextPath(gids, positions, font);
+                    ? BuildGlyphIdTextPath(gids, positions, fallbackGlyphScales, currentFont.Typeface!, font)
+                    : BuildGlyphIdTextPath(gids, positions, currentFont.Typeface!, font);
                 AddPendingTextClipPath(localClipPath, x, y, drawHScale, ySign);
             }
 

--- a/Excise.Rendering/SkiaRenderer.cs
+++ b/Excise.Rendering/SkiaRenderer.cs
@@ -450,12 +450,77 @@ internal partial class RenderContext
     // so parallel test collections cannot interfere with each other's counts.
     [ThreadStatic]
     internal static long ContentStreamParseCacheHits;
+    [ThreadStatic]
+    internal static long GlyphOutlineCacheHits;
+    [ThreadStatic]
+    internal static long GlyphOutlineCacheMisses;
     private readonly Dictionary<(int ObjectNumber, int Generation, ImageBitmapCacheKey Key), SKBitmap?> _imageBitmapByReference = new();
     private readonly Dictionary<Excise.Core.Primitives.PdfStream, Dictionary<ImageBitmapCacheKey, SKBitmap?>> _imageBitmapByStream =
         new(ReferenceEqualityComparer.Instance);
     private readonly List<SKBitmap> _cachedImageBitmaps = new();
+    // Tessellated glyph outlines keyed by (typeface, font-size bits, glyph
+    // string) — see GetCachedGlyphOutline (#598). SKFont.GetTextPath drives the
+    // platform font scaler to build the outline on every call; body text
+    // repeats the same glyph at one size thousands of times per page, so the
+    // uncached path re-tessellates identical geometry. The cache stores the
+    // UNPOSITIONED outline at origin; callers transform a fresh copy per draw
+    // (cursor + horizontal squeeze) and never mutate the cached path, so the
+    // geometry handed to DrawPath is byte-identical to the uncached path.
+    // CreateTextFont is a fixed-property constructor, so any two SKFonts for the
+    // same (typeface, size) yield identical outlines — that is what makes the
+    // key exact. Lifetime is this RenderContext (one page render); disposed in
+    // DisposeOwnedResources. Typeface is compared by reference.
+    private readonly Dictionary<(SKTypeface Typeface, int SizeBits, string Text), SKPath?> _glyphOutlineCache =
+        new(GlyphOutlineKeyComparer.Instance);
+    // The glyph-ID variant of the outline cache (#598). Embedded subset fonts
+    // (Type0/CID and byte-cmap simple fonts) are drawn glyph-by-glyph via
+    // SKFont.GetGlyphPath in BuildGlyphIdTextPath — this is the tessellation
+    // hot path for real-world body text, where the same glyph ID recurs
+    // thousands of times per page at one size. Same immutability/lifetime rules
+    // as _glyphOutlineCache; the key is the glyph ID, so no per-glyph string is
+    // allocated. Typeface is compared by reference.
+    private readonly Dictionary<(SKTypeface Typeface, int SizeBits, ushort Gid), SKPath?> _glyphOutlineByIdCache =
+        new(GlyphIdOutlineKeyComparer.Instance);
     private DeviceCmykBackdrop? _deviceCmykKnockoutInitialBackdrop;
     private int _tilingPatternDepth;
+
+    private sealed class GlyphOutlineKeyComparer
+        : IEqualityComparer<(SKTypeface Typeface, int SizeBits, string Text)>
+    {
+        public static readonly GlyphOutlineKeyComparer Instance = new();
+
+        public bool Equals(
+            (SKTypeface Typeface, int SizeBits, string Text) x,
+            (SKTypeface Typeface, int SizeBits, string Text) y)
+            => ReferenceEquals(x.Typeface, y.Typeface)
+               && x.SizeBits == y.SizeBits
+               && string.Equals(x.Text, y.Text, StringComparison.Ordinal);
+
+        public int GetHashCode((SKTypeface Typeface, int SizeBits, string Text) key)
+            => HashCode.Combine(
+                System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(key.Typeface),
+                key.SizeBits,
+                StringComparer.Ordinal.GetHashCode(key.Text));
+    }
+
+    private sealed class GlyphIdOutlineKeyComparer
+        : IEqualityComparer<(SKTypeface Typeface, int SizeBits, ushort Gid)>
+    {
+        public static readonly GlyphIdOutlineKeyComparer Instance = new();
+
+        public bool Equals(
+            (SKTypeface Typeface, int SizeBits, ushort Gid) x,
+            (SKTypeface Typeface, int SizeBits, ushort Gid) y)
+            => ReferenceEquals(x.Typeface, y.Typeface)
+               && x.SizeBits == y.SizeBits
+               && x.Gid == y.Gid;
+
+        public int GetHashCode((SKTypeface Typeface, int SizeBits, ushort Gid) key)
+            => HashCode.Combine(
+                System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(key.Typeface),
+                key.SizeBits,
+                key.Gid);
+    }
 
     private readonly CancellationToken _cancellationToken;
 


### PR DESCRIPTION
## Summary
Renderer hot-path optimization for #598 (R5 perf). `SKFont.GetTextPath` / `GetGlyphPath` drive the platform font scaler to tessellate a glyph outline on **every** draw; real-world body text recurs the same glyph thousands of times per page, so the uncached path re-tessellates identical geometry.

This caches the **UNPOSITIONED** glyph outline per `(typeface, size, glyph)` and reuses it for the rest of the page. Every draw still transforms a **fresh copy** to its own cursor/scale — the geometry handed to `DrawPath` is byte-identical to before.

Two caches:
- **text-keyed** — the substituted / simple-font `GetTextPath` path.
- **glyph-ID-keyed** — the dominant embedded-subset path (Type0/CID + byte-cmap fonts drawn glyph-by-glyph via `BuildGlyphIdTextPath` → `GetGlyphPath`). This is where the real body text lives: on the smoke corpus the outline cache serves **94.6%** of glyph lookups (~917k/970k; ~561k avoided tessellations on `irs-1040-instructions.pdf` alone).

Caches are **page-scoped** (one `RenderContext` per `RenderPage`), disposed in `DisposeOwnedResources`; typeface compared by reference. All additions are private/internal — no public API change.

## Pixel-identity (the hard gate) — 0 churn
- **Visual PNG baselines: 63/0** (byte-exact checked-in rasters).
- **mutool differential smoke: 49/49** on the IRS/SCOTUS embedded-font corpus (94.6% gid-path) — the identity oracle that actually covers the changed path.
- Guaranteed by construction: cache returns the exact origin-outline the uncached call returned; consumers only use non-mutating `Transform(m,dest)` / `AddPath`.

## Performance (Release, `check-perf-budgets`, min-of-3, back-to-back; non-render `text-extract` flat as a machine-stability control)
| workflow | alloc | time |
|---|---|---|
| all-page-render | 206 → 197 MB (-4.4%) | 794 → 749 ms (-5.7%) |
| navigation-rerender | 69 → 67 MB | 271 → 258 ms (-4.8%) |
| first-page-render | 52 → 52 MB | 273 → 266 ms (-2.6%) |

Perf-budget gate: PASS (no regression). Budgets **not** `--update`d — this session's absolute times run well over the checked-in quiet-machine baseline (different machine class), so ratcheting would corrupt the file.

## Tests
- Full `Excise.Rendering.Tests`: **3444/0** (13 skipped), incl. `MemoryBenchmarkTests`.
- `test-tier.sh t0`: all green.
- `ViewerPublicApiApprovalTests`: pass (no `approved.txt` change).
- Adds a mechanism guard test (`GlyphOutlineCacheTests`).

Closes #598.

🤖 Generated with [Claude Code](https://claude.com/claude-code)