### PR TITLE
test: allow-list 3 tool/fixture-gated App.Tests skips on Linux CI (#619)

### DIFF
--- a/tests/skip-allowlist/Excise.App.Tests.txt
+++ b/tests/skip-allowlist/Excise.App.Tests.txt
@@ -48,3 +48,8 @@ Excise.App.Tests.UI.TextSelectionAlignmentTests.DragSelection_HighlightCoversThe
 Excise.App.Tests.UI.TextSelectionAlignmentTests.FitWidth_InsideSelectTextMode_ActuallyFitsTheViewport   # corpus-gated: local-real-world book absent on CI
 Excise.App.Tests.UI.TextSelectionAlignmentTests.FitAfterSelection_KeepsHighlightsOnRenderedText   # corpus-gated: local-real-world book absent on CI
 Excise.App.Tests.Unit.SignatureApplicationServiceTests.SignDocument_ExternalOracle_PdfsigReportsValidUntrustedSignature   # #623 external oracle: needs poppler pdfsig, absent in CI. Runs on dev machines with poppler installed; the #466 verifier round-trip tests above it always run.
+# Independent-oracle GUI tests gated on mutool (absent on Linux CI); they run on macOS.
+Excise.App.Tests.UI.TypewriterWorkflowTests.SaveFileAsAsync_TypedText_IsReadBackByAnIndependentExtractor
+Excise.App.Tests.Unit.SignatureApplicationServiceTests.SignDocument_VisibleRect_IndependentRendererShowsInkInSignatureRect_AndStillVerifies
+# Permission-gated test needing a restricted fixture absent on Linux CI.
+Excise.App.Tests.UI.TypewriterWorkflowTests.OnTypewriterTextCreated_ModifyForbidden_AddsNothing


### PR DESCRIPTION
Fixes develop's Linux `Skip budget (Excise.App.Tests)` failure. Three legitimately environment-gated skips (mutool absent / restricted-fixture absent on Linux CI; all run on macOS) added to the allow-list. Test-only. Greens develop's Linux job and unblocks the pending R2/R5/R7 wave.