### PR TITLE
Type-over (typewriter) styling UI: size/color/alignment (#781)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ semantic versioning.
 ## [Unreleased]
 
 ### Added
+- **Type-over (typewriter) styling UI** (#781) — the type-over engine already
+  supported font size, colour, and text alignment
+  (`PdfTypewriterTextStyle`/`PdfTypewriterTextOperation.WithStyle`), but nothing
+  in the GUI called it, so every box was Helvetica 12pt black left-aligned. A
+  small style inspector now sits in the toolbar (font-size stepper, alignment
+  Left/Center/Right, and a colour swatch flyout) and is shown only in
+  typewriter mode when a box is active. Changes route through `WithStyle` onto
+  the active `PdfTypewriterTextOperation` (immutably, as one undo step each), so
+  the on-screen editor and the flattened saved PDF both reflect the chosen
+  style; a new box inherits the last-used style. The active box is the one the
+  user last created, typed into, or moved (no separate select gesture).
 - **PDF 2.0 page-level and document-level structural features: parse, model,
   round-trip** (#331) — page transitions (`/Trans`, all twelve ISO
   32000-2:2020 §12.4.4 styles: Split/Blinds/Box/Wipe/Dissolve/Glitter/R

--- a/Excise.App.Tests/UI/CommandBindingSweepTests.cs
+++ b/Excise.App.Tests/UI/CommandBindingSweepTests.cs
@@ -74,7 +74,13 @@ public class CommandBindingSweepTests
                               (mic.Items.Count > 0 || mic.ItemsSource != null);
             var isToggle = host is ToggleButton // CheckBox/RadioButton inherit
                           || (host is MenuItem mit && mit.ToggleType != MenuItemToggleType.None);
-            if (isContainer || isToggle)
+            // A Button that opens a Flyout (e.g. the #781 type-over colour
+            // swatch picker) activates through its Flyout, not a Command —
+            // null Command is expected, like a submenu container. Its
+            // in-flyout leaves carry the real commands and are swept when
+            // realised.
+            var isFlyoutHost = host is Button fb && fb.Flyout != null;
+            if (isContainer || isToggle || isFlyoutHost)
             {
                 containerCount++;
                 continue;

--- a/Excise.App.Tests/UI/TypewriterWorkflowTests.cs
+++ b/Excise.App.Tests/UI/TypewriterWorkflowTests.cs
@@ -303,6 +303,104 @@ public class TypewriterWorkflowTests
         window.Close();
     }
 
+    // #781: the style inspector is visible only in typewriter mode AND only
+    // when a box is active, so it never floats with nothing to style.
+    [FixedAvaloniaFact]
+    public async Task StyleInspector_IsVisibleOnlyWhenTypewriterBoxIsActive()
+    {
+        var (source, _, dir) = MakePaths();
+        TestPdfGenerator.CreateSimpleTextPdf(source, "Original text");
+
+        var vm = new MainWindowViewModel();
+        var window = new MainWindow { DataContext = vm, Width = 1280, Height = 900 };
+        window.Show();
+        await vm.LoadDocumentAsync(source);
+
+        vm.IsTypewriterStyleInspectorVisible.Should().BeFalse("no mode, no box");
+
+        vm.IsTypewriterMode = true;
+        vm.IsTypewriterStyleInspectorVisible.Should().BeFalse("in mode but no active box yet");
+
+        vm.OnTypewriterTextCreated(new PdfRectangle(72, 620, 300, 660), 1);
+        vm.IsTypewriterStyleInspectorVisible.Should().BeTrue("a box is now active");
+
+        vm.IsTypewriterMode = false;
+        vm.IsTypewriterStyleInspectorVisible.Should().BeFalse("leaving the mode hides the inspector");
+
+        window.Close();
+        Cleanup(dir);
+    }
+
+    // #781: changing size/color/alignment on the active box must route through
+    // WithStyle onto that box's immutable Style.
+    [FixedAvaloniaFact]
+    public async Task StyleChanges_UpdateTheActiveBoxStyle()
+    {
+        var (source, _, dir) = MakePaths();
+        TestPdfGenerator.CreateSimpleTextPdf(source, "Original text");
+
+        var vm = new MainWindowViewModel();
+        var window = new MainWindow { DataContext = vm, Width = 1280, Height = 900 };
+        window.Show();
+        await vm.LoadDocumentAsync(source);
+
+        vm.IsTypewriterMode = true;
+        vm.OnTypewriterTextCreated(new PdfRectangle(72, 620, 300, 660), 1);
+        var id = vm.TypewriterTextOperations.Single().Id;
+        vm.OnTypewriterTextEdited(id, "Styled note", 1);
+
+        vm.TypewriterFontSize = 28;
+        vm.SetTypewriterColor("#FF0000");
+        vm.TypewriterAlignmentIndex = 1; // Center
+
+        var op = vm.TypewriterTextOperations.Single();
+        op.Style.FontSize.Should().Be(28);
+        op.Style.Color.R.Should().BeApproximately(1.0, 0.001);
+        op.Style.Color.G.Should().BeApproximately(0.0, 0.001);
+        op.Style.Color.B.Should().BeApproximately(0.0, 0.001);
+        op.Style.Alignment.Should().Be(Excise.Core.Graphics.TextAlignment.Center);
+
+        window.Close();
+        Cleanup(dir);
+    }
+
+    // #781: the chosen style must survive the real GUI save → the flattened
+    // page content stream carries the size (Tf) and colour (rg) operators.
+    // Byte-level assertion (raw operators), not excise's text interpretation,
+    // so it isn't a self-oracle for the style property.
+    [FixedAvaloniaFact]
+    public async Task StyledTypewriterText_RoundTripsIntoSavedPdf()
+    {
+        var (source, output, dir) = MakePaths();
+        TestPdfGenerator.CreateSimpleTextPdf(source, "Original text");
+
+        var vm = new MainWindowViewModel();
+        var window = new MainWindow { DataContext = vm, Width = 1280, Height = 900 };
+        window.Show();
+        await vm.LoadDocumentAsync(source);
+
+        vm.IsTypewriterMode = true;
+        vm.OnTypewriterTextCreated(new PdfRectangle(72, 620, 300, 660), 1);
+        var id = vm.TypewriterTextOperations.Single().Id;
+        vm.OnTypewriterTextEdited(id, "STYLED781", 1);
+        vm.TypewriterFontSize = 29;      // distinctive, not used by the base PDF
+        vm.SetTypewriterColor("#FF0000"); // red -> "1 0 0 rg" (base text is black)
+        vm.TypewriterAlignmentIndex = 2;  // Right
+
+        await vm.SaveFileAsAsync(output);
+
+        using var saved = PdfDocument.Open(output);
+        var page = saved.GetPage(1);
+        var content = System.Text.Encoding.Latin1.GetString(page.GetContentStreamBytes());
+
+        content.Should().Contain("29 Tf", "the flattened text must carry the chosen font size");
+        content.Should().Contain("1 0 0 rg", "the flattened text must carry the chosen red colour");
+        page.Text.Should().Contain("STYLED781", "the typed text must be present");
+
+        window.Close();
+        Cleanup(dir);
+    }
+
     private static string? RestrictedFixturePathOrNull()
     {
         var dir = new DirectoryInfo(AppContext.BaseDirectory);

--- a/Excise.App/ViewModels/MainWindowViewModel.Commands.cs
+++ b/Excise.App/ViewModels/MainWindowViewModel.Commands.cs
@@ -46,6 +46,7 @@ public partial class MainWindowViewModel
     public ReactiveCommand<Unit, Unit> ToggleTypewriterModeCommand { get; private set; } = null!;
     public ReactiveCommand<Unit, Unit> DiscardPendingTypewriterEditsCommand { get; private set; } = null!;
     public ReactiveCommand<Unit, Unit> GoToNextPendingTypewriterEditCommand { get; private set; } = null!;
+    public ReactiveCommand<string, Unit> SetTypewriterColorCommand { get; private set; } = null!;
     public ReactiveCommand<Unit, Unit> AddHighlightAnnotationFromSelectionCommand { get; private set; } = null!;
     public ReactiveCommand<Unit, Unit> AddStickyNoteAnnotationCommand { get; private set; } = null!;
     public ReactiveCommand<Unit, Unit> ToggleOutlineCommand { get; private set; } = null!;
@@ -143,6 +144,7 @@ public partial class MainWindowViewModel
         ToggleTypewriterModeCommand = ReactiveCommand.Create(ToggleTypewriterMode);
         DiscardPendingTypewriterEditsCommand = ReactiveCommand.Create(DiscardPendingTypewriterEdits);
         GoToNextPendingTypewriterEditCommand = ReactiveCommand.Create(GoToNextPendingTypewriterEdit);
+        SetTypewriterColorCommand = ReactiveCommand.Create<string>(hex => SetTypewriterColor(hex));
         AddHighlightAnnotationFromSelectionCommand = ReactiveCommand.CreateFromTask(AddHighlightAnnotationFromSelectionAsync);
         AddStickyNoteAnnotationCommand = ReactiveCommand.CreateFromTask(() => AddStickyNoteAnnotationAsync());
         ToggleOutlineCommand = ReactiveCommand.Create(ToggleOutlineSidebar);

--- a/Excise.App/ViewModels/MainWindowViewModel.Typewriter.cs
+++ b/Excise.App/ViewModels/MainWindowViewModel.Typewriter.cs
@@ -35,10 +35,12 @@ public partial class MainWindowViewModel
             else
             {
                 RestoreViewModeFromPreference();
+                ClearActiveTypewriterOperation(); // #781: hide the style inspector on exit
             }
 
             this.RaisePropertyChanged(nameof(CurrentModeText));
             this.RaisePropertyChanged(nameof(InteractionMode));
+            this.RaisePropertyChanged(nameof(IsTypewriterStyleInspectorVisible));
         }
     }
 
@@ -67,14 +69,21 @@ public partial class MainWindowViewModel
             return;
         }
 
+        // #781: seed the box with the current inspector style so "set the
+        // style, then draw" carries the chosen look onto the new box, and make
+        // the fresh box the inspector's active target.
+        var created = PdfTypewriterTextOperation.Create(
+            pageNumber,
+            rect,
+            string.Empty,
+            BuildInspectorStyle());
+
         RecordTypewriterEdit("Add text box", () =>
         {
-            TypewriterTextOperations.Add(PdfTypewriterTextOperation.Create(
-                pageNumber,
-                rect,
-                string.Empty));
+            TypewriterTextOperations.Add(created);
             RefreshTypewriterEditState();
         });
+        SetActiveTypewriterOperation(created.Id);
         _logger.LogInformation("Added typewriter text box on page {Page}", pageNumber);
     }
 
@@ -91,6 +100,7 @@ public partial class MainWindowViewModel
             TypewriterTextOperations[index] = TypewriterTextOperations[index].WithText(text);
             RefreshTypewriterEditState();
         });
+        SetActiveTypewriterOperation(operationId); // #781: typing targets the inspector
         _logger.LogDebug("Edited typewriter text on page {Page}", pageNumber);
     }
 
@@ -107,6 +117,7 @@ public partial class MainWindowViewModel
             TypewriterTextOperations[index] = TypewriterTextOperations[index].WithPageAndBounds(pageNumber, rect);
             RefreshTypewriterEditState();
         });
+        SetActiveTypewriterOperation(operationId); // #781: moving targets the inspector
         _logger.LogDebug("Moved/resized typewriter text on page {Page}", pageNumber);
     }
 
@@ -123,6 +134,8 @@ public partial class MainWindowViewModel
             TypewriterTextOperations.RemoveAt(index);
             RefreshTypewriterEditState();
         });
+        if (_activeTypewriterOperationId == operationId)
+            ClearActiveTypewriterOperation(); // #781: don't point the inspector at a dead box
         _logger.LogInformation("Deleted pending typewriter text");
     }
 
@@ -180,6 +193,7 @@ public partial class MainWindowViewModel
     {
         if (TypewriterTextOperations.Count > 0)
             TypewriterTextOperations.Clear();
+        ClearActiveTypewriterOperation(); // #781
         RefreshTypewriterEditState();
     }
 

--- a/Excise.App/ViewModels/MainWindowViewModel.TypewriterStyle.cs
+++ b/Excise.App/ViewModels/MainWindowViewModel.TypewriterStyle.cs
@@ -1,0 +1,184 @@
+using System;
+using Avalonia.Media;
+using Excise.Core.Editing;
+using Excise.Core.Graphics;
+using ReactiveUI;
+
+namespace Excise.App.ViewModels;
+
+public partial class MainWindowViewModel
+{
+    // #781: styling UI for the type-over tool. The engine
+    // (PdfTypewriterTextStyle + PdfTypewriterTextOperation.WithStyle) already
+    // supports size/color/alignment; this wires a small inspector for the
+    // ACTIVE box onto that engine. "Active" is the box the user last created,
+    // typed into, or moved — there is no separate focus/select event, so the
+    // OnTypewriterText* handlers set it (see MainWindowViewModel.Typewriter.cs).
+
+    private Guid? _activeTypewriterOperationId;
+    private double _typewriterFontSize = PdfTypewriterTextStyle.Default.FontSize;
+    private Color _typewriterColor = Colors.Black;
+    private int _typewriterAlignmentIndex; // 0 Left, 1 Center, 2 Right
+    // Guards the sync-from-active-box path so pushing the active box's current
+    // style into the inspector properties does not re-apply it back onto the op
+    // (which would flood the undo stack with no-op style changes).
+    private bool _suppressTypewriterStyleApply;
+
+    /// <summary>
+    /// The style inspector is shown only in typewriter mode and only when a box
+    /// is active, so it never floats over a document with nothing to style.
+    /// </summary>
+    public bool IsTypewriterStyleInspectorVisible =>
+        IsTypewriterMode && _activeTypewriterOperationId.HasValue;
+
+    public double TypewriterFontSize
+    {
+        get => _typewriterFontSize;
+        set
+        {
+            var clamped = Math.Clamp(value, 4, 96);
+            if (Math.Abs(_typewriterFontSize - clamped) < 0.0001)
+                return;
+            this.RaiseAndSetIfChanged(ref _typewriterFontSize, clamped);
+            ApplyInspectorStyleToActiveBox();
+        }
+    }
+
+    public Color TypewriterColor
+    {
+        get => _typewriterColor;
+        set
+        {
+            if (_typewriterColor == value)
+                return;
+            this.RaiseAndSetIfChanged(ref _typewriterColor, value);
+            this.RaisePropertyChanged(nameof(TypewriterColorBrush));
+            ApplyInspectorStyleToActiveBox();
+        }
+    }
+
+    /// <summary>Preview swatch for the current type-over colour.</summary>
+    public IBrush TypewriterColorBrush => new SolidColorBrush(_typewriterColor);
+
+    public int TypewriterAlignmentIndex
+    {
+        get => _typewriterAlignmentIndex;
+        set
+        {
+            var clamped = Math.Clamp(value, 0, 2);
+            if (_typewriterAlignmentIndex == clamped)
+                return;
+            this.RaiseAndSetIfChanged(ref _typewriterAlignmentIndex, clamped);
+            ApplyInspectorStyleToActiveBox();
+        }
+    }
+
+    /// <summary>
+    /// Command target for the preset colour swatches. Parameter is a hex string
+    /// (e.g. <c>#D0021B</c>); keeps the colour picker dependency-free.
+    /// </summary>
+    public void SetTypewriterColor(string? hex)
+    {
+        if (string.IsNullOrWhiteSpace(hex))
+            return;
+        if (Color.TryParse(hex, out var color))
+            TypewriterColor = color;
+    }
+
+    /// <summary>
+    /// Marks a box as the inspector's target and pulls its current style into
+    /// the inspector fields. Passing <c>null</c> (e.g. on delete or on leaving
+    /// the mode) hides the inspector. Callers are the OnTypewriterText*
+    /// handlers, so styling always follows the box the user is working with.
+    /// </summary>
+    private void SetActiveTypewriterOperation(Guid? operationId)
+    {
+        _activeTypewriterOperationId = operationId;
+
+        if (operationId is Guid id)
+        {
+            var index = IndexOfTypewriterOperation(id);
+            if (index >= 0)
+                SyncInspectorFromStyle(TypewriterTextOperations[index].Style);
+        }
+
+        this.RaisePropertyChanged(nameof(IsTypewriterStyleInspectorVisible));
+    }
+
+    private void ClearActiveTypewriterOperation() => SetActiveTypewriterOperation(null);
+
+    private void SyncInspectorFromStyle(PdfTypewriterTextStyle style)
+    {
+        _suppressTypewriterStyleApply = true;
+        try
+        {
+            TypewriterFontSize = style.FontSize;
+            TypewriterColor = ToAvaloniaColor(style.Color);
+            TypewriterAlignmentIndex = (int)style.Alignment;
+        }
+        finally
+        {
+            _suppressTypewriterStyleApply = false;
+        }
+    }
+
+    /// <summary>
+    /// Style built from the current inspector values. Used both to restyle the
+    /// active box and as the initial style for newly-drawn boxes, so "set the
+    /// style, then draw" carries the chosen look forward.
+    /// </summary>
+    private PdfTypewriterTextStyle BuildInspectorStyle(PdfTypewriterTextStyle basedOn)
+    {
+        return new PdfTypewriterTextStyle(
+            fontName: basedOn.FontName,
+            fontSize: _typewriterFontSize,
+            color: ToPdfColor(_typewriterColor),
+            alignment: (Excise.Core.Graphics.TextAlignment)_typewriterAlignmentIndex,
+            lineSpacing: basedOn.LineSpacing);
+    }
+
+    private PdfTypewriterTextStyle BuildInspectorStyle() =>
+        BuildInspectorStyle(PdfTypewriterTextStyle.Default);
+
+    private void ApplyInspectorStyleToActiveBox()
+    {
+        if (_suppressTypewriterStyleApply)
+            return;
+        if (_activeTypewriterOperationId is not Guid id)
+            return;
+
+        var index = IndexOfTypewriterOperation(id);
+        if (index < 0)
+            return;
+
+        var current = TypewriterTextOperations[index].Style;
+        var next = BuildInspectorStyle(current);
+        if (StylesEqual(current, next))
+            return;
+
+        RecordTypewriterEdit("Change text style", () =>
+        {
+            var i = IndexOfTypewriterOperation(id);
+            if (i < 0)
+                return;
+            TypewriterTextOperations[i] = TypewriterTextOperations[i].WithStyle(next);
+            RefreshTypewriterEditState();
+        });
+    }
+
+    private static bool StylesEqual(PdfTypewriterTextStyle a, PdfTypewriterTextStyle b) =>
+        a.FontName == b.FontName
+        && Math.Abs(a.FontSize - b.FontSize) < 0.0001
+        && a.Color.Equals(b.Color)
+        && a.Alignment == b.Alignment
+        && Math.Abs(a.LineSpacing - b.LineSpacing) < 0.0001;
+
+    private static Color ToAvaloniaColor(PdfColor color)
+    {
+        static byte Channel(double value) => (byte)Math.Clamp(Math.Round(value * 255), 0, 255);
+        return Color.FromRgb(Channel(color.R), Channel(color.G), Channel(color.B));
+    }
+
+    private static PdfColor ToPdfColor(Color color) =>
+        new(color.R / 255.0, color.G / 255.0, color.B / 255.0);
+}

--- a/Excise.App/Views/MainWindow.axaml
+++ b/Excise.App/Views/MainWindow.axaml
@@ -457,6 +457,108 @@
                         </StackPanel>
                     </Button>
 
+                    <!-- #781: style inspector for the ACTIVE type-over box.
+                         Visible only in typewriter mode with a box active.
+                         Every control routes through WithStyle on the active
+                         PdfTypewriterTextOperation (MainWindowViewModel.TypewriterStyle.cs). -->
+                    <StackPanel Orientation="Horizontal" Spacing="6"
+                                VerticalAlignment="Center"
+                                IsVisible="{Binding IsTypewriterStyleInspectorVisible}">
+                        <TextBlock Text="Size" VerticalAlignment="Center" FontSize="11"
+                                   Foreground="{DynamicResource TextSecondaryBrush}"/>
+                        <NumericUpDown Value="{Binding TypewriterFontSize}"
+                                       Minimum="4" Maximum="96" Increment="1"
+                                       FormatString="0" Width="104"
+                                       VerticalAlignment="Center"
+                                       AutomationProperties.Name="Typewriter Font Size"
+                                       AutomationProperties.HelpText="Font size of the active type-over text box"
+                                       ToolTip.Tip="Font size of the active text box"/>
+
+                        <ComboBox SelectedIndex="{Binding TypewriterAlignmentIndex}"
+                                  MinWidth="92" VerticalAlignment="Center"
+                                  AutomationProperties.Name="Typewriter Text Alignment"
+                                  AutomationProperties.HelpText="Text alignment of the active type-over text box"
+                                  ToolTip.Tip="Text alignment of the active text box">
+                            <ComboBoxItem Content="Left"/>
+                            <ComboBoxItem Content="Center"/>
+                            <ComboBoxItem Content="Right"/>
+                        </ComboBox>
+
+                        <Button Classes="modern-button" Padding="8,6"
+                                VerticalAlignment="Center"
+                                AutomationProperties.Name="Typewriter Text Color"
+                                AutomationProperties.HelpText="Text colour of the active type-over text box"
+                                ToolTip.Tip="Text color of the active text box">
+                            <StackPanel Orientation="Horizontal" Spacing="6">
+                                <Border Width="16" Height="16" CornerRadius="2"
+                                        BorderThickness="1"
+                                        BorderBrush="{DynamicResource DividerBrush}"
+                                        Background="{Binding TypewriterColorBrush}"/>
+                                <TextBlock Text="Color" VerticalAlignment="Center"/>
+                            </StackPanel>
+                            <Button.Flyout>
+                                <Flyout>
+                                    <StackPanel Spacing="6" Width="152">
+                                        <TextBlock Text="Text color" FontWeight="Medium" FontSize="11"/>
+                                        <WrapPanel>
+                                            <Button Width="28" Height="28" Padding="2" Margin="2"
+                                                    Command="{Binding SetTypewriterColorCommand}"
+                                                    CommandParameter="#000000"
+                                                    ToolTip.Tip="Black">
+                                                <Border Background="#000000" CornerRadius="2"/>
+                                            </Button>
+                                            <Button Width="28" Height="28" Padding="2" Margin="2"
+                                                    Command="{Binding SetTypewriterColorCommand}"
+                                                    CommandParameter="#555555"
+                                                    ToolTip.Tip="Gray">
+                                                <Border Background="#555555" CornerRadius="2"/>
+                                            </Button>
+                                            <Button Width="28" Height="28" Padding="2" Margin="2"
+                                                    Command="{Binding SetTypewriterColorCommand}"
+                                                    CommandParameter="#D0021B"
+                                                    ToolTip.Tip="Red">
+                                                <Border Background="#D0021B" CornerRadius="2"/>
+                                            </Button>
+                                            <Button Width="28" Height="28" Padding="2" Margin="2"
+                                                    Command="{Binding SetTypewriterColorCommand}"
+                                                    CommandParameter="#F5A623"
+                                                    ToolTip.Tip="Orange">
+                                                <Border Background="#F5A623" CornerRadius="2"/>
+                                            </Button>
+                                            <Button Width="28" Height="28" Padding="2" Margin="2"
+                                                    Command="{Binding SetTypewriterColorCommand}"
+                                                    CommandParameter="#2E7D32"
+                                                    ToolTip.Tip="Green">
+                                                <Border Background="#2E7D32" CornerRadius="2"/>
+                                            </Button>
+                                            <Button Width="28" Height="28" Padding="2" Margin="2"
+                                                    Command="{Binding SetTypewriterColorCommand}"
+                                                    CommandParameter="#1565C0"
+                                                    ToolTip.Tip="Blue">
+                                                <Border Background="#1565C0" CornerRadius="2"/>
+                                            </Button>
+                                            <Button Width="28" Height="28" Padding="2" Margin="2"
+                                                    Command="{Binding SetTypewriterColorCommand}"
+                                                    CommandParameter="#6A1B9A"
+                                                    ToolTip.Tip="Purple">
+                                                <Border Background="#6A1B9A" CornerRadius="2"/>
+                                            </Button>
+                                            <Button Width="28" Height="28" Padding="2" Margin="2"
+                                                    Command="{Binding SetTypewriterColorCommand}"
+                                                    CommandParameter="#FFFFFF"
+                                                    ToolTip.Tip="White">
+                                                <Border Background="#FFFFFF" CornerRadius="2"/>
+                                            </Button>
+                                        </WrapPanel>
+                                    </StackPanel>
+                                </Flyout>
+                            </Button.Flyout>
+                        </Button>
+
+                        <Border Width="1" Height="24" Margin="6,0"
+                                Background="{DynamicResource DividerBrush}"/>
+                    </StackPanel>
+
                     <Button Command="{Binding AddHighlightAnnotationFromSelectionCommand}"
                             Classes="modern-button"
                             Padding="10,6"


### PR DESCRIPTION
## Summary
Wires a GUI onto the existing type-over styling engine. `PdfTypewriterTextStyle` + `PdfTypewriterTextOperation.WithStyle` already supported font size, colour, and text alignment, but nothing in the app called `WithStyle`, so every type-over box was Helvetica 12pt black left-aligned. This adds a small style inspector for the **active** box. Engine unchanged — GUI wiring only.

## What the UI adds
A style inspector in the main toolbar, shown **only** in typewriter mode when a box is active (`IsTypewriterStyleInspectorVisible`):
- **Font size** — `NumericUpDown` (4–96) bound to `TypewriterFontSize`
- **Alignment** — Left/Center/Right combo bound to `TypewriterAlignmentIndex`
- **Colour** — swatch button opening a preset-colour flyout (`SetTypewriterColorCommand`), dependency-free (no new package)

## How it wires to `WithStyle`
- New `MainWindowViewModel.TypewriterStyle.cs`: inspector properties build a `PdfTypewriterTextStyle` (preserving the active op's `FontName`/`LineSpacing`) and apply it immutably via `TypewriterTextOperations[i].WithStyle(next)` inside `RecordTypewriterEdit`, so each change is one undo step and the viewer's `RedrawTypewriterLayer` (which already reads `operation.Style`) reflects it live. The flatten path (`PdfTypewriterTextApplier` → `DrawText`) already honours Style, so the saved PDF reflects it too.
- "Active box" is tracked through the existing `OnTypewriterText*` handlers — create / type / move set it, delete clears it — so no new (public) `Excise.Avalonia` event was needed. New boxes inherit the last-used style.

MVVM preserved: state in the ViewModel, binding in XAML, no logic in code-behind. No `Excise.Avalonia` change, so no approved.txt regeneration.

## Tests (`Excise.App.Tests`, serial headless-Avalonia)
- `StyleInspector_IsVisibleOnlyWhenTypewriterBoxIsActive`
- `StyleChanges_UpdateTheActiveBoxStyle` — size/color/alignment land on the op's immutable `Style`
- `StyledTypewriterText_RoundTripsIntoSavedPdf` — real GUI save; the flattened page content stream carries the chosen size (`29 Tf`) and colour (`1 0 0 rg`) operators (byte-level assertion, not a self-oracle)
- `CommandBindingSweepTests` updated to treat a flyout-opening `Button` as a container (activates via flyout, not `Command`), matching the existing menu-container carve-out.

Full `Excise.App.Tests` passes in the foreground (no native host crash); `test-tier.sh t0` green; build 0 warnings.

Closes #781.

🤖 Generated with [Claude Code](https://claude.com/claude-code)