### PR TITLE
perf(#731): cut Excise.Cli.Tests wall-clock 72s->5s (redundant rebuild removal)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,40 +104,48 @@ semantic versioning.
   coverage loss). Clears the existing 93% gate (measured 93.27% locally, up from
   the 92.39% that had reddened `develop`; the Linux CI coverage job is the
   authority); the threshold itself is unchanged.
-- **`Excise.Cli.Tests` wall-clock cut ~93% (72s → 5s measured) by removing an
-  accidental full rebuild from every `-c Release` run** (#731). Root cause:
-  `BenchmarkSuite.ResolveExciseCliInvocation()` (`tools/Excise.RenderTools/`,
-  used only by `BenchmarkSuiteTests`' CLI-subprocess benchmark path) picked
-  which `Excise.Cli/bin/<config>/` directory to look in via this assembly's
-  own `#if DEBUG`/`#else "Release"` compile-time symbol. `Excise.RenderTools`
-  is a tool project outside `excise.sln`, so it always builds Debug
-  regardless of what configuration the CLI or the calling test host used —
-  meaning any `-c Release` `Excise.Cli.Tests` run (`release-smoke.sh
-  --release-tests`, or a maintainer running `dotnet test -c Release`
-  directly) looked for a Debug binary a Release-only build never produces,
-  silently fell through to `dotnet run -c Debug --`, and paid for a
-  from-scratch Debug build of `Excise.Cli` + `Excise.Core` +
-  `Excise.Rendering` + `Excise.Ocr` inside a single test
-  (`BenchmarkSuite_WritesJsonCsvMarkdownAndPassesSyntheticGate`, measured 68
-  of the suite's 72s). Fixed by probing the filesystem for an already-built
-  `excise`/`excise.dll` under both `Release` and `Debug` before ever falling
-  back to `dotnet run` — same CLI binary invoked, same assertions, same 126
-  tests (125 passed / 1 skipped, unchanged) — this was a redundant-build
-  removal, not a coverage or behavior change. `-c Debug` runs (CI's PR gate,
-  `t0`/`t1`) were never affected: RenderTools' Debug default happened to
-  match. Measured this session on a 10-core Apple Silicon machine, Release
-  build, all five suites run individually: `Excise.Core.Tests` 4s (3755
-  tests), `Excise.Rendering.Tests` 32s (3420 tests, already 4-way parallel
-  per #732), `Excise.App.Tests` 226s (1098 tests, serial by design — #363),
-  `Excise.Avalonia.Tests` 2s (86 tests), `Excise.Cli.Tests` 72s→5s (126
-  tests). Investigated and explicitly NOT pursued this pass, per the #731
-  analysis already on the issue: overlapping `Excise.Core.Tests` with the
-  now-4-way-parallel `Excise.Rendering.Tests` in `release-smoke.sh`, and
-  sharding `Excise.App.Tests` across concurrent local processes — both
-  reintroduce the CPU-contention false-red class #619 exists to prevent
-  (wall-clock-budgeted tests reading as hangs under contention), for a
-  smaller, single-machine-only saving than this fix. `Excise.App.Tests`
-  stays serial (#363 SkiaSharp native font-manager crash) and untouched.
+- **`Excise.Cli.Tests` wall-clock cut ~93% (72s → 5s measured, `-c Release`
+  only) by removing an accidental full rebuild** (#731). Root cause:
+  `BenchmarkSuite.ResolveExciseCliInvocation()` (`tools/Excise.RenderTools/`
+  — the shared implementation behind the shipping `benchmark-suite` CLI
+  command, not test-only code) picked which `Excise.Cli/bin/<config>/`
+  directory to look in via this assembly's own `#if DEBUG`/`#else "Release"`
+  compile-time symbol. `Excise.RenderTools` is a tool project outside
+  `excise.sln`, so it always builds Debug regardless of what configuration
+  the CLI or the calling process used. `run-benchmarks.sh`,
+  `check-perf-budgets.sh`, and every `release-smoke.sh`/`ci.yml` caller
+  already set the `CONFIG` env var explicitly and were never affected by the
+  symbol; only `BenchmarkSuiteTests`, which calls `RenderProgram.RunAsync`
+  in-process with no `CONFIG` set, hit the bug. Any `-c Release`
+  `Excise.Cli.Tests` run (`release-smoke.sh --release-tests`, or a
+  maintainer running `dotnet test -c Release` directly) looked for a Debug
+  binary a Release-only build never produces, silently fell through to
+  `dotnet run -c Debug --`, and paid for a from-scratch Debug build of
+  `Excise.Cli` + `Excise.Core` + `Excise.Rendering` + `Excise.Ocr` inside a
+  single test (`BenchmarkSuite_WritesJsonCsvMarkdownAndPassesSyntheticGate`,
+  measured 68 of the suite's 72s). Fixed by probing the filesystem for an
+  already-built `excise`/`excise.dll` under both `Release` and `Debug`
+  before ever falling back to `dotnet run` — same CLI binary invoked, same
+  assertions, same 126 tests (125 passed / 1 skipped, unchanged) — a
+  redundant-build removal, not a coverage or behavior change. Verified `-c
+  Debug` (CI's PR gate, `t0`/`t1`) is unaffected either way: 865ms before and
+  after, with only a Debug build on disk (simulating a fresh CI checkout) —
+  RenderTools' Debug default already matched, so this fix saves nothing on
+  the PR gate; the win applies to `t2`/`release-smoke.sh --release-tests`
+  and any local `-c Release` run. Measured this session on a 10-core Apple
+  Silicon machine, Release build, all five suites run individually:
+  `Excise.Core.Tests` 4s (3755 tests), `Excise.Rendering.Tests` 32s (3420
+  tests, already 4-way parallel per #732), `Excise.App.Tests` 226s (1098
+  tests, serial by design — #363), `Excise.Avalonia.Tests` 2s (86 tests),
+  `Excise.Cli.Tests` 72s→5s (126 tests). Investigated and explicitly NOT
+  pursued this pass, per the #731 analysis already on the issue: overlapping
+  `Excise.Core.Tests` with the now-4-way-parallel `Excise.Rendering.Tests` in
+  `release-smoke.sh`, and sharding `Excise.App.Tests` across concurrent
+  local processes — both reintroduce the CPU-contention false-red class #619
+  exists to prevent (wall-clock-budgeted tests reading as hangs under
+  contention), for a smaller, single-machine-only saving than this fix.
+  `Excise.App.Tests` stays serial (#363 SkiaSharp native font-manager crash)
+  and untouched.
 
 ## [3.3.1] - 2026-07-26
 - **GUI interaction latency: per-page search-highlight index (#601).** Page

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,40 @@ semantic versioning.
   coverage loss). Clears the existing 93% gate (measured 93.27% locally, up from
   the 92.39% that had reddened `develop`; the Linux CI coverage job is the
   authority); the threshold itself is unchanged.
+- **`Excise.Cli.Tests` wall-clock cut ~93% (72s → 5s measured) by removing an
+  accidental full rebuild from every `-c Release` run** (#731). Root cause:
+  `BenchmarkSuite.ResolveExciseCliInvocation()` (`tools/Excise.RenderTools/`,
+  used only by `BenchmarkSuiteTests`' CLI-subprocess benchmark path) picked
+  which `Excise.Cli/bin/<config>/` directory to look in via this assembly's
+  own `#if DEBUG`/`#else "Release"` compile-time symbol. `Excise.RenderTools`
+  is a tool project outside `excise.sln`, so it always builds Debug
+  regardless of what configuration the CLI or the calling test host used —
+  meaning any `-c Release` `Excise.Cli.Tests` run (`release-smoke.sh
+  --release-tests`, or a maintainer running `dotnet test -c Release`
+  directly) looked for a Debug binary a Release-only build never produces,
+  silently fell through to `dotnet run -c Debug --`, and paid for a
+  from-scratch Debug build of `Excise.Cli` + `Excise.Core` +
+  `Excise.Rendering` + `Excise.Ocr` inside a single test
+  (`BenchmarkSuite_WritesJsonCsvMarkdownAndPassesSyntheticGate`, measured 68
+  of the suite's 72s). Fixed by probing the filesystem for an already-built
+  `excise`/`excise.dll` under both `Release` and `Debug` before ever falling
+  back to `dotnet run` — same CLI binary invoked, same assertions, same 126
+  tests (125 passed / 1 skipped, unchanged) — this was a redundant-build
+  removal, not a coverage or behavior change. `-c Debug` runs (CI's PR gate,
+  `t0`/`t1`) were never affected: RenderTools' Debug default happened to
+  match. Measured this session on a 10-core Apple Silicon machine, Release
+  build, all five suites run individually: `Excise.Core.Tests` 4s (3755
+  tests), `Excise.Rendering.Tests` 32s (3420 tests, already 4-way parallel
+  per #732), `Excise.App.Tests` 226s (1098 tests, serial by design — #363),
+  `Excise.Avalonia.Tests` 2s (86 tests), `Excise.Cli.Tests` 72s→5s (126
+  tests). Investigated and explicitly NOT pursued this pass, per the #731
+  analysis already on the issue: overlapping `Excise.Core.Tests` with the
+  now-4-way-parallel `Excise.Rendering.Tests` in `release-smoke.sh`, and
+  sharding `Excise.App.Tests` across concurrent local processes — both
+  reintroduce the CPU-contention false-red class #619 exists to prevent
+  (wall-clock-budgeted tests reading as hangs under contention), for a
+  smaller, single-machine-only saving than this fix. `Excise.App.Tests`
+  stays serial (#363 SkiaSharp native font-manager crash) and untouched.
 
 ## [3.3.1] - 2026-07-26
 - **GUI interaction latency: per-page search-highlight index (#601).** Page

--- a/tools/Excise.RenderTools/BenchmarkSuite.cs
+++ b/tools/Excise.RenderTools/BenchmarkSuite.cs
@@ -418,38 +418,61 @@ partial class Program
         if (root is null)
             return null;
 
-        var configuration = Environment.GetEnvironmentVariable("CONFIG") ??
-#if DEBUG
-            "Debug";
-#else
-            "Release";
-#endif
-        var outputDir = Path.Combine(root, "Excise.Cli", "bin", configuration, "net10.0");
-        var executable = Path.Combine(outputDir, OperatingSystem.IsWindows() ? "excise.exe" : "excise");
-        if (File.Exists(executable))
-            return (executable, Array.Empty<string>());
+        var explicitConfiguration = Environment.GetEnvironmentVariable("CONFIG");
 
-        foreach (var candidate in new[]
-                 {
-                     Path.Combine(outputDir, "excise.dll"),
-                     Path.Combine(outputDir, "Excise.Cli.dll"),
-                 })
+        // Probe on-disk build output for an already-built excise CLI before
+        // ever falling back to `dotnet run` (which performs a full build).
+        // Don't trust this assembly's own #if DEBUG/#else symbol to pick the
+        // configuration to look for: Excise.RenderTools is a tool project
+        // outside excise.sln, so it builds Debug by default regardless of
+        // what configuration the CLI (or the test host calling this method)
+        // was actually built in. Trusting #if DEBUG here made every
+        // Excise.Cli.Tests run under `-c Release` look for a Debug binary
+        // that a Release-only build never produces, silently falling back to
+        // `dotnet run -c Debug` — a full from-scratch Debug build of
+        // Excise.Cli + Excise.Core + Excise.Rendering + Excise.Ocr on every
+        // single test run (~68s of Excise.Cli.Tests' ~72s wall-clock,
+        // measured — see #731). Checking the filesystem for either
+        // configuration's output is just as cheap and can't be wrong.
+        var searchOrder = string.IsNullOrWhiteSpace(explicitConfiguration)
+            ? new[] { "Release", "Debug" }
+            : new[] { explicitConfiguration };
+
+        foreach (var configuration in searchOrder)
         {
-            if (File.Exists(candidate))
-                return ("dotnet", new[] { candidate });
+            var outputDir = Path.Combine(root, "Excise.Cli", "bin", configuration, "net10.0");
+            var executable = Path.Combine(outputDir, OperatingSystem.IsWindows() ? "excise.exe" : "excise");
+            if (File.Exists(executable))
+                return (executable, Array.Empty<string>());
+
+            foreach (var candidate in new[]
+                     {
+                         Path.Combine(outputDir, "excise.dll"),
+                         Path.Combine(outputDir, "Excise.Cli.dll"),
+                     })
+            {
+                if (File.Exists(candidate))
+                    return ("dotnet", new[] { candidate });
+            }
         }
 
         var project = Path.Combine(root, "Excise.Cli", "Excise.Cli.csproj");
         if (!File.Exists(project))
             return null;
 
+        var fallbackConfiguration = explicitConfiguration ??
+#if DEBUG
+            "Debug";
+#else
+            "Release";
+#endif
         return ("dotnet", new[]
         {
             "run",
             "--project",
             project,
             "-c",
-            configuration,
+            fallbackConfiguration,
             "--",
         });
     }


### PR DESCRIPTION
## Summary
- `#731` asked for test-suite wall-clock reduction without coverage loss. Measured all five suites fresh (Release, this session's 10-core Apple Silicon machine) and found `Excise.Cli.Tests` spending 68 of its 72 seconds on a single test silently triggering a full `dotnet run -c Debug` rebuild of `Excise.Cli` + `Excise.Core` + `Excise.Rendering` + `Excise.Ocr`.
- Root cause: `BenchmarkSuite.ResolveExciseCliInvocation()` (`tools/Excise.RenderTools/` — the shared implementation behind the shipping `benchmark-suite` CLI command, **not** test-only code) picked the `Excise.Cli/bin/<config>/` directory to probe via its own `#if DEBUG`/`#else "Release"` compile-time symbol. `Excise.RenderTools` lives outside `excise.sln` and always builds Debug, so any `-c Release` test run looked for a Debug binary a Release build never produces and fell back to a full rebuild via `dotnet run`.
  - Script-driven callers (`run-benchmarks.sh`, `check-perf-budgets.sh`, `release-smoke.sh`, `ci.yml`) already set the `CONFIG` env var explicitly and were never affected. Only `BenchmarkSuiteTests`, which calls `RenderProgram.RunAsync` in-process with no `CONFIG` set, hit the bug.
- Fix: probe the filesystem for an already-built `excise`/`excise.dll` under both `Release` and `Debug` before ever falling back to `dotnet run`. Same CLI binary invoked, same assertions, same 126 tests (125 passed / 1 skipped — unchanged).
- Added a `CHANGELOG.md` `[Unreleased] / ### Changed` entry with the measured before/after numbers and the levers investigated-and-rejected in the issue thread.

## Measured wall-clock (Release build, all suites run individually, this session)
| Suite | Before | After | Notes |
|---|---|---|---|
| Excise.Core.Tests | 4s | 4s | unaffected (3755 tests) |
| Excise.Rendering.Tests | 32s | 32s | unaffected; already 4-way parallel per #732 (3420 tests) |
| Excise.App.Tests | 226s | 226s | unaffected; serial by design, #363 (1098 tests) |
| Excise.Avalonia.Tests | 2s | 2s | unaffected (86 tests) |
| **Excise.Cli.Tests** | **72s** | **5s** | **this PR** — 126 tests, 125 passed / 1 skipped, identical both runs |

**CI PR-gate impact: none.** CI's PR gate runs everything `-c Debug`. Verified directly: with only a Debug build on disk (simulating a fresh CI checkout — `rm -rf Excise.Cli/bin/Release tools/*/bin/Release`), `dotnet test Excise.Cli.Tests --no-build -c Debug` takes the same ~865ms for the benchmark test before and after this change, because RenderTools' Debug default already matched what a `-c Debug` run needs. The win applies to `t2`/`release-smoke.sh --release-tests` and any local `-c Release` run — not the CI PR gate.

Note: these are fresh measurements on today's machine/hardware, not a re-run of the older T2 baseline numbers quoted in #731 — the relative before/after delta for Cli.Tests is the apples-to-apples comparison (`--no-build`, same commit, only the code change and `-c` flag differ).

## Why not lever 2/3/4 from the issue
Already investigated and explicitly rejected on the issue thread before this PR:
- **Lever 2** (overlap `Core`+`Rendering` in `release-smoke.sh`): reintroduces #619 CPU-contention false-reds on `CorpusConformanceTests`' 10s-per-file wall-clock budget for a ~60s, t2-only saving.
- **Lever 4** (shard `Excise.App.Tests` across concurrent local processes): `Excise.App.Tests` stays serial per #363 (SkiaSharp process-wide native font-manager crash); concurrent shards on one machine reintroduce the same contention class tripping wall-clock-budgeted assertions (e.g. #733's ThumbnailCache <100ms).
- **Lever 3** (reference-renderer disk cache): contention-free but cold on every clean CI run — local-rerun-only benefit, high implementation effort. Left for a future pass if local-rerun speed becomes a priority.

## Gates verified
- `dotnet build excise.sln -c Release` and `-c Debug`: 0 warnings, 0 errors both.
- `scripts/verify-doc-claims.sh`: pass.
- `scripts/verify-true-redaction.sh`: pass (all 12 checks).
- `scripts/check-gate-asymmetry.sh origin/develop`: pass ("no performance-sensitive paths touched").
- Redaction suites (`--filter "FullyQualifiedName~Redaction"`, solution-wide, Release): 5 projects, 359 tests, 0 failures.
- `-c Debug` (CI PR-gate simulation, Release build artifacts removed first): `Excise.Cli.Tests` 126 tests, 125 passed / 1 skipped, unchanged — confirms no regression on the config CI actually gates on.
- `scripts/check-skip-budget.sh Excise.Core.Tests/...`: fails identically **with and without** this diff (verified via `git stash`) — pre-existing environmental drift on this sandbox machine (missing `test-pdfs` corpus / veraPDF / OpenJpeg tooling), not caused by this change.
- Coverage gate (Excise.Core ≥93%) and `scripts/check-extraction-parity.sh`: not re-run — this diff touches only `tools/Excise.RenderTools/BenchmarkSuite.cs`; verified via grep that `Excise.Core.Tests`/`Excise.Rendering.Tests`/`Excise.App.Tests`/`Excise.Avalonia.Tests` do not reference `Excise.RenderTools` at all, so these gates are structurally unaffected.

## Test plan
- [x] `dotnet build excise.sln -c Release` / `-c Debug` — 0 warnings/errors both
- [x] `dotnet test Excise.Cli.Tests --no-build -c Release` — 126 tests, 125 passed / 1 skipped, 5s (was 72s)
- [x] `dotnet test Excise.Cli.Tests --no-build -c Debug` (Release artifacts removed) — 126 tests, 125 passed / 1 skipped, 865ms (matches pre-change Debug behavior)
- [x] Redaction suites green (359 tests across 5 projects)
- [x] `verify-true-redaction.sh`, `check-gate-asymmetry.sh`, `verify-doc-claims.sh` green
- [x] Confirmed skip-budget discrepancy is pre-existing/environmental, not introduced by this diff

**Not merging** — leaving this for review per instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)