### PR TITLE
perf(#599): cut image decode / colour-conversion allocations (pixel-identical)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ semantic versioning.
 ## [Unreleased]
 
 ### Performance
+- **Renderer image decode / colour-conversion allocation cuts** (#599) — the
+  image decode path no longer stages a large transient managed pixel buffer per
+  image. The raw, DCT-RGB, and fast Gray/RGB/CMYK decoders now fill the final
+  `SKBitmap`'s pixel store directly (via a writable span) instead of allocating
+  a `width*height*4` byte[] and `Marshal.Copy`-ing it in, and the fast CMYK
+  decoder reuses one CMYK sample buffer instead of allocating a `double[4]` per
+  pixel — that per-pixel array was the dominant allocator on colour-heavy CMYK
+  pages. The `/Decode`-array lookup and max-sample constant are hoisted out of
+  the per-pixel loop. Decoded images are also cached across child render
+  contexts (transparency groups / tiling patterns / soft masks), so an image
+  reused inside a group or pattern decodes once per page, not once per context;
+  only the owning context disposes the shared cache. Measured in Release on the
+  colour-heavy Altona visual suite (`altona_visual_1v2a_x3.pdf` p1, min-of-4):
+  managed allocation 2473.7 → 2028.1 MB (-18%) with render time flat; the
+  remaining per-pixel cost is the ICC CMYK→RGB conversion in `Excise.Core`
+  (out of scope here). Output is byte-identical — verified by the Visual PNG
+  baselines (63/0 unchanged) and the full `Excise.Rendering.Tests` differential
+  suite (3463/0). The decoded-image cache lifetime is one page render.
 - **Renderer glyph-outline caching on the text hot path** (#598) — glyph
   outlines are now tessellated once per (typeface, size, glyph) and reused for
   the rest of the page instead of re-decoding the same outline on every draw.

--- a/Excise.Rendering.Tests/ImageDecodeCacheTests.cs
+++ b/Excise.Rendering.Tests/ImageDecodeCacheTests.cs
@@ -1,0 +1,95 @@
+using System.IO;
+using System.Text;
+using AwesomeAssertions;
+using Excise.Core.Document;
+using Xunit;
+
+namespace Excise.Rendering.Tests;
+
+/// <summary>
+/// Guards the decoded-image cache on the render image hot path (#599).
+/// SKCodec / raw-image decode + colour conversion is expensive; an image
+/// XObject reused on a page must be decoded ONCE and the repeat served from
+/// the cache. The cache holds only the decoded pixels — every draw still runs
+/// its own CTM/paint, which is what keeps the raster byte-identical (see the
+/// pixel-identity Visual/Differential suites, which also exercise the
+/// cross-context sharing into transparency groups / tiling patterns / soft
+/// masks and would fault on a mis-scoped dispose).
+/// </summary>
+public class ImageDecodeCacheTests
+{
+    [Fact]
+    public void RepeatedImageXObjectIsDecodedOnceAndReused()
+    {
+        var pdf = BuildTwoDrawSingleImagePdf();
+        using var doc = PdfDocument.Open(pdf);
+        var renderer = new SkiaRenderer();
+
+        RenderContext.ImageBitmapCacheHits = 0;
+        RenderContext.ImageBitmapCacheMisses = 0;
+
+        using (renderer.RenderPage(doc.GetPage(1), new RenderOptions { Dpi = 96 })) { }
+
+        long hits = RenderContext.ImageBitmapCacheHits;
+        long misses = RenderContext.ImageBitmapCacheMisses;
+
+        misses.Should().Be(1,
+            "the single image XObject must be decoded exactly once");
+        hits.Should().BeGreaterThan(0,
+            "the second draw of the same image must be served from the cache, not re-decoded");
+    }
+
+    // Minimal PDF: one 2x2 DeviceRGB image XObject, drawn twice at different
+    // positions on the page. Binary image samples are written straight to the
+    // stream (an ASCII StreamWriter would corrupt them).
+    private static byte[] BuildTwoDrawSingleImagePdf()
+    {
+        // 2x2 RGB: red, green, blue, white.
+        byte[] image =
+        {
+            255, 0, 0,
+            0, 255, 0,
+            0, 0, 255,
+            255, 255, 255,
+        };
+        const string content =
+            "q 100 0 0 100 100 100 cm /Im1 Do Q " +
+            "q 100 0 0 100 300 400 cm /Im1 Do Q";
+
+        using var ms = new MemoryStream();
+        var offsets = new long[6];
+
+        void Ascii(string s) => Write(ms, Encoding.ASCII.GetBytes(s));
+
+        Ascii("%PDF-1.4\n");
+
+        offsets[1] = ms.Position;
+        Ascii("1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n");
+
+        offsets[2] = ms.Position;
+        Ascii("2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n");
+
+        offsets[3] = ms.Position;
+        Ascii("3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] " +
+              "/Contents 4 0 R /Resources << /XObject << /Im1 5 0 R >> >> >>\nendobj\n");
+
+        offsets[4] = ms.Position;
+        Ascii($"4 0 obj\n<< /Length {content.Length} >>\nstream\n{content}\nendstream\nendobj\n");
+
+        offsets[5] = ms.Position;
+        Ascii("5 0 obj\n<< /Type /XObject /Subtype /Image /Width 2 /Height 2 " +
+              $"/ColorSpace /DeviceRGB /BitsPerComponent 8 /Length {image.Length} >>\nstream\n");
+        Write(ms, image);
+        Ascii("\nendstream\nendobj\n");
+
+        long xrefPos = ms.Position;
+        Ascii("xref\n0 6\n0000000000 65535 f \n");
+        for (int i = 1; i <= 5; i++)
+            Ascii($"{offsets[i]:D10} 00000 n \n");
+        Ascii("trailer\n<< /Root 1 0 R /Size 6 >>\nstartxref\n" + xrefPos + "\n%%EOF\n");
+
+        return ms.ToArray();
+    }
+
+    private static void Write(Stream s, byte[] bytes) => s.Write(bytes, 0, bytes.Length);
+}

--- a/Excise.Rendering/SkiaRenderer.Images.cs
+++ b/Excise.Rendering/SkiaRenderer.Images.cs
@@ -431,9 +431,14 @@ internal partial class RenderContext
             var cacheKey = (referenceKey.ObjectNumber, referenceKey.Generation, key);
             if (!_imageBitmapByReference.TryGetValue(cacheKey, out var bitmap))
             {
+                ImageBitmapCacheMisses++;
                 bitmap = DecodeImageBitmap(imageStream, width, height, bitsPerComponent, colorSpace);
                 TrackCachedImageBitmap(bitmap);
                 _imageBitmapByReference[cacheKey] = bitmap;
+            }
+            else
+            {
+                ImageBitmapCacheHits++;
             }
 
             return bitmap;
@@ -447,9 +452,14 @@ internal partial class RenderContext
 
         if (!streamCache.TryGetValue(key, out var streamBitmap))
         {
+            ImageBitmapCacheMisses++;
             streamBitmap = DecodeImageBitmap(imageStream, width, height, bitsPerComponent, colorSpace);
             TrackCachedImageBitmap(streamBitmap);
             streamCache[key] = streamBitmap;
+        }
+        else
+        {
+            ImageBitmapCacheHits++;
         }
 
         return streamBitmap;
@@ -556,6 +566,11 @@ internal partial class RenderContext
 
     private void DisposeImageBitmapCache()
     {
+        // Child transparency-group / pattern contexts share the root's decoded
+        // images (#599); only the owner disposes, or a shared bitmap would be
+        // freed while a sibling context still holds it.
+        if (!_ownsImageBitmapCache)
+            return;
         foreach (var bitmap in _cachedImageBitmaps)
             bitmap.Dispose();
         _cachedImageBitmaps.Clear();
@@ -981,7 +996,7 @@ internal partial class RenderContext
                 0,
                 1));
 
-            var child = new RenderContext(canvas, _page, _options, _cancellationToken);
+            var child = new RenderContext(canvas, _page, _options, _cancellationToken, imageCacheOwner: this);
             child._resourcesStack.Push(_page.Resources);
             child._state = _state.Clone();
             child._state.SoftMask = null;
@@ -1622,7 +1637,14 @@ internal partial class RenderContext
             if (cinfo.Output_components != 3)
                 return null;
 
-            var pixels = new byte[checked(width * height * 4)];
+            var bitmap = new SKBitmap(width, height, SKColorType.Rgba8888, SKAlphaType.Premul);
+            var pixels = GetWritablePixelSpan(bitmap);
+            if (pixels.IsEmpty)
+            {
+                bitmap.Dispose();
+                return null;
+            }
+
             var scanline = new[] { new byte[checked(width * cinfo.Output_components)] };
             var dst = 0;
             while (cinfo.Output_scanline < cinfo.Output_height)
@@ -1639,9 +1661,6 @@ internal partial class RenderContext
             }
 
             cinfo.jpeg_finish_decompress();
-            var bitmap = CreateBitmapFromRgbaBytes(width, height, pixels);
-            if (bitmap == null)
-                return null;
 
             return ResizeDecodedBitmap(
                 bitmap,
@@ -2011,7 +2030,15 @@ internal partial class RenderContext
             return fastBitmap;
 
         var bitmap = new SKBitmap(width, height, SKColorType.Rgba8888, SKAlphaType.Premul);
-        var pixels = new byte[width * height * 4];
+        // Fill the bitmap's pixel store directly (#599): every pixel below writes
+        // all four RGBA bytes unconditionally, so there is no reliance on the
+        // buffer being pre-zeroed and no large transient byte[] / Marshal.Copy.
+        var pixels = GetWritablePixelSpan(bitmap);
+        if (pixels.IsEmpty)
+        {
+            bitmap.Dispose();
+            return null;
+        }
 
         try
         {
@@ -2021,6 +2048,13 @@ internal partial class RenderContext
             var imageMaskPaintBits = isImageMask
                 ? ResolveImageMaskPaintBits(stream)
                 : default;
+            // Hoist the /Decode lookup and max-sample constant out of the
+            // per-pixel loop (#599): DecodeImageSample was resolving the stream
+            // dictionary and calling Math.Pow once per component per pixel —
+            // millions of redundant lookups on a large image. Both are image-wide
+            // invariants; the arithmetic is otherwise identical.
+            var decodeArray = stream.GetOptional("Decode") as Excise.Core.Primitives.PdfArray;
+            var maxSample = Math.Pow(2, bitsPerComponent) - 1;
 
             for (int y = 0; y < height; y++)
             {
@@ -2034,11 +2068,11 @@ internal partial class RenderContext
                         {
                             for (int i = 0; i < componentsPerPixel; i++)
                                 pixelValues[i] = DecodeImageSample(
-                                    stream,
+                                    decodeArray,
                                     pdfColorSpace,
                                     i,
                                     data[srcIndex + i],
-                                    bitsPerComponent);
+                                    maxSample);
                             srcIndex += componentsPerPixel;
 
                             var (rd, gd, bd) = pdfColorSpace.ToRgb(pixelValues);
@@ -2060,11 +2094,11 @@ internal partial class RenderContext
                                         bitOffset + (i * bitsPerComponent),
                                         bitsPerComponent);
                                     pixelValues[i] = DecodeImageSample(
-                                        stream,
+                                        decodeArray,
                                         pdfColorSpace,
                                         i,
                                         sample,
-                                        bitsPerComponent);
+                                        maxSample);
                                 }
 
                                 var (rd, gd, bd) = pdfColorSpace.ToRgb(pixelValues);
@@ -2118,15 +2152,6 @@ internal partial class RenderContext
                     srcIndex = ((srcIndex + 7) / 8) * 8; // Align to byte boundary
                 }
             }
-
-            var destination = bitmap.GetPixels();
-            if (destination == IntPtr.Zero)
-            {
-                bitmap.Dispose();
-                return null;
-            }
-
-            System.Runtime.InteropServices.Marshal.Copy(pixels, 0, destination, pixels.Length);
         }
         catch
         {
@@ -2174,7 +2199,14 @@ internal partial class RenderContext
 
     private static SKBitmap? CreateFastGrayBitmap(byte[] data, int width, int height)
     {
-        var pixels = new byte[width * height * 4];
+        var bitmap = new SKBitmap(width, height, SKColorType.Rgba8888, SKAlphaType.Premul);
+        var pixels = GetWritablePixelSpan(bitmap);
+        if (pixels.IsEmpty)
+        {
+            bitmap.Dispose();
+            return null;
+        }
+
         var src = 0;
         var dst = 0;
         for (var i = 0; i < width * height; i++)
@@ -2186,12 +2218,19 @@ internal partial class RenderContext
             pixels[dst++] = 255;
         }
 
-        return CreateBitmapFromRgbaBytes(width, height, pixels);
+        return bitmap;
     }
 
     private static SKBitmap? CreateFastRgbBitmap(byte[] data, int width, int height)
     {
-        var pixels = new byte[width * height * 4];
+        var bitmap = new SKBitmap(width, height, SKColorType.Rgba8888, SKAlphaType.Premul);
+        var pixels = GetWritablePixelSpan(bitmap);
+        if (pixels.IsEmpty)
+        {
+            bitmap.Dispose();
+            return null;
+        }
+
         var src = 0;
         var dst = 0;
         for (var i = 0; i < width * height; i++)
@@ -2202,28 +2241,52 @@ internal partial class RenderContext
             pixels[dst++] = 255;
         }
 
-        return CreateBitmapFromRgbaBytes(width, height, pixels);
+        return bitmap;
     }
 
     private static SKBitmap? CreateFastCmykBitmap(byte[] data, int width, int height, PdfColorSpace colorSpace)
     {
-        var pixels = new byte[width * height * 4];
+        var bitmap = new SKBitmap(width, height, SKColorType.Rgba8888, SKAlphaType.Premul);
+        var pixels = GetWritablePixelSpan(bitmap);
+        if (pixels.IsEmpty)
+        {
+            bitmap.Dispose();
+            return null;
+        }
+
+        // One reused CMYK buffer instead of a fresh double[4] per pixel (#599):
+        // ToRgb reads the array by index and never retains it, so reuse is
+        // behaviour-identical while removing width*height allocations per image.
+        var cmyk = new double[4];
         var src = 0;
         var dst = 0;
         for (var i = 0; i < width * height; i++)
         {
-            var c = data[src++] / 255.0;
-            var m = data[src++] / 255.0;
-            var y = data[src++] / 255.0;
-            var k = data[src++] / 255.0;
-            var (r, g, b) = colorSpace.ToRgb(new[] { c, m, y, k });
+            cmyk[0] = data[src++] / 255.0;
+            cmyk[1] = data[src++] / 255.0;
+            cmyk[2] = data[src++] / 255.0;
+            cmyk[3] = data[src++] / 255.0;
+            var (r, g, b) = colorSpace.ToRgb(cmyk);
             pixels[dst++] = (byte)Math.Clamp(r * 255, 0, 255);
             pixels[dst++] = (byte)Math.Clamp(g * 255, 0, 255);
             pixels[dst++] = (byte)Math.Clamp(b * 255, 0, 255);
             pixels[dst++] = 255;
         }
 
-        return CreateBitmapFromRgbaBytes(width, height, pixels);
+        return bitmap;
+    }
+
+    // Writable view over an SKBitmap's contiguous pixel store, so a decode can
+    // fill the final bitmap directly instead of allocating a large transient
+    // managed byte[] and Marshal.Copy-ing it in (#599). Rgba8888 with no row
+    // padding gives RowBytes == Width*4, so the span is Width*Height*4 bytes —
+    // the same length the transient buffer had. Byte-for-byte identical output.
+    private static unsafe Span<byte> GetWritablePixelSpan(SKBitmap bitmap)
+    {
+        var ptr = bitmap.GetPixels();
+        return ptr == IntPtr.Zero
+            ? Span<byte>.Empty
+            : new Span<byte>((void*)ptr, bitmap.RowBytes * bitmap.Height);
     }
 
     private static SKBitmap? CreateBitmapFromRgbaBytes(
@@ -2396,10 +2459,24 @@ internal partial class RenderContext
         int componentIndex,
         int sample,
         int bitsPerComponent)
+        => DecodeImageSample(
+            stream.GetOptional("Decode") as Excise.Core.Primitives.PdfArray,
+            colorSpace,
+            componentIndex,
+            sample,
+            Math.Pow(2, bitsPerComponent) - 1);
+
+    // Hoisted variant used by the raw-image fill loop: the caller resolves the
+    // /Decode array and max-sample constant once per image instead of once per
+    // component per pixel (#599). Arithmetic is identical to the overload above.
+    private static double DecodeImageSample(
+        Excise.Core.Primitives.PdfArray? decode,
+        PdfColorSpace colorSpace,
+        int componentIndex,
+        int sample,
+        double maxSample)
     {
-        var decode = stream.GetOptional("Decode") as Excise.Core.Primitives.PdfArray;
         var offset = componentIndex * 2;
-        var maxSample = Math.Pow(2, bitsPerComponent) - 1;
         if (decode != null && decode.Count >= offset + 2)
         {
             var d0 = decode.GetNumber(offset);

--- a/Excise.Rendering/SkiaRenderer.Patterns.cs
+++ b/Excise.Rendering/SkiaRenderer.Patterns.cs
@@ -288,7 +288,7 @@ internal partial class RenderContext
             cellCanvas.Save();
             cellCanvas.ClipRect(cellBounds, SKClipOperation.Intersect, antialias: false);
 
-            child = new RenderContext(cellCanvas, _page, _options, _cancellationToken);
+            child = new RenderContext(cellCanvas, _page, _options, _cancellationToken, imageCacheOwner: this);
             CopyRenderScopeTo(child);
             child._state = _state.Clone();
             child._state.FillPatternName = null;

--- a/Excise.Rendering/SkiaRenderer.XObjects.cs
+++ b/Excise.Rendering/SkiaRenderer.XObjects.cs
@@ -194,7 +194,8 @@ internal partial class RenderContext
                 _options,
                 _cancellationToken,
                 groupBitmap,
-                startsInDeviceCmykTransparencyGroup: true);
+                startsInDeviceCmykTransparencyGroup: true,
+                imageCacheOwner: this);
             child._resourcesStack.Push(_page.Resources);
             child._state = invocationState.Clone();
             child._state.BlendMode = SKBlendMode.SrcOver;

--- a/Excise.Rendering/SkiaRenderer.cs
+++ b/Excise.Rendering/SkiaRenderer.cs
@@ -454,10 +454,24 @@ internal partial class RenderContext
     internal static long GlyphOutlineCacheHits;
     [ThreadStatic]
     internal static long GlyphOutlineCacheMisses;
-    private readonly Dictionary<(int ObjectNumber, int Generation, ImageBitmapCacheKey Key), SKBitmap?> _imageBitmapByReference = new();
-    private readonly Dictionary<Excise.Core.Primitives.PdfStream, Dictionary<ImageBitmapCacheKey, SKBitmap?>> _imageBitmapByStream =
-        new(ReferenceEqualityComparer.Instance);
-    private readonly List<SKBitmap> _cachedImageBitmaps = new();
+    // Decoded-image cache observability (#599). A hit means a repeated image
+    // XObject (logo, background, tiled-pattern cell, form-invoked art) reused an
+    // already-decoded SKBitmap instead of re-running the SKCodec decode + color
+    // conversion. Counted across the whole page render, including child
+    // transparency-group / pattern contexts, which share the root cache.
+    // Thread-static for the same reason as the glyph counters above.
+    [ThreadStatic]
+    internal static long ImageBitmapCacheHits;
+    [ThreadStatic]
+    internal static long ImageBitmapCacheMisses;
+    // Decoded-image caches. Shared with child transparency-group / tiling-pattern
+    // contexts via the shared-scope constructor so a repeated image decodes once
+    // per page, not once per context (#599). Only the owning (root) context
+    // disposes them — see _ownsImageBitmapCache / DisposeImageBitmapCache.
+    private readonly Dictionary<(int ObjectNumber, int Generation, ImageBitmapCacheKey Key), SKBitmap?> _imageBitmapByReference;
+    private readonly Dictionary<Excise.Core.Primitives.PdfStream, Dictionary<ImageBitmapCacheKey, SKBitmap?>> _imageBitmapByStream;
+    private readonly List<SKBitmap> _cachedImageBitmaps;
+    private readonly bool _ownsImageBitmapCache;
     // Tessellated glyph outlines keyed by (typeface, font-size bits, glyph
     // string) — see GetCachedGlyphOutline (#598). SKFont.GetTextPath drives the
     // platform font scaler to build the outline on every call; body text
@@ -542,13 +556,31 @@ internal partial class RenderContext
     public RenderContext(SKCanvas canvas, PdfPage page, RenderOptions options,
         CancellationToken cancellationToken = default,
         SKBitmap? rootBitmap = null,
-        bool startsInDeviceCmykTransparencyGroup = false)
+        bool startsInDeviceCmykTransparencyGroup = false,
+        RenderContext? imageCacheOwner = null)
     {
         _canvas = canvas;
         _rootBitmap = rootBitmap;
         _page = page;
         _options = options;
         _cancellationToken = cancellationToken;
+        if (imageCacheOwner != null)
+        {
+            // Share the decoded-image cache with the owning context so an image
+            // reused across a transparency group / tiling pattern decodes once
+            // per page (#599). The owner disposes; this context does not.
+            _imageBitmapByReference = imageCacheOwner._imageBitmapByReference;
+            _imageBitmapByStream = imageCacheOwner._imageBitmapByStream;
+            _cachedImageBitmaps = imageCacheOwner._cachedImageBitmaps;
+            _ownsImageBitmapCache = false;
+        }
+        else
+        {
+            _imageBitmapByReference = new();
+            _imageBitmapByStream = new(ReferenceEqualityComparer.Instance);
+            _cachedImageBitmaps = new();
+            _ownsImageBitmapCache = true;
+        }
         _deviceCmykPreviewColorSpace = PdfColorSpace.Parse(PdfName.DeviceCMYK, page.Document);
         _deviceCmykTransparencyGroupDepth = startsInDeviceCmykTransparencyGroup ? 1 : 0;
         _deviceCmykBackdrop = startsInDeviceCmykTransparencyGroup && rootBitmap != null


### PR DESCRIPTION
Closes part of #599 (R5 image decode / colour conversion). Base: `develop`.

## What
Cuts managed allocation on the image decode + colour-conversion hot path, pixel-identically.

- **Direct-to-bitmap fill.** The raw, DCT-RGB, and fast Gray/RGB/CMYK decoders now write the decoded pixels straight into the final `SKBitmap`'s pixel store via a writable span, instead of allocating a `width*height*4` transient managed byte[] and `Marshal.Copy`-ing it in.
- **Reused CMYK buffer.** `CreateFastCmykBitmap` reused one `double[4]` for the whole image instead of allocating `new[]{c,m,y,k}` per pixel — the dominant allocator on colour-heavy CMYK pages (~1.44M arrays per 1200x1200 image).
- **Hoisted `/Decode` lookup + max-sample constant** out of the per-pixel loop (was resolved once per component per pixel).
- **Cross-context decode cache.** Child render contexts (device-CMYK transparency groups, composed tiling-pattern cells, soft-mask forms) now share the root context's decoded-image cache, so an image reused inside a group/pattern decodes once per page, not once per context. Only the owning context disposes the shared cache (page-scoped, mirrors #598's glyph cache).

Added `ImageBitmapCacheHits/Misses` observability counters and a mechanism-guard test (`ImageDecodeCacheTests`).

## Measured (Release, min-of-4)
Colour-heavy Altona visual suite, `altona_visual_1v2a_x3.pdf` p1:

| | alloc | render time |
|---|---|---|
| before (develop) | 2473.7 MB | 2102 ms |
| after | 2028.1 MB | 2042 ms |
| delta | **-445 MB (-18%)** | flat |

The remaining per-pixel cost is the ICC CMYK->RGB conversion in `Excise.Core` (`PdfIccProfile.ToRgb` cache-key allocation) — out of scope here; candidate follow-up issue. The cross-context cache is ~0 on the smoke corpus (images there aren't reused across contexts) — the reportable delta is the allocation work, not the cache.

## Pixel-identity gate (hard requirement)
Byte-identical rasters, 0 baseline churn:
- Visual PNG baselines: **63 passed / 0 failed**
- Full `Excise.Rendering.Tests` (incl. mutool/gs/pdftocairo differential byte-baselines): **3463 passed / 0 failed**
- GUI headless `MatchesBaseline`: **2 passed / 0 failed**

## Other gates
- `scripts/check-perf-budgets.sh`: PASS (no regression; `all-page-render` alloc improved to the budget edge)
- `scripts/test-tier.sh t0`: PASS (build 0 warnings; avalonia public-API approval unchanged — all additions are internal/private)
- No new skipping differential tests -> no skip-allowlist change.

STOP: do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
