### PR TITLE
PDF/UA-1 + PDF/A structural conformance checker (#772)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ semantic versioning.
 ## [Unreleased]
 
 ### Added
+- **PDF/UA-1 and PDF/A conformance checker** (#772) — a new
+  `Excise.Core.Validation` namespace adds a *checker* (not an emitter):
+  `PdfUaValidator.Validate(document)` reports a bounded, honestly-scoped subset
+  of PDF/UA-1 (ISO 14289-1) rules that are decidable from what excise already
+  parses — document is tagged (`/MarkInfo /Marked`), has a `/StructTreeRoot`,
+  declares `/Lang`, has a title (Info `/Title` or XMP `dc:title`) with
+  `/ViewerPreferences /DisplayDocTitle true`, custom structure types are
+  role-mapped (`/RoleMap`) to standard ones, figures carry `/Alt` or
+  `/ActualText`, heading levels don't skip, tables use `TR`/`TH`/`TD`, lists use
+  `L`/`LI`/`LBody`, and real page text is either inside the structure tree or
+  marked `/Artifact`. `PdfAStructuralValidator.Validate(document, conformance)`
+  structurally checks the PDF/A markers excise itself emits (XMP `pdfaid`
+  part/level, sRGB OutputIntent, trailer `/ID`). Each rule reports
+  pass/fail/not-applicable/not-checked with a severity and a location, and every
+  `ValidationReport` carries an explicit `UncoveredCheckpoints` list plus a
+  deliberately-named `CheckedSubsetConformant` flag so a green result can never
+  be mistaken for full ISO conformance. The content-tagging rule re-walks the
+  page content stream itself (honoring `/Artifact` and `/MCID`) rather than
+  going through the text extractor, so it distinguishes an artifact from
+  untagged content and touches nothing on the extraction path. A small
+  `excise validate <file> [--pdfa 1b|2b] [--json]` CLI command surfaces the
+  report. Tests drive per-rule pass/fail fixtures whose verdict is known by
+  construction and, where veraPDF is installed, cross-check excise's verdict
+  against it.
 - **Type-over (typewriter) styling UI** (#781) — the type-over engine already
   supported font size, colour, and text alignment
   (`PdfTypewriterTextStyle`/`PdfTypewriterTextOperation.WithStyle`), but nothing

--- a/Excise.Cli/Program.cs
+++ b/Excise.Cli/Program.cs
@@ -29,6 +29,7 @@ partial class Program
             CreateCommandsCommand(),
             CreateBatchCommand(),
             CreateInfoCommand(),
+            CreateValidateCommand(),
             CreateTextCommand(),
             CreateLettersCommand(),
             CreateRenderCommand(),
@@ -225,6 +226,127 @@ partial class Program
                 }
                 if (doc.PageCount > 10)
                     Console.WriteLine($"  ... and {doc.PageCount - 10} more pages");
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"Error: {ex.Message}");
+                Environment.ExitCode = 1;
+            }
+        });
+
+        return command;
+    }
+
+    /// <summary>
+    /// excise validate &lt;file&gt; [--pdfa 1b|2b] [--json] - Bounded PDF/UA-1 (and
+    /// optional PDF/A structural) conformance check. This is a CHECKER over a
+    /// deliberately small, honestly-scoped subset of the standard — not a full
+    /// ISO validator. Exit code is non-zero when a checked Error-severity rule
+    /// fails. See issue #772.
+    /// </summary>
+    static Command CreateValidateCommand()
+    {
+        var fileArg = new Argument<FileInfo>("file") { Description = "PDF file to validate" };
+        var pdfaOption = new Option<string?>("--pdfa")
+        {
+            Description = "Also run the PDF/A structural check for the given level (1b or 2b)",
+        };
+        var jsonOption = new Option<bool>("--json")
+        {
+            Description = "Write the conformance report as JSON",
+            DefaultValueFactory = _ => false,
+        };
+        var passwordOption = new Option<string?>("--password")
+        {
+            Description = "User password for encrypted PDFs",
+        };
+
+        var command = new Command("validate", "Check PDF/UA-1 (and optionally PDF/A) conformance — bounded structural subset, not a full ISO validator")
+        {
+            fileArg,
+            pdfaOption,
+            jsonOption,
+            passwordOption,
+        };
+
+        command.SetAction(parseResult =>
+        {
+            var file = parseResult.GetValue(fileArg)!;
+            var json = parseResult.GetValue(jsonOption);
+            var password = parseResult.GetValue(passwordOption);
+            var pdfaText = parseResult.GetValue(pdfaOption);
+
+            if (!file.Exists)
+            {
+                Console.Error.WriteLine($"File not found: {file.FullName}");
+                Environment.ExitCode = 1;
+                return;
+            }
+
+            Excise.Core.Authoring.PdfAConformance? pdfa = pdfaText?.Trim().ToLowerInvariant() switch
+            {
+                null or "" => null,
+                "1b" or "pdfa1b" => Excise.Core.Authoring.PdfAConformance.PdfA1B,
+                "2b" or "pdfa2b" => Excise.Core.Authoring.PdfAConformance.PdfA2B,
+                _ => throw new ArgumentException("invalid --pdfa level"),
+            };
+
+            try
+            {
+                using var doc = OpenPdfDocument(file.FullName, password);
+
+                var reports = new List<Excise.Core.Validation.ValidationReport>
+                {
+                    Excise.Core.Validation.PdfUaValidator.Validate(doc),
+                };
+                if (pdfa is { } level)
+                    reports.Add(Excise.Core.Validation.PdfAStructuralValidator.Validate(doc, level));
+
+                bool conformant = reports.All(r => r.CheckedSubsetConformant);
+
+                if (json)
+                {
+                    WriteJson(new
+                    {
+                        schemaVersion = 1,
+                        command = "validate",
+                        status = conformant ? "PASS" : "FAIL",
+                        file = file.FullName,
+                        note = "Bounded structural subset checker — not a full ISO conformance verdict. Use veraPDF for authoritative validation.",
+                        reports = reports.Select(r => new
+                        {
+                            standard = r.Standard.ToString(),
+                            checkedSubsetConformant = r.CheckedSubsetConformant,
+                            uncoveredCheckpoints = r.UncoveredCheckpoints,
+                            results = r.Results.Select(x => new
+                            {
+                                ruleId = x.RuleId,
+                                status = x.Status.ToString(),
+                                severity = x.Severity.ToString(),
+                                x.Description,
+                                x.Location,
+                                x.Reference,
+                            }),
+                        }),
+                    });
+                }
+                else
+                {
+                    Console.WriteLine($"File: {file.Name}");
+                    Console.WriteLine("Bounded structural conformance check (NOT a full ISO verdict — use veraPDF for that).");
+                    foreach (var r in reports)
+                    {
+                        Console.WriteLine();
+                        Console.WriteLine($"=== {r.Standard} — CheckedSubsetConformant={r.CheckedSubsetConformant} ===");
+                        foreach (var x in r.Results)
+                            Console.WriteLine($"  [{x.Status}] {x.RuleId} ({x.Severity}){(x.Location is null ? "" : $" @ {x.Location}")}: {x.Description}");
+                        Console.WriteLine("  NOT checked:");
+                        foreach (var u in r.UncoveredCheckpoints)
+                            Console.WriteLine($"    - {u}");
+                    }
+                }
+
+                Environment.ExitCode = conformant ? 0 : 1;
             }
             catch (Exception ex)
             {

--- a/Excise.Core.Tests/PublicApi/Excise.Core.approved.txt
+++ b/Excise.Core.Tests/PublicApi/Excise.Core.approved.txt
@@ -1893,6 +1893,59 @@ namespace Excise.Core.Text.Segmentation
         public System.Collections.Generic.List<Excise.Core.Text.Segmentation.TextSegment> BuildSegments(string text, Excise.Core.Document.PdfRectangle operationBounds, System.Collections.Generic.List<Excise.Core.Text.Segmentation.LetterMatch> letterMatches, Excise.Core.Document.PdfRectangle redactionArea, Excise.Core.Text.Segmentation.GlyphRemovalStrategy strategy = 0) { }
     }
 }
+namespace Excise.Core.Validation
+{
+    public enum ConformanceStandard
+    {
+        PdfUA1 = 0,
+        PdfA1B = 1,
+        PdfA2B = 2,
+    }
+    public static class PdfAStructuralValidator
+    {
+        public static Excise.Core.Validation.ValidationReport Validate(Excise.Core.Document.PdfDocument document, Excise.Core.Authoring.PdfAConformance conformance) { }
+    }
+    public static class PdfUaValidator
+    {
+        public static Excise.Core.Validation.ValidationReport Validate(Excise.Core.Document.PdfDocument document) { }
+    }
+    public enum RuleSeverity
+    {
+        Error = 0,
+        Warning = 1,
+        Info = 2,
+    }
+    public enum RuleStatus
+    {
+        Pass = 0,
+        Fail = 1,
+        NotApplicable = 2,
+        NotChecked = 3,
+    }
+    public sealed class ValidationReport
+    {
+        public ValidationReport(Excise.Core.Validation.ConformanceStandard standard, System.Collections.Generic.IReadOnlyList<Excise.Core.Validation.ValidationResult> results, System.Collections.Generic.IReadOnlyList<string> uncoveredCheckpoints) { }
+        public bool CheckedSubsetConformant { get; }
+        public System.Collections.Generic.IEnumerable<Excise.Core.Validation.ValidationResult> Errors { get; }
+        public System.Collections.Generic.IEnumerable<Excise.Core.Validation.ValidationResult> Failures { get; }
+        public System.Collections.Generic.IReadOnlyList<Excise.Core.Validation.ValidationResult> Results { get; }
+        public Excise.Core.Validation.ConformanceStandard Standard { get; }
+        public System.Collections.Generic.IReadOnlyList<string> UncoveredCheckpoints { get; }
+        public System.Collections.Generic.IEnumerable<Excise.Core.Validation.ValidationResult> Warnings { get; }
+        public override string ToString() { }
+    }
+    public sealed class ValidationResult
+    {
+        public ValidationResult(string ruleId, string description, Excise.Core.Validation.RuleSeverity severity, Excise.Core.Validation.RuleStatus status, string? location = null, string? reference = null) { }
+        public string Description { get; }
+        public string? Location { get; }
+        public string? Reference { get; }
+        public string RuleId { get; }
+        public Excise.Core.Validation.RuleSeverity Severity { get; }
+        public Excise.Core.Validation.RuleStatus Status { get; }
+        public override string ToString() { }
+    }
+}
 namespace Excise.Core.Writing
 {
     public class PdfDocumentWriter

--- a/Excise.Core.Tests/Validation/PdfAStructuralValidatorTests.cs
+++ b/Excise.Core.Tests/Validation/PdfAStructuralValidatorTests.cs
@@ -1,0 +1,69 @@
+using System.Linq;
+using AwesomeAssertions;
+using Excise.Core.Authoring;
+using Excise.Core.Document;
+using Excise.Core.Graphics;
+using Excise.Core.Tests.Fixtures;
+using Excise.Core.Validation;
+using Xunit;
+
+namespace Excise.Core.Tests.Validation;
+
+/// <summary>
+/// Verifies <see cref="PdfAStructuralValidator"/> against excise's own PDF/A
+/// emitter: what <see cref="PdfDocumentBuilder.PdfA"/> writes must round-trip
+/// (save → reparse) as structurally conformant, and a document missing a marker
+/// must be flagged.
+/// </summary>
+public class PdfAStructuralValidatorTests
+{
+    private static byte[] EmitPdfA(PdfAConformance conformance)
+    {
+        var font = PdfFont.FromTrueType(TestFontFixtures.LoadDejaVuSansBytes(), 11);
+        return PdfDocumentBuilder.Create()
+            .Language("en-US").Title("Archival Test").DefaultFont(font)
+            .PdfA(conformance)
+            .Heading("Archival Test")
+            .Paragraph("Body text with unicode: café.")
+            .SaveToBytes();
+    }
+
+    [Theory]
+    [InlineData(PdfAConformance.PdfA1B)]
+    [InlineData(PdfAConformance.PdfA2B)]
+    public void EmittedPdfA_RoundTrips_AsStructurallyConformant(PdfAConformance conformance)
+    {
+        var doc = PdfDocument.Open(EmitPdfA(conformance));
+        var report = PdfAStructuralValidator.Validate(doc, conformance);
+
+        report.CheckedSubsetConformant.Should().BeTrue(
+            "excise's own PDF/A output must carry the required document-level markers. Report:\n" + report);
+        Status(report, "A-XmpPdfaId").Should().Be(RuleStatus.Pass);
+        Status(report, "A-OutputIntent").Should().Be(RuleStatus.Pass);
+        Status(report, "A-TrailerId").Should().Be(RuleStatus.Pass);
+        report.UncoveredCheckpoints.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public void WrongPartNumber_IsFlagged()
+    {
+        // A file emitted as PDF/A-2 checked against the -1 expectation must fail
+        // the pdfaid part rule.
+        var doc = PdfDocument.Open(EmitPdfA(PdfAConformance.PdfA2B));
+        Status(PdfAStructuralValidator.Validate(doc, PdfAConformance.PdfA1B), "A-XmpPdfaId")
+            .Should().Be(RuleStatus.Fail);
+    }
+
+    [Fact]
+    public void MissingOutputIntent_IsFlagged()
+    {
+        var doc = PdfDocument.Open(EmitPdfA(PdfAConformance.PdfA2B));
+        doc.Catalog.Remove("OutputIntents");
+        var report = PdfAStructuralValidator.Validate(doc, PdfAConformance.PdfA2B);
+        Status(report, "A-OutputIntent").Should().Be(RuleStatus.Fail);
+        report.CheckedSubsetConformant.Should().BeFalse();
+    }
+
+    private static RuleStatus Status(ValidationReport report, string ruleId) =>
+        report.Results.Single(r => r.RuleId == ruleId).Status;
+}

--- a/Excise.Core.Tests/Validation/PdfUaValidatorTests.cs
+++ b/Excise.Core.Tests/Validation/PdfUaValidatorTests.cs
@@ -1,0 +1,285 @@
+using System.Linq;
+using System.Text;
+using AwesomeAssertions;
+using Excise.Core.Authoring;
+using Excise.Core.Document;
+using Excise.Core.Graphics;
+using Excise.Core.Primitives;
+using Excise.Core.Tests.Fixtures;
+using Excise.Core.Validation;
+using Xunit;
+
+namespace Excise.Core.Tests.Validation;
+
+/// <summary>
+/// Fixture-driven tests for <see cref="PdfUaValidator"/>. The PASS case is a real
+/// <see cref="PdfDocumentBuilder.Tagged"/> document round-tripped through save/
+/// reparse (so tagging is materialized, not just registered). Each FAIL case is a
+/// minimally-crafted document that breaks exactly one rule, so the expected
+/// verdict is known by construction — excise is never its own oracle for a PASS.
+/// </summary>
+public class PdfUaValidatorTests
+{
+    // ── PASS: a real, well-tagged document ────────────────────────────────────
+
+    private static byte[] WellTaggedBytes()
+    {
+        var font = PdfFont.FromTrueType(TestFontFixtures.LoadDejaVuSansBytes(), 11);
+        return PdfDocumentBuilder.Create()
+            .Tagged().DefaultFont(font).Language("en-US").Title("Accessible Sample")
+            .Heading("Overview", 1)
+            .Paragraph("Body text with an accent: café.")
+            .Heading("Details", 2)
+            .BulletList(new[] { "First", "Second" })
+            .Table(new[] { new[] { "Item", "Qty" }, new[] { "Widget", "3" } }, headerRow: true)
+            .SaveToBytes();
+    }
+
+    [Fact]
+    public void WellTaggedDocument_PassesCheckedSubset()
+    {
+        var doc = PdfDocument.Open(WellTaggedBytes());
+        var report = PdfUaValidator.Validate(doc);
+
+        report.CheckedSubsetConformant.Should().BeTrue(
+            "a Tagged() builder document should pass every checked Error rule. Report:\n" + report);
+
+        Status(report, "UA-Marked").Should().Be(RuleStatus.Pass);
+        Status(report, "UA-StructTreeRoot").Should().Be(RuleStatus.Pass);
+        Status(report, "UA-Lang").Should().Be(RuleStatus.Pass);
+        Status(report, "UA-Title").Should().Be(RuleStatus.Pass);
+        Status(report, "UA-DisplayDocTitle").Should().Be(RuleStatus.Pass);
+        Status(report, "UA-RoleMap").Should().Be(RuleStatus.Pass);
+        Status(report, "UA-Heading-Order").Should().Be(RuleStatus.Pass);
+        Status(report, "UA-Table-Structure").Should().Be(RuleStatus.Pass);
+        Status(report, "UA-List-Structure").Should().Be(RuleStatus.Pass);
+        Status(report, "UA-Content-Tagged").Should().Be(RuleStatus.Pass,
+            "the builder tags every text run with an MCID the tree references");
+    }
+
+    [Fact]
+    public void Report_AlwaysDeclaresUncoveredCheckpoints()
+    {
+        var report = PdfUaValidator.Validate(PdfDocument.Open(WellTaggedBytes()));
+        report.UncoveredCheckpoints.Should().NotBeEmpty(
+            "a green report must never imply full PDF/UA conformance");
+    }
+
+    // ── FAIL: one broken rule per fixture ─────────────────────────────────────
+
+    [Fact]
+    public void MissingMarkInfo_FailsMarkedRule()
+    {
+        var doc = Craft(SimpleTaggedTree(), marked: false);
+        Status(PdfUaValidator.Validate(doc), "UA-Marked").Should().Be(RuleStatus.Fail);
+    }
+
+    [Fact]
+    public void MissingStructTreeRoot_FailsStructTreeRule()
+    {
+        var doc = Craft(SimpleTaggedTree(), includeStructTree: false);
+        var report = PdfUaValidator.Validate(doc);
+        Status(report, "UA-StructTreeRoot").Should().Be(RuleStatus.Fail);
+        Status(report, "UA-Content-Tagged").Should().Be(RuleStatus.NotChecked,
+            "without a tree we cannot decide what is untagged");
+    }
+
+    [Fact]
+    public void MissingLang_FailsLangRule()
+    {
+        var doc = Craft(SimpleTaggedTree(), lang: null);
+        var report = PdfUaValidator.Validate(doc);
+        Status(report, "UA-Lang").Should().Be(RuleStatus.Fail);
+        Status(report, "UA-Marked").Should().Be(RuleStatus.Pass, "only /Lang should be broken");
+    }
+
+    [Fact]
+    public void MissingTitle_FailsTitleRule()
+    {
+        var doc = Craft(SimpleTaggedTree(), title: null);
+        Status(PdfUaValidator.Validate(doc), "UA-Title").Should().Be(RuleStatus.Fail);
+    }
+
+    [Fact]
+    public void MissingDisplayDocTitle_FailsDisplayRule()
+    {
+        var doc = Craft(SimpleTaggedTree(), displayDocTitle: false);
+        Status(PdfUaValidator.Validate(doc), "UA-DisplayDocTitle").Should().Be(RuleStatus.Fail);
+    }
+
+    [Fact]
+    public void FigureWithoutAlt_Fails_WithAlt_Passes()
+    {
+        var noAlt = Craft(new PdfArray(SE("Document", new PdfArray(SE("Figure")))));
+        Status(PdfUaValidator.Validate(noAlt), "UA-Figure-Alt").Should().Be(RuleStatus.Fail);
+
+        var withAlt = Craft(new PdfArray(SE("Document", new PdfArray(SE("Figure", alt: "A photo of a cat")))));
+        Status(PdfUaValidator.Validate(withAlt), "UA-Figure-Alt").Should().Be(RuleStatus.Pass);
+    }
+
+    [Fact]
+    public void SkippedHeadingLevel_Fails_ProperOrder_Passes()
+    {
+        var skipped = Craft(new PdfArray(SE("Document", new PdfArray(SE("H1"), SE("H3")))));
+        Status(PdfUaValidator.Validate(skipped), "UA-Heading-Order").Should().Be(RuleStatus.Fail);
+
+        var ordered = Craft(new PdfArray(SE("Document", new PdfArray(SE("H1"), SE("H2"), SE("H3")))));
+        Status(PdfUaValidator.Validate(ordered), "UA-Heading-Order").Should().Be(RuleStatus.Pass);
+    }
+
+    [Fact]
+    public void TableWithNonCellChild_Fails()
+    {
+        // /Table -> /TR -> /P (a paragraph where a cell must be).
+        var tree = new PdfArray(SE("Document", new PdfArray(
+            SE("Table", new PdfArray(SE("TR", new PdfArray(SE("P"))))))));
+        Status(PdfUaValidator.Validate(Craft(tree)), "UA-Table-Structure").Should().Be(RuleStatus.Fail);
+    }
+
+    [Fact]
+    public void ValidTable_Passes()
+    {
+        var tree = new PdfArray(SE("Document", new PdfArray(
+            SE("Table", new PdfArray(
+                SE("TR", new PdfArray(SE("TH"), SE("TH"))),
+                SE("TR", new PdfArray(SE("TD"), SE("TD"))))))));
+        Status(PdfUaValidator.Validate(Craft(tree)), "UA-Table-Structure").Should().Be(RuleStatus.Pass);
+    }
+
+    [Fact]
+    public void ListWithoutItems_Fails_ValidList_Passes()
+    {
+        var empty = new PdfArray(SE("Document", new PdfArray(SE("L", new PdfArray(SE("P"))))));
+        Status(PdfUaValidator.Validate(Craft(empty)), "UA-List-Structure").Should().Be(RuleStatus.Fail);
+
+        var valid = new PdfArray(SE("Document", new PdfArray(
+            SE("L", new PdfArray(
+                SE("LI", new PdfArray(SE("Lbl"), SE("LBody"))))))));
+        var report = PdfUaValidator.Validate(Craft(valid));
+        Status(report, "UA-List-Structure").Should().Be(RuleStatus.Pass);
+        Status(report, "UA-List-ItemBody").Should().Be(RuleStatus.Pass);
+    }
+
+    [Fact]
+    public void UnmappedCustomType_FailsRoleMap_MappedType_Passes()
+    {
+        var unmapped = new PdfArray(SE("Document", new PdfArray(SE("Chapter"))));
+        Status(PdfUaValidator.Validate(Craft(unmapped)), "UA-RoleMap").Should().Be(RuleStatus.Fail);
+
+        // Same custom type, but role-mapped to a standard type.
+        var roleMap = new PdfDictionary();
+        roleMap.SetName("Chapter", "Sect");
+        var doc = Craft(new PdfArray(SE("Document", new PdfArray(SE("Chapter")))), roleMap: roleMap);
+        Status(PdfUaValidator.Validate(doc), "UA-RoleMap").Should().Be(RuleStatus.Pass);
+    }
+
+    [Fact]
+    public void RoleMappedCustomHeading_IsEvaluatedAsHeading()
+    {
+        // Chapter->H1, Section->H3 : a skipped level even though the raw types are custom.
+        var roleMap = new PdfDictionary();
+        roleMap.SetName("Chapter", "H1");
+        roleMap.SetName("Section", "H3");
+        var doc = Craft(new PdfArray(SE("Document", new PdfArray(SE("Chapter"), SE("Section")))), roleMap: roleMap);
+        Status(PdfUaValidator.Validate(doc), "UA-Heading-Order").Should().Be(RuleStatus.Fail,
+            "role-mapped custom headings must be resolved before the level-skip check");
+    }
+
+    // ── FAIL/PASS: untagged page content ──────────────────────────────────────
+
+    [Fact]
+    public void UntaggedPageText_FailsContentTagged()
+    {
+        // A tagged document (MarkInfo + StructTreeRoot present) whose page draws
+        // text OUTSIDE any marked-content span — the isolated rule-10 violation.
+        var doc = Craft(SimpleTaggedTree());
+        SetPageContent(doc, "BT /F1 12 Tf 72 700 Td (Untagged secret) Tj ET");
+
+        var report = PdfUaValidator.Validate(doc);
+        Status(report, "UA-Marked").Should().Be(RuleStatus.Pass);
+        Status(report, "UA-StructTreeRoot").Should().Be(RuleStatus.Pass);
+        Status(report, "UA-Content-Tagged").Should().Be(RuleStatus.Fail);
+    }
+
+    [Fact]
+    public void ArtifactedPageText_PassesContentTagged()
+    {
+        var doc = Craft(SimpleTaggedTree());
+        SetPageContent(doc, "/Artifact BMC BT /F1 12 Tf 72 20 Td (Page 1) Tj ET EMC");
+        Status(PdfUaValidator.Validate(doc), "UA-Content-Tagged").Should().Be(RuleStatus.Pass,
+            "content inside an /Artifact span is intentionally untagged and conformant");
+    }
+
+    [Fact]
+    public void StructReferencedPageText_PassesContentTagged()
+    {
+        // Tree references MCID 0 on page 1; the page draws that content inside a
+        // matching BDC span.
+        var p = SE("P", new PdfInteger(0));
+        var doc = Craft(new PdfArray(SE("Document", new PdfArray(p))));
+        // Attach the page reference so the (page, mcid) qualifies.
+        p["Pg"] = doc.GetPageReference(1)!;
+        SetPageContent(doc, "/P <</MCID 0>> BDC BT /F1 12 Tf 72 700 Td (Tagged body) Tj ET EMC");
+        Status(PdfUaValidator.Validate(doc), "UA-Content-Tagged").Should().Be(RuleStatus.Pass);
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private static RuleStatus Status(ValidationReport report, string ruleId) =>
+        report.Results.Single(r => r.RuleId == ruleId).Status;
+
+    private static PdfArray SimpleTaggedTree() =>
+        new(SE("Document", new PdfArray(SE("P"))));
+
+    private static PdfDictionary SE(string s, PdfObject? k = null, string? alt = null, string? actual = null)
+    {
+        var d = new PdfDictionary();
+        d.SetName("Type", "StructElem");
+        d.SetName("S", s);
+        if (k != null) d["K"] = k;
+        if (alt != null) d.SetString("Alt", alt);
+        if (actual != null) d.SetString("ActualText", actual);
+        return d;
+    }
+
+    private static PdfDocument Craft(
+        PdfObject structRootK,
+        bool marked = true,
+        bool includeStructTree = true,
+        string? lang = "en-US",
+        string? title = "Crafted",
+        bool displayDocTitle = true,
+        PdfDictionary? roleMap = null)
+    {
+        var doc = PdfDocument.CreateNew();
+        doc.Pages.AddBlank();
+
+        if (title != null) doc.SetTitle(title);
+        if (lang != null) doc.Language = lang;
+
+        if (marked)
+        {
+            var mi = new PdfDictionary();
+            mi.SetBool("Marked", true);
+            doc.Catalog["MarkInfo"] = mi;
+        }
+        if (displayDocTitle)
+        {
+            var vp = new PdfDictionary();
+            vp.SetBool("DisplayDocTitle", true);
+            doc.Catalog["ViewerPreferences"] = vp;
+        }
+        if (includeStructTree)
+        {
+            var root = new PdfDictionary();
+            root.SetName("Type", "StructTreeRoot");
+            root["K"] = structRootK;
+            if (roleMap != null) root["RoleMap"] = roleMap;
+            doc.Catalog["StructTreeRoot"] = root;
+        }
+        return doc;
+    }
+
+    private static void SetPageContent(PdfDocument doc, string content) =>
+        doc.GetPage(1).SetContentStreamBytes(Encoding.ASCII.GetBytes(content));
+}

--- a/Excise.Core.Tests/Validation/PdfUaVeraPdfCrossCheckTests.cs
+++ b/Excise.Core.Tests/Validation/PdfUaVeraPdfCrossCheckTests.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using AwesomeAssertions;
+using Excise.Core.Authoring;
+using Excise.Core.Document;
+using Excise.Core.Graphics;
+using Excise.Core.Tests.Fixtures;
+using Excise.Core.Validation;
+using Xunit;
+
+namespace Excise.Core.Tests.Validation;
+
+/// <summary>
+/// No-self-oracle cross-check (#772): where the reference PDF/UA validator
+/// (veraPDF) is available, excise's <see cref="PdfUaValidator"/> verdict must
+/// AGREE with it on controlled fixtures whose expected verdict is known by
+/// construction — a conformant builder document, and a document with /Lang
+/// removed. Skips cleanly when veraPDF is not installed (as on a dev box);
+/// CI installs it, so the cross-check runs there.
+/// </summary>
+public class PdfUaVeraPdfCrossCheckTests
+{
+    private static byte[] WellTaggedBytes()
+    {
+        var font = PdfFont.FromTrueType(TestFontFixtures.LoadDejaVuSansBytes(), 11);
+        return PdfDocumentBuilder.Create()
+            .Tagged().DefaultFont(font).Language("en-US").Title("Accessible Sample")
+            .Heading("Overview", 1)
+            .Paragraph("Body text with an accent: café.")
+            .Table(new[] { new[] { "Item", "Qty" }, new[] { "Widget", "3" } }, headerRow: true)
+            .SaveToBytes();
+    }
+
+    [Fact]
+    public void ExciseVerdict_AgreesWithVeraPdf_OnConformantFixture()
+    {
+        var verapdf = FindVeraPdf();
+        Assert.SkipWhen(verapdf is null, "veraPDF not installed (~/verapdf/verapdf or PATH)");
+
+        var bytes = WellTaggedBytes();
+        bool exciseConformant = PdfUaValidator.Validate(PdfDocument.Open(bytes)).CheckedSubsetConformant;
+        bool veraConformant = VeraPdfSaysConformant(verapdf!, bytes);
+
+        exciseConformant.Should().BeTrue("the builder fixture is conformant by construction");
+        veraConformant.Should().BeTrue("veraPDF must agree the builder fixture is PDF/UA-1 conformant");
+        exciseConformant.Should().Be(veraConformant, "excise and veraPDF must agree on the conformant fixture");
+    }
+
+    [Fact]
+    public void ExciseVerdict_AgreesWithVeraPdf_OnUntaggedFixture()
+    {
+        var verapdf = FindVeraPdf();
+        Assert.SkipWhen(verapdf is null, "veraPDF not installed (~/verapdf/verapdf or PATH)");
+
+        // Remove the structure tree, then re-save so the on-disk file is what both
+        // validators see. A document that claims to be tagged with no
+        // /StructTreeRoot is unambiguously non-conformant to both validators.
+        var doc = PdfDocument.Open(WellTaggedBytes());
+        doc.Catalog.Remove("StructTreeRoot");
+        var bytes = doc.SaveToBytes();
+
+        bool exciseConformant = PdfUaValidator.Validate(PdfDocument.Open(bytes)).CheckedSubsetConformant;
+        bool veraConformant = VeraPdfSaysConformant(verapdf!, bytes);
+
+        exciseConformant.Should().BeFalse("a document without /StructTreeRoot violates a checked Error rule");
+        veraConformant.Should().BeFalse("veraPDF must also reject a document without a structure tree");
+    }
+
+    private static bool VeraPdfSaysConformant(string verapdf, byte[] pdf)
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"xcheck_{Guid.NewGuid():N}.pdf");
+        File.WriteAllBytes(path, pdf);
+        try
+        {
+            var psi = new ProcessStartInfo(verapdf)
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            psi.ArgumentList.Add("--format");
+            psi.ArgumentList.Add("xml");
+            psi.ArgumentList.Add("-f");
+            psi.ArgumentList.Add("ua1");
+            psi.ArgumentList.Add(path);
+
+            using var proc = Process.Start(psi)!;
+            string report = proc.StandardOutput.ReadToEnd();
+            proc.WaitForExit(120_000);
+            return report.Contains("isCompliant=\"true\"", StringComparison.Ordinal);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    private static string? FindVeraPdf()
+    {
+        var home = Environment.GetEnvironmentVariable("HOME") ?? "";
+        var local = Path.Combine(home, "verapdf", "verapdf");
+        if (File.Exists(local)) return local;
+        foreach (var dir in (Environment.GetEnvironmentVariable("PATH") ?? "").Split(Path.PathSeparator))
+        {
+            var p = Path.Combine(dir, "verapdf");
+            if (File.Exists(p)) return p;
+        }
+        return null;
+    }
+}

--- a/Excise.Core/Validation/ContentTaggingScanner.cs
+++ b/Excise.Core/Validation/ContentTaggingScanner.cs
@@ -1,0 +1,101 @@
+using System.Collections.Generic;
+using Excise.Core.Content;
+using Excise.Core.Document;
+using Excise.Core.Primitives;
+
+namespace Excise.Core.Validation;
+
+/// <summary>
+/// Scans a page content stream for text-showing operators that are neither
+/// inside the structure tree (a marked-content span whose /MCID the tree
+/// references) nor marked as an <c>/Artifact</c>. Such text is "untagged real
+/// content", the PDF/UA §7.1 violation.
+///
+/// <para>Self-contained on purpose: it re-walks the raw operator stream rather
+/// than going through <see cref="Text.TextExtractor"/>, so it can distinguish an
+/// artifact from untagged content (which <see cref="Text.Letter"/> cannot) and
+/// touches nothing on the extraction path.</para>
+/// </summary>
+internal static class ContentTaggingScanner
+{
+    private readonly struct Frame
+    {
+        public readonly bool Artifact;
+        public readonly int? Mcid;
+        public Frame(bool artifact, int? mcid) { Artifact = artifact; Mcid = mcid; }
+    }
+
+    /// <summary>
+    /// Count text-showing operators on <paramref name="page"/> that draw visible
+    /// text yet fall outside both the structure tree and any /Artifact span.
+    /// </summary>
+    public static int CountUntaggedTextRuns(
+        PdfPage page,
+        int pageNumber,
+        HashSet<(int, int)> taggedQualified,
+        HashSet<int> taggedPageAgnostic)
+    {
+        byte[] bytes;
+        try { bytes = page.GetContentStreamBytes(); }
+        catch { return 0; }
+        if (bytes.Length == 0) return 0;
+
+        ContentStream stream;
+        try
+        {
+            stream = new ContentStreamParser(bytes) { ComputeOperatorMetadata = false }.Parse();
+        }
+        catch { return 0; }
+
+        var mcStack = new Stack<Frame>();
+        int untagged = 0;
+
+        foreach (var op in stream.Operators)
+        {
+            switch (op.Name)
+            {
+                case "BDC":
+                case "BMC":
+                {
+                    string tag = op.Operands.Count > 0 && op.Operands[0] is PdfName n ? n.Value : "";
+                    int? mcid = op.Name == "BDC" && op.Operands.Count > 1 && op.Operands[1] is PdfDictionary props
+                        && props.GetOptional("MCID") is PdfInteger m ? (int)m.Value : (int?)null;
+
+                    bool parentArtifact = mcStack.Count > 0 && mcStack.Peek().Artifact;
+                    int? parentMcid = mcStack.Count > 0 ? mcStack.Peek().Mcid : null;
+                    mcStack.Push(new Frame(parentArtifact || tag == "Artifact", mcid ?? parentMcid));
+                    break;
+                }
+                case "EMC":
+                    if (mcStack.Count > 0) mcStack.Pop();
+                    break;
+                case "Tj":
+                case "TJ":
+                case "'":
+                case "\"":
+                    if (!HasVisibleText(op.Operands)) break;
+                    var frame = mcStack.Count > 0 ? mcStack.Peek() : new Frame(false, null);
+                    if (frame.Artifact) break;                                   // artifact — fine
+                    if (frame.Mcid is int id &&
+                        (taggedQualified.Contains((pageNumber, id)) || taggedPageAgnostic.Contains(id)))
+                        break;                                                   // inside struct tree — fine
+                    untagged++;
+                    break;
+            }
+        }
+
+        return untagged;
+    }
+
+    private static bool HasVisibleText(IReadOnlyList<PdfObject> operands)
+    {
+        foreach (var o in operands)
+        {
+            if (o is PdfString s && s.Bytes.Length > 0) return true;
+            if (o is PdfArray arr)
+                foreach (var e in arr)
+                    if (e is PdfString es && es.Bytes.Length > 0) return true;
+        }
+        return false;
+    }
+}

--- a/Excise.Core/Validation/PdfAStructuralValidator.cs
+++ b/Excise.Core/Validation/PdfAStructuralValidator.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Collections.Generic;
+using Excise.Core.Authoring;
+using Excise.Core.Document;
+using Excise.Core.Primitives;
+
+namespace Excise.Core.Validation;
+
+/// <summary>
+/// A light <b>structural</b> PDF/A conformance check for the document-level
+/// markers excise itself emits (<see cref="PdfDocumentBuilder.PdfA"/>): the XMP
+/// <c>pdfaid</c> identifier at the requested part/level, an sRGB OutputIntent,
+/// and a trailer <c>/ID</c>. It exists so excise can verify its own emitted
+/// PDF/A round-trips with the required structures intact.
+///
+/// <para><b>Not a full PDF/A validator.</b> It does not verify font embedding,
+/// colour spaces, transparency, encryption absence, or the hundreds of other
+/// ISO 19005 clauses. <see cref="ValidationReport.UncoveredCheckpoints"/> lists
+/// the gaps; use veraPDF for an authoritative verdict.</para>
+/// </summary>
+public static class PdfAStructuralValidator
+{
+    private static readonly string[] Uncovered =
+    {
+        "Font embedding and completeness (all fonts embedded, /CIDSet for subset CID fonts)",
+        "Colour-space and OutputIntent ICC-profile correctness (only presence is checked)",
+        "Transparency, JavaScript, embedded-file, and encryption prohibitions",
+        "Annotation and action restrictions",
+        "Full XMP schema and Info/XMP consistency validation (only pdfaid keys are parsed)",
+        "All remaining ISO 19005 clauses",
+    };
+
+    /// <summary>
+    /// Structurally check <paramref name="document"/> for the PDF/A markers of the
+    /// given <paramref name="conformance"/> level.
+    /// </summary>
+    public static ValidationReport Validate(PdfDocument document, PdfAConformance conformance)
+    {
+        if (document == null) throw new ArgumentNullException(nameof(document));
+
+        var standard = conformance == PdfAConformance.PdfA1B
+            ? ConformanceStandard.PdfA1B
+            : ConformanceStandard.PdfA2B;
+        int expectedPart = conformance == PdfAConformance.PdfA1B ? 1 : 2;
+
+        var results = new List<ValidationResult>();
+
+        // XMP metadata packet with the pdfaid identifier at the expected part/level.
+        string xmp = ReadXmp(document);
+        bool hasPart = xmp.Contains($"pdfaid:part>{expectedPart}", StringComparison.Ordinal);
+        bool hasLevel = xmp.Contains("pdfaid:conformance>B", StringComparison.Ordinal);
+        results.Add(new ValidationResult(
+            "A-XmpPdfaId",
+            $"XMP metadata declares pdfaid:part {expectedPart} and conformance B.",
+            RuleSeverity.Error,
+            (hasPart && hasLevel) ? RuleStatus.Pass : RuleStatus.Fail,
+            location: "Catalog/Metadata",
+            reference: "ISO 19005-1/-2 §6.7.11 (metadata)"));
+
+        // sRGB OutputIntent with a destination profile.
+        bool hasOutputIntent = HasOutputIntent(document, out string oiDetail);
+        results.Add(new ValidationResult(
+            "A-OutputIntent",
+            "An OutputIntent (GTS_PDFA1) with a /DestOutputProfile is present.",
+            RuleSeverity.Error,
+            hasOutputIntent ? RuleStatus.Pass : RuleStatus.Fail,
+            location: "Catalog/OutputIntents" + (oiDetail.Length > 0 ? $" ({oiDetail})" : ""),
+            reference: "ISO 19005-1/-2 §6.2.2 (output intent)"));
+
+        // Trailer /ID — required for a conformant file.
+        bool hasId = document.Trailer.ContainsKey("ID");
+        results.Add(new ValidationResult(
+            "A-TrailerId",
+            "The trailer has a file identifier (/ID).",
+            RuleSeverity.Error,
+            hasId ? RuleStatus.Pass : RuleStatus.Fail,
+            location: "Trailer/ID",
+            reference: "ISO 19005-1/-2 §6.1.3 (file structure)"));
+
+        return new ValidationReport(standard, results, Uncovered);
+    }
+
+    private static string ReadXmp(PdfDocument doc)
+    {
+        if (doc.Resolve(doc.Catalog.GetOptional("Metadata") ?? PdfNull.Instance) is not PdfStream s)
+            return "";
+        try { return s.GetDecodedString(System.Text.Encoding.UTF8); }
+        catch { return ""; }
+    }
+
+    private static bool HasOutputIntent(PdfDocument doc, out string detail)
+    {
+        detail = "";
+        if (doc.Resolve(doc.Catalog.GetOptional("OutputIntents") ?? PdfNull.Instance) is not PdfArray arr)
+            return false;
+        foreach (var item in arr)
+        {
+            if (doc.Resolve(item) is not PdfDictionary oi) continue;
+            bool isPdfA = doc.Resolve(oi.GetOptional("S") ?? PdfNull.Instance) is PdfName s && s.Value == "GTS_PDFA1";
+            bool hasProfile = oi.ContainsKey("DestOutputProfile");
+            if (isPdfA && hasProfile)
+            {
+                detail = "GTS_PDFA1 + DestOutputProfile";
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/Excise.Core/Validation/PdfUaValidator.cs
+++ b/Excise.Core/Validation/PdfUaValidator.cs
@@ -1,0 +1,398 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Excise.Core.Document;
+using Excise.Core.Primitives;
+
+namespace Excise.Core.Validation;
+
+/// <summary>
+/// A bounded, honest PDF/UA-1 (ISO 14289-1) conformance <b>checker</b> — it
+/// verifies the structurally checkable rules excise can decide from the data it
+/// already parses (document catalog, structure tree, page content), and reports
+/// every rule with a pass / fail / not-applicable / not-checked status and a
+/// location.
+///
+/// <para><b>Scope, stated up front.</b> PDF/UA-1 is defined by roughly 136
+/// Matterhorn-Protocol checkpoints. This validator implements a deliberately
+/// small subset — the tag/metadata/structure rules that can be decided
+/// mechanically — and lists everything it does NOT cover in
+/// <see cref="ValidationReport.UncoveredCheckpoints"/>. A green report means
+/// "the checked subset passed", never "PDF/UA conformant". For an authoritative
+/// verdict, run a reference validator such as veraPDF.</para>
+/// </summary>
+public static class PdfUaValidator
+{
+    /// <summary>Matterhorn areas this checker does not evaluate — surfaced in every report.</summary>
+    private static readonly string[] Uncovered =
+    {
+        "Reading-order correctness (that the tag order matches the visual/logical order)",
+        "Semantic correctness of tags (that a P is really a paragraph, that Alt text is meaningful)",
+        "Table header-cell associations (/Scope, /Headers, /THead-/TBody roles) — only TR/TH/TD nesting is checked",
+        "Colour contrast and use-of-colour (01-004, 04-*)",
+        "Font embedding and character-to-Unicode mapping for every glyph (glyphs without a ToUnicode map)",
+        "Annotations, links, and form-field accessibility (widgets, tab order, /TU) beyond tag presence",
+        "Optional-content, XObject, and annotation appearance-stream tagging (only the page content stream is scanned for untagged text)",
+        "Full XMP metadata schema validation (only dc:title presence is consulted as a Title fallback)",
+        "Multi-page marked-content-to-page qualification when /Pg is absent (single-page association only)",
+        "Approximately 120 further Matterhorn checkpoints not listed above",
+    };
+
+    /// <summary>
+    /// Validate <paramref name="document"/> against the checked PDF/UA-1 subset.
+    /// </summary>
+    public static ValidationReport Validate(PdfDocument document)
+    {
+        if (document == null) throw new ArgumentNullException(nameof(document));
+
+        var results = new List<ValidationResult>();
+        var tree = StructTreeAnalysis.Build(document);
+
+        CheckTagged(document, tree, results);
+        CheckLanguage(document, results);
+        CheckTitle(document, results);
+        CheckDisplayDocTitle(document, results);
+        CheckRoleMap(tree, results);
+        CheckFigures(tree, results);
+        CheckHeadings(tree, results);
+        CheckTables(tree, results);
+        CheckLists(tree, results);
+        CheckContentTagged(document, tree, results);
+
+        return new ValidationReport(ConformanceStandard.PdfUA1, results, Uncovered);
+    }
+
+    // 7.1 — the document must be tagged and have a structure tree.
+    private static void CheckTagged(PdfDocument doc, StructTreeAnalysis tree, List<ValidationResult> results)
+    {
+        bool marked = doc.Resolve(doc.Catalog.GetOptional("MarkInfo") ?? PdfNull.Instance)
+            is PdfDictionary mi && mi.GetBool("Marked");
+        results.Add(new ValidationResult(
+            "UA-Marked",
+            "Document is marked as tagged (/MarkInfo /Marked true).",
+            RuleSeverity.Error,
+            marked ? RuleStatus.Pass : RuleStatus.Fail,
+            location: "Catalog/MarkInfo",
+            reference: "ISO 14289-1 §7.1; Matterhorn 01-005"));
+
+        results.Add(new ValidationResult(
+            "UA-StructTreeRoot",
+            "Document has a structure tree (/StructTreeRoot).",
+            RuleSeverity.Error,
+            tree.StructTreeRoot != null ? RuleStatus.Pass : RuleStatus.Fail,
+            location: "Catalog/StructTreeRoot",
+            reference: "ISO 14289-1 §7.1; Matterhorn 01-006"));
+    }
+
+    // 7.2 — natural language must be declared at the document level.
+    private static void CheckLanguage(PdfDocument doc, List<ValidationResult> results)
+    {
+        bool hasLang = !string.IsNullOrWhiteSpace(doc.Language);
+        results.Add(new ValidationResult(
+            "UA-Lang",
+            "Document declares a natural language (/Lang in the catalog).",
+            RuleSeverity.Error,
+            hasLang ? RuleStatus.Pass : RuleStatus.Fail,
+            location: "Catalog/Lang",
+            reference: "ISO 14289-1 §7.2; Matterhorn 11-001"));
+    }
+
+    // 7.1 — a title must be present (Info /Title or XMP dc:title).
+    private static void CheckTitle(PdfDocument doc, List<ValidationResult> results)
+    {
+        bool infoTitle = !string.IsNullOrWhiteSpace(doc.Title);
+        bool xmpTitle = XmpHasDcTitle(doc);
+        results.Add(new ValidationResult(
+            "UA-Title",
+            "Document has a title (Info /Title or XMP dc:title).",
+            RuleSeverity.Error,
+            (infoTitle || xmpTitle) ? RuleStatus.Pass : RuleStatus.Fail,
+            location: infoTitle ? "Info/Title" : "Metadata/dc:title",
+            reference: "ISO 14289-1 §7.1; Matterhorn 06-004"));
+    }
+
+    // 7.1 — the viewer must be told to show the title, not the file name.
+    private static void CheckDisplayDocTitle(PdfDocument doc, List<ValidationResult> results)
+    {
+        bool display = doc.Resolve(doc.Catalog.GetOptional("ViewerPreferences") ?? PdfNull.Instance)
+            is PdfDictionary vp && vp.GetBool("DisplayDocTitle");
+        results.Add(new ValidationResult(
+            "UA-DisplayDocTitle",
+            "/ViewerPreferences /DisplayDocTitle is true.",
+            RuleSeverity.Error,
+            display ? RuleStatus.Pass : RuleStatus.Fail,
+            location: "Catalog/ViewerPreferences/DisplayDocTitle",
+            reference: "ISO 14289-1 §7.1; Matterhorn 07-001"));
+    }
+
+    // 7.1 — every non-standard structure type must be role-mapped to a standard one.
+    private static void CheckRoleMap(StructTreeAnalysis tree, List<ValidationResult> results)
+    {
+        if (tree.StructTreeRoot == null)
+        {
+            results.Add(NotChecked("UA-RoleMap",
+                "Custom structure types map to standard types (/RoleMap).",
+                "no structure tree", "ISO 14289-1 §7.1; Matterhorn 02-001"));
+            return;
+        }
+
+        var unmapped = tree.UnmappedCustomTypes;
+        results.Add(new ValidationResult(
+            "UA-RoleMap",
+            "Custom structure types are mapped to standard types via /RoleMap.",
+            RuleSeverity.Error,
+            unmapped.Count == 0 ? RuleStatus.Pass : RuleStatus.Fail,
+            location: unmapped.Count == 0 ? null : "unmapped types: " + string.Join(", ", unmapped.Select(t => "/" + t)),
+            reference: "ISO 14289-1 §7.1; Matterhorn 02-001"));
+    }
+
+    // 7.3 — figures need a text alternative.
+    private static void CheckFigures(StructTreeAnalysis tree, List<ValidationResult> results)
+    {
+        var figures = AllNodes(tree).Where(n => n.ResolvedType == "Figure").ToList();
+        if (figures.Count == 0)
+        {
+            results.Add(NotApplicable("UA-Figure-Alt",
+                "Figures have alternative text (/Alt or /ActualText).",
+                "no /Figure elements", "ISO 14289-1 §7.3; Matterhorn 13-004"));
+            return;
+        }
+
+        var missing = figures.Where(f =>
+            string.IsNullOrWhiteSpace(f.Alt) && string.IsNullOrWhiteSpace(f.ActualText)).ToList();
+        results.Add(new ValidationResult(
+            "UA-Figure-Alt",
+            "Every /Figure has alternative text (/Alt or /ActualText).",
+            RuleSeverity.Error,
+            missing.Count == 0 ? RuleStatus.Pass : RuleStatus.Fail,
+            location: missing.Count == 0
+                ? $"{figures.Count} figure(s)"
+                : $"{missing.Count} of {figures.Count} /Figure element(s) lack /Alt and /ActualText",
+            reference: "ISO 14289-1 §7.3; Matterhorn 13-004"));
+    }
+
+    // 7.4.2 — heading levels must not skip (H1 → H3 without H2).
+    private static void CheckHeadings(StructTreeAnalysis tree, List<ValidationResult> results)
+    {
+        // Collect headings in document (reading) order. Level 0 == unnumbered /H.
+        var headings = new List<(int Level, string Type)>();
+        void Walk(StructNode n)
+        {
+            if (n.ResolvedType == "H") headings.Add((0, n.ResolvedType));
+            else if (n.ResolvedType.Length == 2 && n.ResolvedType[0] == 'H'
+                     && n.ResolvedType[1] is >= '1' and <= '6')
+                headings.Add((n.ResolvedType[1] - '0', n.ResolvedType));
+            foreach (var c in n.Children) Walk(c);
+        }
+        foreach (var r in tree.Roots) Walk(r);
+
+        if (headings.Count == 0)
+        {
+            results.Add(NotApplicable("UA-Heading-Order",
+                "Heading levels are used without skipping a level.",
+                "no heading elements", "ISO 14289-1 §7.4.2; Matterhorn 14-002"));
+            return;
+        }
+
+        var numbered = headings.Where(h => h.Level > 0).Select(h => h.Level).ToList();
+        bool usesUnnumbered = headings.Any(h => h.Level == 0);
+
+        // Mixing the strong (H1..H6) and weak (H) heading models is not conformant.
+        if (numbered.Count > 0 && usesUnnumbered)
+        {
+            results.Add(new ValidationResult(
+                "UA-Heading-Order",
+                "A document must use either numbered headings (H1..H6) or unnumbered (H), not both.",
+                RuleSeverity.Error,
+                RuleStatus.Fail,
+                location: "mixed /H and /H1../H6 headings",
+                reference: "ISO 14289-1 §7.4.2; Matterhorn 14-002/14-003"));
+            return;
+        }
+
+        if (numbered.Count == 0)
+        {
+            // Pure /H model — level nesting is not expressible; treat as pass.
+            results.Add(new ValidationResult(
+                "UA-Heading-Order",
+                "Document uses the unnumbered /H heading model.",
+                RuleSeverity.Warning,
+                RuleStatus.Pass,
+                location: $"{headings.Count} /H element(s)",
+                reference: "ISO 14289-1 §7.4.2"));
+            return;
+        }
+
+        // Numbered model: first heading should be H1; each heading at most one
+        // level deeper than the previous.
+        string? violation = null;
+        if (numbered[0] != 1)
+            violation = $"first heading is H{numbered[0]}, expected H1";
+        int prev = numbered[0];
+        for (int i = 1; i < numbered.Count && violation == null; i++)
+        {
+            if (numbered[i] > prev + 1)
+                violation = $"H{prev} → H{numbered[i]} skips level(s)";
+            prev = numbered[i];
+        }
+
+        results.Add(new ValidationResult(
+            "UA-Heading-Order",
+            "Numbered heading levels start at H1 and never skip a level.",
+            RuleSeverity.Error,
+            violation == null ? RuleStatus.Pass : RuleStatus.Fail,
+            location: violation ?? $"{numbered.Count} numbered heading(s)",
+            reference: "ISO 14289-1 §7.4.2; Matterhorn 14-002"));
+    }
+
+    // 7.5 — table structure: Table → (THead/TBody/TFoot →)? TR → TH|TD.
+    private static void CheckTables(StructTreeAnalysis tree, List<ValidationResult> results)
+    {
+        var tables = AllNodes(tree).Where(n => n.ResolvedType == "Table").ToList();
+        if (tables.Count == 0)
+        {
+            results.Add(NotApplicable("UA-Table-Structure",
+                "Tables use TR / TH / TD structure.",
+                "no /Table elements", "ISO 14289-1 §7.5; Matterhorn 15-003"));
+            return;
+        }
+
+        var problems = new List<string>();
+        foreach (var t in tables)
+        {
+            var rows = new List<StructNode>();
+            foreach (var c in t.Children)
+            {
+                if (c.ResolvedType == "TR") rows.Add(c);
+                else if (c.ResolvedType is "THead" or "TBody" or "TFoot")
+                    rows.AddRange(c.Children.Where(g => g.ResolvedType == "TR"));
+                else if (c.ResolvedType is not ("Caption"))
+                    problems.Add($"/Table has unexpected child /{c.ResolvedType}");
+            }
+            if (rows.Count == 0)
+            {
+                problems.Add("/Table has no /TR rows");
+                continue;
+            }
+            foreach (var tr in rows)
+            {
+                var badCells = tr.Children.Where(cell => cell.ResolvedType is not ("TH" or "TD")).ToList();
+                foreach (var bad in badCells)
+                    problems.Add($"/TR contains non-cell /{bad.ResolvedType}");
+            }
+        }
+
+        results.Add(new ValidationResult(
+            "UA-Table-Structure",
+            "Every /Table contains /TR rows whose children are /TH or /TD cells.",
+            RuleSeverity.Error,
+            problems.Count == 0 ? RuleStatus.Pass : RuleStatus.Fail,
+            location: problems.Count == 0
+                ? $"{tables.Count} table(s)"
+                : string.Join("; ", problems.Take(5)) + (problems.Count > 5 ? $"; +{problems.Count - 5} more" : ""),
+            reference: "ISO 14289-1 §7.5; Matterhorn 15-003/15-005"));
+    }
+
+    // 7.6 — list structure: L → LI → (Lbl?, LBody).
+    private static void CheckLists(StructTreeAnalysis tree, List<ValidationResult> results)
+    {
+        var lists = AllNodes(tree).Where(n => n.ResolvedType == "L").ToList();
+        var strayLi = AllNodes(tree).Where(n => n.ResolvedType == "LI").ToList()
+            .Where(li => !lists.Any(l => l.Children.Contains(li))).ToList();
+
+        if (lists.Count == 0 && strayLi.Count == 0)
+        {
+            results.Add(NotApplicable("UA-List-Structure",
+                "Lists use L / LI / Lbl / LBody structure.",
+                "no /L elements", "ISO 14289-1 §7.6; Matterhorn 16-001"));
+            return;
+        }
+
+        var problems = new List<string>();
+        foreach (var l in lists)
+        {
+            var items = l.Children.Where(c => c.ResolvedType == "LI").ToList();
+            var nonItems = l.Children.Where(c => c.ResolvedType is not ("LI" or "Caption")).ToList();
+            if (items.Count == 0) problems.Add("/L has no /LI items");
+            foreach (var bad in nonItems) problems.Add($"/L has non-item child /{bad.ResolvedType}");
+        }
+        foreach (var _ in strayLi) problems.Add("/LI is not a child of an /L");
+
+        results.Add(new ValidationResult(
+            "UA-List-Structure",
+            "Every /L contains /LI items, and every /LI is a child of an /L.",
+            RuleSeverity.Error,
+            problems.Count == 0 ? RuleStatus.Pass : RuleStatus.Fail,
+            location: problems.Count == 0 ? $"{lists.Count} list(s)" : string.Join("; ", problems.Take(5)),
+            reference: "ISO 14289-1 §7.6; Matterhorn 16-001/16-003"));
+
+        // Recommended (not strictly required): each LI has an LBody.
+        var allItems = lists.SelectMany(l => l.Children).Where(c => c.ResolvedType == "LI").ToList();
+        if (allItems.Count > 0)
+        {
+            var noBody = allItems.Where(li => !li.Children.Any(c => c.ResolvedType == "LBody")).ToList();
+            results.Add(new ValidationResult(
+                "UA-List-ItemBody",
+                "Each /LI contains an /LBody (recommended list-item structure).",
+                RuleSeverity.Warning,
+                noBody.Count == 0 ? RuleStatus.Pass : RuleStatus.Fail,
+                location: noBody.Count == 0 ? $"{allItems.Count} item(s)" : $"{noBody.Count} of {allItems.Count} /LI lack an /LBody",
+                reference: "ISO 14289-1 §7.6"));
+        }
+    }
+
+    // 7.1 — real (non-artifact) page content must be inside the structure tree.
+    private static void CheckContentTagged(PdfDocument doc, StructTreeAnalysis tree, List<ValidationResult> results)
+    {
+        if (tree.StructTreeRoot == null)
+        {
+            results.Add(NotChecked("UA-Content-Tagged",
+                "Real page content is tagged (inside the structure tree or marked /Artifact).",
+                "no structure tree", "ISO 14289-1 §7.1; Matterhorn 01-002"));
+            return;
+        }
+
+        var (qualified, agnostic) = tree.TaggedContent();
+        var untaggedPages = new List<string>();
+
+        for (int p = 1; p <= doc.PageCount; p++)
+        {
+            PdfPage page;
+            try { page = doc.GetPage(p); }
+            catch { continue; }
+
+            int untagged = ContentTaggingScanner.CountUntaggedTextRuns(page, p, qualified, agnostic);
+            if (untagged > 0)
+                untaggedPages.Add($"page {p}: {untagged} untagged text run(s)");
+        }
+
+        results.Add(new ValidationResult(
+            "UA-Content-Tagged",
+            "Page text is either inside the structure tree or marked as an /Artifact.",
+            RuleSeverity.Error,
+            untaggedPages.Count == 0 ? RuleStatus.Pass : RuleStatus.Fail,
+            location: untaggedPages.Count == 0 ? null : string.Join("; ", untaggedPages.Take(5)),
+            reference: "ISO 14289-1 §7.1; Matterhorn 01-002"));
+    }
+
+    private static IEnumerable<StructNode> AllNodes(StructTreeAnalysis tree) =>
+        tree.Roots.SelectMany(r => r.DescendantsAndSelf());
+
+    private static bool XmpHasDcTitle(PdfDocument doc)
+    {
+        if (doc.Resolve(doc.Catalog.GetOptional("Metadata") ?? PdfNull.Instance) is not PdfStream s)
+            return false;
+        try
+        {
+            var xmp = s.GetDecodedString(System.Text.Encoding.UTF8);
+            return xmp.Contains("dc:title", StringComparison.Ordinal);
+        }
+        catch { return false; }
+    }
+
+    private static ValidationResult NotApplicable(string id, string desc, string why, string reference) =>
+        new(id, desc, RuleSeverity.Error, RuleStatus.NotApplicable, why, reference);
+
+    private static ValidationResult NotChecked(string id, string desc, string why, string reference) =>
+        new(id, desc, RuleSeverity.Error, RuleStatus.NotChecked, why, reference);
+}

--- a/Excise.Core/Validation/StructTreeAnalysis.cs
+++ b/Excise.Core/Validation/StructTreeAnalysis.cs
@@ -1,0 +1,262 @@
+using System.Collections.Generic;
+using System.Linq;
+using Excise.Core.Document;
+using Excise.Core.Primitives;
+
+namespace Excise.Core.Validation;
+
+/// <summary>
+/// A single node in a structure tree, as seen by the validator: the raw <c>/S</c>
+/// type, the type after <c>/RoleMap</c> resolution, accessibility text, and the
+/// marked-content this element owns. Deliberately independent of
+/// <see cref="Document.PdfStructTreeParser"/> — that parser drops <c>/MCR</c>
+/// marked-content references and does not apply the role map, both of which the
+/// PDF/UA rules depend on.
+/// </summary>
+internal sealed class StructNode
+{
+    public string RawType = "";
+    public string ResolvedType = "";
+    public string? Alt;
+    public string? ActualText;
+    public string? Lang;
+    public readonly List<StructNode> Children = new();
+    /// <summary>(page number 1-based or -1 unknown, MCID) pairs this element owns.</summary>
+    public readonly List<(int Page, int Mcid)> Content = new();
+    public PdfDictionary Dict = new();
+
+    /// <summary>Depth-first enumeration of this node and all descendants.</summary>
+    public IEnumerable<StructNode> DescendantsAndSelf()
+    {
+        yield return this;
+        foreach (var c in Children)
+            foreach (var n in c.DescendantsAndSelf())
+                yield return n;
+    }
+}
+
+/// <summary>
+/// Parses a document's structure tree into <see cref="StructNode"/>s with role-map
+/// resolution and marked-content collection, and answers the questions the PDF/UA
+/// rules ask. Read-only over <see cref="PdfDocument"/>.
+/// </summary>
+internal sealed class StructTreeAnalysis
+{
+    private const int MaxDepth = 64;
+
+    private readonly PdfDocument _doc;
+    private readonly Dictionary<string, string> _roleMap = new();
+
+    /// <summary>The synthetic roots (top-level /K of the StructTreeRoot).</summary>
+    public IReadOnlyList<StructNode> Roots { get; }
+
+    /// <summary>The StructTreeRoot dictionary, or null when absent.</summary>
+    public PdfDictionary? StructTreeRoot { get; }
+
+    /// <summary>Distinct raw <c>/S</c> types that are neither standard nor in the role map.</summary>
+    public IReadOnlyCollection<string> UnmappedCustomTypes { get; }
+
+    private StructTreeAnalysis(
+        PdfDocument doc,
+        PdfDictionary? root,
+        IReadOnlyList<StructNode> roots,
+        IReadOnlyCollection<string> unmapped)
+    {
+        _doc = doc;
+        StructTreeRoot = root;
+        Roots = roots;
+        UnmappedCustomTypes = unmapped;
+    }
+
+    /// <summary>Parse the structure tree. <see cref="StructTreeRoot"/> is null if none.</summary>
+    public static StructTreeAnalysis Build(PdfDocument doc)
+    {
+        var rootDict = doc.Resolve(doc.Catalog.GetOptional("StructTreeRoot") ?? PdfNull.Instance) as PdfDictionary;
+        var analysis = new StructTreeAnalysis(doc, rootDict, System.Array.Empty<StructNode>(), System.Array.Empty<string>());
+        if (rootDict == null)
+            return analysis;
+
+        analysis.LoadRoleMap(rootDict);
+
+        var roots = new List<StructNode>();
+        var kObj = rootDict.GetOptional("K");
+        if (kObj != null)
+            analysis.AppendChildren(doc.Resolve(kObj), roots, depth: 0);
+
+        var unmapped = new HashSet<string>();
+        foreach (var node in roots.SelectMany(r => r.DescendantsAndSelf()))
+        {
+            if (!StandardStructureTypes.Contains(node.RawType) &&
+                !analysis._roleMap.ContainsKey(node.RawType))
+            {
+                unmapped.Add(node.RawType);
+            }
+        }
+
+        return new StructTreeAnalysis(doc, rootDict, roots, unmapped);
+    }
+
+    private void LoadRoleMap(PdfDictionary rootDict)
+    {
+        if (_doc.Resolve(rootDict.GetOptional("RoleMap") ?? PdfNull.Instance) is not PdfDictionary rm)
+            return;
+        foreach (var key in rm.Keys)
+        {
+            if (_doc.Resolve(rm.GetOptional(key.Value)!) is PdfName target)
+                _roleMap[key.Value] = target.Value;
+        }
+    }
+
+    /// <summary>Resolve a raw type through the role map to a standard type (transitively, cycle-guarded).</summary>
+    private string Resolve(string rawType)
+    {
+        var seen = new HashSet<string>();
+        var cur = rawType;
+        while (_roleMap.TryGetValue(cur, out var next) && seen.Add(cur))
+            cur = next;
+        return cur;
+    }
+
+    private void AppendChildren(PdfObject kResolved, List<StructNode> into, int depth)
+    {
+        if (depth > MaxDepth) return;
+        if (kResolved is PdfArray arr)
+        {
+            foreach (var item in arr)
+            {
+                var node = ParseElement(_doc.Resolve(item), depth);
+                if (node != null) into.Add(node);
+            }
+        }
+        else
+        {
+            var node = ParseElement(kResolved, depth);
+            if (node != null) into.Add(node);
+        }
+    }
+
+    /// <summary>
+    /// Parse a single object under a /K. Returns a node only for structure
+    /// element dictionaries (those with an /S). MCR / OBJR / bare-integer kids
+    /// are consumed by the parent (see <see cref="ParseKids"/>), not here.
+    /// </summary>
+    private StructNode? ParseElement(PdfObject obj, int depth)
+    {
+        if (obj is not PdfDictionary dict) return null;
+        if (_doc.Resolve(dict.GetOptional("S") ?? PdfNull.Instance) is not PdfName sName) return null;
+
+        var node = new StructNode
+        {
+            RawType = sName.Value,
+            ResolvedType = Resolve(sName.Value),
+            Alt = dict.GetStringOrNull("Alt"),
+            ActualText = dict.GetStringOrNull("ActualText"),
+            Lang = dict.GetStringOrNull("Lang"),
+            Dict = dict,
+        };
+
+        int elementPage = ResolvePageNumber(dict.GetOptional("Pg"));
+        ParseKids(dict.GetOptional("K"), node, elementPage, depth);
+        return node;
+    }
+
+    /// <summary>
+    /// Walk an element's /K: nested elements recurse; integers are MCIDs on the
+    /// element's page; /MCR dicts carry their own /MCID (+ optional /Pg); /OBJR
+    /// dicts reference annotations (ignored for these rules).
+    /// </summary>
+    private void ParseKids(PdfObject? kObj, StructNode node, int elementPage, int depth)
+    {
+        if (kObj == null) return;
+        var resolved = _doc.Resolve(kObj);
+        if (resolved is PdfArray arr)
+        {
+            foreach (var item in arr)
+                ParseKid(_doc.Resolve(item), node, elementPage, depth);
+        }
+        else
+        {
+            ParseKid(resolved, node, elementPage, depth);
+        }
+    }
+
+    private void ParseKid(PdfObject kid, StructNode node, int elementPage, int depth)
+    {
+        switch (kid)
+        {
+            case PdfInteger i:
+                node.Content.Add((elementPage, (int)i.Value));
+                break;
+            case PdfDictionary d when GetName(d, "Type") == "MCR":
+            {
+                int page = d.ContainsKey("Pg") ? ResolvePageNumber(d.GetOptional("Pg")) : elementPage;
+                if (_doc.Resolve(d.GetOptional("MCID") ?? PdfNull.Instance) is PdfInteger mcid)
+                    node.Content.Add((page, (int)mcid.Value));
+                break;
+            }
+            case PdfDictionary d when GetName(d, "Type") == "OBJR":
+                break; // annotation reference — outside the text-content rules
+            case PdfDictionary d when d.ContainsKey("S"):
+            {
+                var child = ParseElement(d, depth + 1);
+                if (child != null) node.Children.Add(child);
+                break;
+            }
+        }
+    }
+
+    private string? GetName(PdfDictionary d, string key) =>
+        _doc.Resolve(d.GetOptional(key) ?? PdfNull.Instance) is PdfName n ? n.Value : null;
+
+    /// <summary>Map a /Pg page reference to a 1-based page number, or -1 if unknown.</summary>
+    private int ResolvePageNumber(PdfObject? pgObj)
+    {
+        if (pgObj is not PdfReference pgRef) return -1;
+        for (int p = 1; p <= _doc.PageCount; p++)
+        {
+            if (_doc.GetPageReference(p) is { } r && r.Equals(pgRef))
+                return p;
+        }
+        return -1;
+    }
+
+    /// <summary>
+    /// The set of (page, MCID) pairs referenced anywhere in the structure tree —
+    /// i.e. content that IS tagged. A pair with page -1 (unknown page) is treated
+    /// as page-agnostic by <see cref="IsTagged"/> so single-page documents, where
+    /// page qualification is unambiguous, still match.
+    /// </summary>
+    public (HashSet<(int, int)> Qualified, HashSet<int> PageAgnostic) TaggedContent()
+    {
+        var qualified = new HashSet<(int, int)>();
+        var agnostic = new HashSet<int>();
+        foreach (var node in Roots.SelectMany(r => r.DescendantsAndSelf()))
+        {
+            foreach (var (page, mcid) in node.Content)
+            {
+                if (page < 0) agnostic.Add(mcid);
+                else qualified.Add((page, mcid));
+            }
+        }
+        return (qualified, agnostic);
+    }
+
+    /// <summary>The standard PDF structure types (ISO 32000-1 §14.8.4).</summary>
+    public static readonly HashSet<string> StandardStructureTypes = new()
+    {
+        // Grouping
+        "Document", "Part", "Art", "Sect", "Div", "BlockQuote", "Caption", "TOC",
+        "TOCI", "Index", "NonStruct", "Private",
+        // Paragraph-like / heading
+        "P", "H", "H1", "H2", "H3", "H4", "H5", "H6",
+        // List
+        "L", "LI", "Lbl", "LBody",
+        // Table
+        "Table", "TR", "TH", "TD", "THead", "TBody", "TFoot",
+        // Inline
+        "Span", "Quote", "Note", "Reference", "BibEntry", "Code", "Link", "Annot",
+        "Ruby", "RB", "RT", "RP", "Warichu", "WT", "WP",
+        // Illustration
+        "Figure", "Formula", "Form",
+    };
+}

--- a/Excise.Core/Validation/ValidationModel.cs
+++ b/Excise.Core/Validation/ValidationModel.cs
@@ -1,0 +1,171 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Excise.Core.Validation;
+
+/// <summary>
+/// The conformance standard a <see cref="ValidationReport"/> was produced for.
+/// </summary>
+public enum ConformanceStandard
+{
+    /// <summary>PDF/UA-1 (ISO 14289-1) accessibility.</summary>
+    PdfUA1,
+
+    /// <summary>PDF/A-1b (ISO 19005-1) archival, level B.</summary>
+    PdfA1B,
+
+    /// <summary>PDF/A-2b (ISO 19005-2) archival, level B.</summary>
+    PdfA2B,
+}
+
+/// <summary>The outcome of a single conformance rule.</summary>
+public enum RuleStatus
+{
+    /// <summary>The rule was evaluated and the document satisfies it.</summary>
+    Pass,
+
+    /// <summary>The rule was evaluated and the document violates it.</summary>
+    Fail,
+
+    /// <summary>The rule does not apply to this document (nothing to check).</summary>
+    NotApplicable,
+
+    /// <summary>
+    /// The rule is part of the standard but excise does not (yet) check it.
+    /// Present so a report never implies a checkpoint passed when it was never
+    /// looked at.
+    /// </summary>
+    NotChecked,
+}
+
+/// <summary>How much a <see cref="RuleStatus.Fail"/> matters.</summary>
+public enum RuleSeverity
+{
+    /// <summary>A hard conformance violation — blocks <see cref="ValidationReport.CheckedSubsetConformant"/>.</summary>
+    Error,
+
+    /// <summary>A likely problem or a recommended-not-required construct; does not block conformance.</summary>
+    Warning,
+
+    /// <summary>Informational only.</summary>
+    Info,
+}
+
+/// <summary>
+/// The result of evaluating one conformance rule against a document.
+/// </summary>
+public sealed class ValidationResult
+{
+    /// <summary>Stable, machine-readable rule id (e.g. <c>UA-Tagged</c>).</summary>
+    public string RuleId { get; }
+
+    /// <summary>Human-readable description of what the rule requires.</summary>
+    public string Description { get; }
+
+    /// <summary>How much a failure of this rule matters.</summary>
+    public RuleSeverity Severity { get; }
+
+    /// <summary>Whether the document passed, failed, or the rule was skipped.</summary>
+    public RuleStatus Status { get; }
+
+    /// <summary>
+    /// Where the problem is (page number, struct-element type, catalog key…),
+    /// or null when not applicable / the whole document.
+    /// </summary>
+    public string? Location { get; }
+
+    /// <summary>
+    /// A pointer into the source standard (an ISO clause or Matterhorn
+    /// checkpoint) for the reader who wants the authoritative text.
+    /// </summary>
+    public string? Reference { get; }
+
+    public ValidationResult(
+        string ruleId,
+        string description,
+        RuleSeverity severity,
+        RuleStatus status,
+        string? location = null,
+        string? reference = null)
+    {
+        RuleId = ruleId;
+        Description = description;
+        Severity = severity;
+        Status = status;
+        Location = location;
+        Reference = reference;
+    }
+
+    public override string ToString() =>
+        $"[{Status}] {RuleId} ({Severity}){(Location is null ? "" : $" @ {Location}")}: {Description}";
+}
+
+/// <summary>
+/// The outcome of running a conformance validator over a document: the per-rule
+/// results plus an explicit, honest statement of what was NOT checked.
+///
+/// <para><b>This is a bounded, structural subset checker, not a full ISO
+/// validator.</b> <see cref="CheckedSubsetConformant"/> means only that no
+/// <see cref="RuleSeverity.Error"/> rule that excise actually evaluated failed —
+/// it is NOT a claim of full PDF/UA or PDF/A conformance. Read
+/// <see cref="UncoveredCheckpoints"/> for the checkpoints outside excise's
+/// scope; for an authoritative verdict use a reference validator such as
+/// veraPDF.</para>
+/// </summary>
+public sealed class ValidationReport
+{
+    /// <summary>The standard this report was produced for.</summary>
+    public ConformanceStandard Standard { get; }
+
+    /// <summary>Every rule excise evaluated, in evaluation order.</summary>
+    public IReadOnlyList<ValidationResult> Results { get; }
+
+    /// <summary>
+    /// The categories of ISO / Matterhorn checkpoints this validator does NOT
+    /// cover. Present so a caller can never mistake a green report for full
+    /// conformance.
+    /// </summary>
+    public IReadOnlyList<string> UncoveredCheckpoints { get; }
+
+    public ValidationReport(
+        ConformanceStandard standard,
+        IReadOnlyList<ValidationResult> results,
+        IReadOnlyList<string> uncoveredCheckpoints)
+    {
+        Standard = standard;
+        Results = results;
+        UncoveredCheckpoints = uncoveredCheckpoints;
+    }
+
+    /// <summary>All rules that failed (any severity).</summary>
+    public IEnumerable<ValidationResult> Failures =>
+        Results.Where(r => r.Status == RuleStatus.Fail);
+
+    /// <summary>Failed rules with <see cref="RuleSeverity.Error"/> severity.</summary>
+    public IEnumerable<ValidationResult> Errors =>
+        Results.Where(r => r.Status == RuleStatus.Fail && r.Severity == RuleSeverity.Error);
+
+    /// <summary>Failed rules with <see cref="RuleSeverity.Warning"/> severity.</summary>
+    public IEnumerable<ValidationResult> Warnings =>
+        Results.Where(r => r.Status == RuleStatus.Fail && r.Severity == RuleSeverity.Warning);
+
+    /// <summary>
+    /// True when no <see cref="RuleSeverity.Error"/> rule that was actually
+    /// evaluated failed. <b>Bounded meaning:</b> conformant with respect to the
+    /// checked subset only — see <see cref="UncoveredCheckpoints"/>. Never treat
+    /// this as a full-conformance guarantee.
+    /// </summary>
+    public bool CheckedSubsetConformant => !Errors.Any();
+
+    public override string ToString()
+    {
+        var lines = new List<string>
+        {
+            $"{Standard} structural check — CheckedSubsetConformant={CheckedSubsetConformant} " +
+            $"(bounded subset; not a full ISO verdict)",
+        };
+        lines.AddRange(Results.Select(r => "  " + r));
+        lines.Add($"  NOT checked: {string.Join("; ", UncoveredCheckpoints)}");
+        return string.Join("\n", lines);
+    }
+}


### PR DESCRIPTION
Implements #772: a **conformance checker** (not an emitter) for a bounded, honestly-scoped subset of PDF/UA-1 (ISO 14289-1), plus a light structural check for the PDF/A markers excise itself emits.

## What's added
New `Excise.Core.Validation` namespace:
- `PdfUaValidator.Validate(document) -> ValidationReport`
- `PdfAStructuralValidator.Validate(document, conformance) -> ValidationReport`
- `ValidationReport` / `ValidationResult` model with per-rule status (pass / fail / not-applicable / not-checked), severity, location, and an explicit `UncoveredCheckpoints` list. Conformance is exposed as `CheckedSubsetConformant` (deliberately **not** `IsConformant`) so a green report can never be read as full ISO conformance.

Also: a small optional `excise validate <file> [--pdfa 1b|2b] [--json]` CLI command.

## PDF/UA rules implemented
Tagged (`/MarkInfo /Marked`), `/StructTreeRoot` present, `/Lang`, title (`/Title` or XMP `dc:title`) + `/ViewerPreferences /DisplayDocTitle`, `/RoleMap` sanity (custom types resolve to standard), figure `/Alt`/`/ActualText`, heading-level skips, table `TR`/`TH`/`TD` nesting, list `L`/`LI`/`LBody`, and untagged real page content (a self-contained content-stream walk honoring `/Artifact` and `/MCID` — it never touches the text extractor, so the extraction path and its parity gate are untouched).

Structural rules resolve types through `/RoleMap` before evaluating, and collect marked-content from `/MCR` refs directly (the existing struct-tree parser drops both).

## Honest coverage — what is NOT covered
Reading-order correctness, tag semantics, colour contrast, per-glyph ToUnicode, annotation/link/form accessibility, table header *associations* (Scope/Headers — only nesting is checked), full XMP schema, multi-page MCID-to-page qualification without `/Pg`, and ~120 further Matterhorn checkpoints. All surfaced in `UncoveredCheckpoints`.

## Verification
- Per-rule pass/fail fixtures whose verdict is **known by construction** (well-tagged builder doc for PASS; minimal single-rule-broken docs for FAIL). 22 fixtures pass.
- excise's own emitted PDF/A-1b/2b round-trips (save → reparse) as structurally conformant; a stripped OutputIntent is flagged.
- veraPDF cross-check (positive: conformant builder doc; negative: `/StructTreeRoot` removed) asserts excise and veraPDF **agree** — skips locally (veraPDF not installed here), runs on CI.
- `scripts/test-tier.sh t0` green; build 0 warnings; `Excise.Core.approved.txt` regenerated for the new public API.
- Extraction-parity not run: no extraction code was touched (structure analysis only).

STOP point: not merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)