### PR TITLE
Text selection in the continuous view + GUI highlight tests (#815)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ semantic versioning.
 
 ## [Unreleased]
 
+### Added
+- **Text selection works in the continuous reading view** (#815) — text
+  selection used to be a mode toggle that forced single-page layout, so the
+  default continuous reading view had no way to drag-to-select and showed no
+  highlight. Selecting text is now treated as a read affordance (like clicking a
+  link), not a draw/edit mode: entering it keeps the continuous view, and a drag
+  paints a per-page semi-transparent highlight over the selected glyphs on that
+  page's overlay. Each `PdfPageSlot` carries the highlight rectangles bound to a
+  Canvas overlay in the reading-view page template; the gesture reuses the exact
+  single-page selection engine and the continuous pointer→page mapping the link
+  hit-test already uses. Bounded first version: a selection lives on the single
+  page the press landed on — a drag onto another page is clamped rather than
+  drawing a cross-page range (cross-page selection deferred).
+
+### Fixed
+- **Text-selection highlight now has automated GUI coverage** (#815) — the
+  single-page "selection box" drawing was untested at the GUI level, so any
+  coordinate/z-order regression (e.g. the historic "highlight far to the left"
+  origin offset) could ship silently. New headless-Avalonia tests drive a real
+  pointer press→drag and assert the highlight rectangles land on the selected
+  glyphs, verified against an independent layout-geometry oracle (overlay/page
+  image share an origin; each rect sits at its glyph's MediaBox fraction) rather
+  than the coordinate mapper vouching for itself. Single-page rendering was
+  found already correct; the tests lock it in and cover the new continuous view.
+
 ## [3.4.0] - 2026-07-27
 
 ### Added

--- a/Excise.App.Tests/Controls/PdfViewerControlTests.cs
+++ b/Excise.App.Tests/Controls/PdfViewerControlTests.cs
@@ -645,7 +645,9 @@ public class PdfViewerControlTests
     [FixedAvaloniaFact]
     public void EnteringEditingMode_InContinuous_AutoSwitchesToSinglePage()
     {
-        foreach (var editing in new[] { InteractionMode.Redaction, InteractionMode.TextSelection, InteractionMode.FormAuthoring })
+        // Text selection is deliberately excluded (#815): it is a read affordance
+        // that now works in the continuous view, so it must NOT force single-page.
+        foreach (var editing in new[] { InteractionMode.Redaction, InteractionMode.FormAuthoring, InteractionMode.Typewriter })
         {
             var control = new PdfViewerControl { ViewMode = PdfViewMode.Continuous };
             control.ViewMode.Should().Be(PdfViewMode.Continuous);
@@ -655,6 +657,20 @@ public class PdfViewerControlTests
             control.ViewMode.Should().Be(PdfViewMode.SinglePage,
                 $"{editing} is an editing interaction and must force single-page");
         }
+    }
+
+    [FixedAvaloniaFact]
+    public void EnteringTextSelection_InContinuous_StaysInContinuous()
+    {
+        // #815: selecting text is a reading-view affordance, not an edit. Entering
+        // it must keep the continuous reading view rather than snapping to
+        // single-page (which is what made it undiscoverable).
+        var control = new PdfViewerControl { ViewMode = PdfViewMode.Continuous };
+
+        control.InteractionMode = InteractionMode.TextSelection;
+
+        control.ViewMode.Should().Be(PdfViewMode.Continuous,
+            "text selection works in the continuous view and must not force single-page");
     }
 
     [FixedAvaloniaFact]

--- a/Excise.App.Tests/Controls/PdfViewerSelectionTests.cs
+++ b/Excise.App.Tests/Controls/PdfViewerSelectionTests.cs
@@ -1,0 +1,497 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Shapes;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using AwesomeAssertions;
+using Excise.Avalonia.Controls;
+using Excise.App.Tests.Utilities;
+using Xunit;
+using PdfCoreDocument = Excise.Core.Document.PdfDocument;
+
+namespace Excise.App.Tests.Controls;
+
+/// <summary>
+/// GUI coverage for the text-selection highlight ("selection box"), #815.
+///
+/// These drive a REAL routed pointer gesture (press at a known glyph → drag to
+/// another glyph) through the control's interaction pipeline and assert that the
+/// TextSelectionLayer acquires highlight rectangles at the correct ON-SCREEN
+/// position.
+///
+/// The position oracle is deliberately NOT <c>PdfRectangleToDips</c> compared to
+/// itself (that is tautological and blind to the exact "highlight far to the
+/// left" layout regression the axaml <c>ZoomHost</c> centering fixes). Instead we
+/// verify the drawn rectangles' real layout geometry: (1) the highlight canvas
+/// and the page image share an origin, and (2) each drawn rect lands at the
+/// glyph's MediaBox fraction inside the page image's bounds — computed
+/// independently from PDF content coordinates. An origin/centering offset trips
+/// both.
+/// </summary>
+[Collection("AvaloniaTests")]
+public class PdfViewerSelectionTests
+{
+    [FixedAvaloniaFact]
+    public async Task SinglePageDrag_DrawsHighlightOverSelectedGlyphs_AtCorrectOnPagePositions()
+    {
+        // Text placed well away from the left/top edges so an origin/centering
+        // offset in the overlay would push the highlight off the glyphs.
+        var bytes = TestPdfGenerator.CreatePdfWithTextAtPosition("SELECTME", x: 220, y: 500, fontSize: 24);
+
+        PdfCoreDocument doc = null!;
+        PdfViewerControl control = null!;
+        Window window = null!;
+
+        await Dispatcher.UIThread.InvokeAsync(() =>
+        {
+            doc = PdfCoreDocument.Open(bytes);
+            control = new PdfViewerControl { Document = doc, CurrentPage = 1 };
+            window = new Window { Content = control, Width = 900, Height = 1000 };
+            window.Show();
+        });
+
+        // Wait until the page image has rendered (real Bounds) and the page's
+        // letters are available.
+        Image? pdfImage = null;
+        var deadline = DateTime.UtcNow.AddSeconds(15);
+        while (DateTime.UtcNow < deadline)
+        {
+            bool ready = false;
+            await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                window.UpdateLayout();
+                pdfImage = control.FindControl<Image>("PdfImage");
+                ready = pdfImage is { } img
+                        && img.IsAttachedToVisualTree()
+                        && img.Bounds.Width > 1
+                        && doc.GetPage(1).Letters.Count > 0;
+            });
+            if (ready) break;
+            await Task.Delay(100);
+        }
+
+        var letters = doc.GetPage(1).Letters;
+        letters.Should().NotBeEmpty("the test PDF has extractable glyphs to select");
+
+        await Dispatcher.UIThread.InvokeAsync(() =>
+        {
+            window.UpdateLayout();
+            control.InteractionMode = InteractionMode.TextSelection;
+
+            var overlay = control.FindControl<Canvas>("OverlayCanvas")!;
+            overlay.IsAttachedToVisualTree().Should().BeTrue();
+
+            // Press at the visually leftmost glyph, drag to the rightmost. Pointer
+            // positions are reported relative to the OverlayCanvas (the control
+            // reads the press point off it), so rootVisual == overlay makes
+            // GetPosition an identity and the injected DIP point is what the
+            // hit-test sees.
+            var leftmost = letters.OrderBy(l => l.GlyphRectangle.Left).First();
+            var rightmost = letters.OrderByDescending(l => l.GlyphRectangle.Right).First();
+            var anchorDip = control.GlyphRectToViewerDipsForTest(leftmost.GlyphRectangle);
+            var focusDip = control.GlyphRectToViewerDipsForTest(rightmost.GlyphRectangle);
+            RaiseSelectionDrag(overlay, anchorDip.Center, focusDip.Center);
+        });
+
+        await Dispatcher.UIThread.InvokeAsync(() =>
+        {
+            var layer = control.FindControl<Canvas>("TextSelectionLayer")!;
+            var overlay = control.FindControl<Canvas>("OverlayCanvas")!;
+            var img = control.FindControl<Image>("PdfImage")!;
+
+            var rects = layer.Children.OfType<Rectangle>().ToList();
+
+            // 1) A real, multi-glyph selection was drawn.
+            rects.Should().NotBeEmpty("dragging across the line must draw a highlight");
+            rects.Count.Should().BeGreaterThanOrEqualTo(2,
+                "dragging from the leftmost to the rightmost glyph highlights several glyphs");
+
+            // 2) Layout oracle A — the highlight layer and the page image share an
+            //    origin. The "highlight far to the left" regression breaks exactly
+            //    this (overlay anchored at the widened grid's left edge while the
+            //    image centers), and PdfRectangleToDips cannot see it.
+            var sharedOrigin = overlay.TranslatePoint(new Point(0, 0), img);
+            sharedOrigin.Should().NotBeNull();
+            sharedOrigin!.Value.X.Should().BeApproximately(0, 1.5,
+                "the selection overlay and the page image must share a horizontal origin");
+            sharedOrigin.Value.Y.Should().BeApproximately(0, 1.5,
+                "the selection overlay and the page image must share a vertical origin");
+
+            // 3) Layout oracle B — EVERY drawn highlight lands on a real glyph.
+            //    Each letter's expected on-screen rect is computed independently
+            //    from PDF content coordinates (visual = content shifted to the
+            //    MediaBox origin, Y flipped; rotation-0 page) as a fraction of the
+            //    page image bounds. A drawn rect, translated into the page image's
+            //    own coordinate space, must have its center inside one of those
+            //    expected glyph rects. An origin/centering offset moves the drawn
+            //    rects off every glyph and trips this — PdfRectangleToDips cannot.
+            var page = doc.GetPage(1);
+            var mb = page.MediaBox.Normalize();
+            double imgW = img.Bounds.Width, imgH = img.Bounds.Height;
+            imgW.Should().BeGreaterThan(0);
+
+            Rect ExpectedGlyphImageRect(Excise.Core.Text.Letter l)
+            {
+                var g = l.GlyphRectangle;
+                double x0 = (g.Left - mb.Left) / mb.Width * imgW;
+                double y0 = (mb.Top - g.Top) / mb.Height * imgH;
+                double x1 = (g.Right - mb.Left) / mb.Width * imgW;
+                double y1 = (mb.Top - g.Bottom) / mb.Height * imgH;
+                return new Rect(x0, y0, x1 - x0, y1 - y0);
+            }
+            var expectedGlyphRects = letters.Select(ExpectedGlyphImageRect).ToList();
+            double pad = Math.Max(4.0, imgW * 0.02); // glyph-metric slack
+
+            foreach (var r in rects)
+            {
+                var tl = r.TranslatePoint(new Point(0, 0), img);
+                tl.Should().NotBeNull("each highlight rect must be resolvable into page-image space");
+                var drawn = new Rect(tl!.Value.X, tl.Value.Y, r.Bounds.Width, r.Bounds.Height);
+
+                // On-page.
+                drawn.X.Should().BeGreaterThanOrEqualTo(-pad, "highlight must not spill off the left of the page");
+                drawn.Y.Should().BeGreaterThanOrEqualTo(-pad, "highlight must not spill off the top of the page");
+                drawn.Right.Should().BeLessThanOrEqualTo(imgW + pad, "highlight must not spill off the right of the page");
+                drawn.Bottom.Should().BeLessThanOrEqualTo(imgH + pad, "highlight must not spill off the bottom of the page");
+
+                // Sits on a real glyph.
+                var c = drawn.Center;
+                expectedGlyphRects.Should().Contain(
+                    e => c.X >= e.X - pad && c.X <= e.Right + pad && c.Y >= e.Y - pad && c.Y <= e.Bottom + pad,
+                    "every drawn highlight rect must sit over one of the page's glyphs, not off to the side");
+            }
+
+            // The highlight as a whole spans a meaningful width of the line (a
+            // left-to-right drag, not a single-glyph blip).
+            var drawnBBoxLeft = rects.Min(r => r.TranslatePoint(new Point(0, 0), img)!.Value.X);
+            var drawnBBoxRight = rects.Max(r => r.TranslatePoint(new Point(0, 0), img)!.Value.X + r.Bounds.Width);
+            (drawnBBoxRight - drawnBBoxLeft).Should().BeGreaterThan(imgW * 0.05,
+                "a left-to-right drag across the line produces a wide highlight");
+        });
+
+        await Dispatcher.UIThread.InvokeAsync(() =>
+        {
+            window.Close();
+            doc.Dispose();
+        });
+    }
+
+    [FixedAvaloniaFact]
+    public async Task ClearSelectionHighlight_EmptiesTheLayer()
+    {
+        var bytes = TestPdfGenerator.CreatePdfWithTextAtPosition("CLEARME", x: 200, y: 480, fontSize: 24);
+
+        PdfCoreDocument doc = null!;
+        PdfViewerControl control = null!;
+        Window window = null!;
+
+        await Dispatcher.UIThread.InvokeAsync(() =>
+        {
+            doc = PdfCoreDocument.Open(bytes);
+            control = new PdfViewerControl { Document = doc, CurrentPage = 1 };
+            window = new Window { Content = control, Width = 900, Height = 1000 };
+            window.Show();
+        });
+
+        var deadline = DateTime.UtcNow.AddSeconds(15);
+        while (DateTime.UtcNow < deadline)
+        {
+            bool ready = false;
+            await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                window.UpdateLayout();
+                var img = control.FindControl<Image>("PdfImage");
+                ready = img is { } i && i.Bounds.Width > 1 && doc.GetPage(1).Letters.Count > 0;
+            });
+            if (ready) break;
+            await Task.Delay(100);
+        }
+
+        await Dispatcher.UIThread.InvokeAsync(() =>
+        {
+            window.UpdateLayout();
+            control.InteractionMode = InteractionMode.TextSelection;
+            var overlay = control.FindControl<Canvas>("OverlayCanvas")!;
+            var letters = doc.GetPage(1).Letters;
+            var a = control.GlyphRectToViewerDipsForTest(letters[0].GlyphRectangle);
+            var f = control.GlyphRectToViewerDipsForTest(letters[^1].GlyphRectangle);
+            RaiseSelectionDrag(overlay, a.Center, f.Center);
+
+            control.FindControl<Canvas>("TextSelectionLayer")!.Children.OfType<Rectangle>()
+                .Should().NotBeEmpty("a drag drew a highlight");
+
+            control.ClearSelectionHighlight();
+
+            control.FindControl<Canvas>("TextSelectionLayer")!.Children
+                .Should().BeEmpty("ClearSelectionHighlight removes every highlight rect");
+        });
+
+        await Dispatcher.UIThread.InvokeAsync(() =>
+        {
+            window.Close();
+            doc.Dispose();
+        });
+    }
+
+    // ── Continuous (reading) view selection (#815) ──────────────────────────
+
+    [FixedAvaloniaFact]
+    public async Task ContinuousViewDrag_DrawsPerPageHighlight_OverSelectedGlyphs()
+    {
+        var bytes = TestPdfGenerator.CreatePdfWithTextAtPosition("READINGVIEW", x: 180, y: 520, fontSize: 26);
+
+        PdfCoreDocument doc = null!;
+        PdfViewerControl control = null!;
+        Window window = null!;
+
+        await Dispatcher.UIThread.InvokeAsync(() =>
+        {
+            doc = PdfCoreDocument.Open(bytes);
+            control = new PdfViewerControl { Document = doc, CurrentPage = 1 };
+            control.ViewMode = PdfViewMode.Continuous;
+            window = new Window { Content = control, Width = 900, Height = 1100 };
+            window.Show();
+        });
+
+        // Wait for continuous slots to exist and the items panel to lay out.
+        ItemsControl items = null!;
+        PdfPageSlot slot = null!;
+        var deadline = DateTime.UtcNow.AddSeconds(15);
+        while (DateTime.UtcNow < deadline)
+        {
+            bool ready = false;
+            await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                window.UpdateLayout();
+                items = control.FindControl<ItemsControl>("ContinuousItems")!;
+                slot = items.ItemsSource?.Cast<PdfPageSlot>().FirstOrDefault()!;
+                ready = slot != null && items.Bounds.Width > 1 && slot.DisplayWidth > 1
+                        && doc.GetPage(1).Letters.Count > 0;
+            });
+            if (ready) break;
+            await Task.Delay(100);
+        }
+
+        slot.Should().NotBeNull("continuous view builds one slot for the single page");
+        var letters = doc.GetPage(1).Letters;
+        letters.Should().NotBeEmpty();
+
+        double zoom = 0, itemsWidth = 0, topDip = 0, dispW = 0;
+        await Dispatcher.UIThread.InvokeAsync(() =>
+        {
+            zoom = control.ZoomLevel;
+            itemsWidth = items.Bounds.Width;
+            topDip = slot.TopDip;
+            dispW = slot.DisplayWidth;
+        });
+
+        var page = doc.GetPage(1);
+        var mb = page.MediaBox.Normalize();
+        double upp = PdfViewerControl.PointsToDip * zoom;   // page-local DIP per PDF point
+        double xOffset = Math.Max(0, (itemsWidth - dispW) / 2);
+
+        // Rotation-0 page: page-local DIP of a content point. Items-coordinate =
+        // page-local + centering x-offset + slot top.
+        Point ItemsCenter(Excise.Core.Text.Letter l)
+        {
+            var g = l.GlyphRectangle;
+            double localX = ((g.Left + g.Right) / 2 - mb.Left) * upp;
+            double localY = (mb.Top - (g.Top + g.Bottom) / 2) * upp;
+            return new Point(xOffset + localX, topDip + localY);
+        }
+
+        var leftmost = letters.OrderBy(l => l.GlyphRectangle.Left).First();
+        var rightmost = letters.OrderByDescending(l => l.GlyphRectangle.Right).First();
+
+        await Dispatcher.UIThread.InvokeAsync(() =>
+        {
+            control.InteractionMode = InteractionMode.TextSelection;
+            // Text selection must NOT force single-page anymore (#815).
+            control.ViewMode.Should().Be(PdfViewMode.Continuous,
+                "text selection is a read affordance and stays in the continuous reading view");
+
+            RaiseSelectionDrag(items, ItemsCenter(leftmost), ItemsCenter(rightmost));
+        });
+
+        await Dispatcher.UIThread.InvokeAsync(() =>
+        {
+            // The page's slot got highlight rects; no other slot did.
+            var slots = items.ItemsSource!.Cast<PdfPageSlot>().ToList();
+            var target = slots.Single(s => s.PageNumber == 1);
+            target.SelectionRects.Count.Should().BeGreaterThanOrEqualTo(2,
+                "dragging across the line highlights several glyphs on that page");
+            slots.Where(s => s.PageNumber != 1).Should().OnlyContain(s => s.SelectionRects.Count == 0,
+                "only the page under the drag is highlighted");
+
+            // Each highlight rect sits over a real glyph, at its independently
+            // computed page-local position (visual = content shifted to MediaBox
+            // origin, Y flipped; rotation-0 page). This is not ToContinuousDips
+            // compared to itself — the expected geometry is derived by hand.
+            Rect ExpectedLocal(Excise.Core.Text.Letter l)
+            {
+                var g = l.GlyphRectangle;
+                double x = (g.Left - mb.Left) * upp;
+                double y = (mb.Top - g.Top) * upp;
+                return new Rect(x, y, g.Width * upp, g.Height * upp);
+            }
+            var expected = letters.Select(ExpectedLocal).ToList();
+            double pad = Math.Max(4.0, dispW * 0.02);
+
+            foreach (var hl in target.SelectionRects)
+            {
+                // On-page.
+                hl.X.Should().BeGreaterThanOrEqualTo(-pad);
+                hl.Y.Should().BeGreaterThanOrEqualTo(-pad);
+                (hl.X + hl.Width).Should().BeLessThanOrEqualTo(slot.DisplayWidth + pad);
+                (hl.Y + hl.Height).Should().BeLessThanOrEqualTo(slot.DisplayHeight + pad);
+
+                // Centered on a real glyph.
+                double cx = hl.X + hl.Width / 2, cy = hl.Y + hl.Height / 2;
+                expected.Should().Contain(
+                    e => cx >= e.X - pad && cx <= e.Right + pad && cy >= e.Y - pad && cy <= e.Bottom + pad,
+                    "every continuous-view highlight rect must sit over one of the page's glyphs");
+            }
+        });
+
+        // The bound data renders as real, POSITIONED Rectangles — this catches a
+        // silent ReflectionBinding failure that would collapse every highlight to
+        // (0,0) while the SelectionRects data still looked correct.
+        await Dispatcher.UIThread.InvokeAsync(() => window.UpdateLayout());
+        await Dispatcher.UIThread.InvokeAsync(() =>
+        {
+            var target = items.ItemsSource!.Cast<PdfPageSlot>().Single(s => s.PageNumber == 1);
+            var container = items.GetRealizedContainers()
+                .FirstOrDefault(c => (c.DataContext as PdfPageSlot)?.PageNumber == 1);
+            container.Should().NotBeNull("page 1 is at the top of the reading view and must be realized");
+
+            var drawn = container!.GetVisualDescendants().OfType<Rectangle>().ToList();
+            drawn.Count.Should().Be(target.SelectionRects.Count,
+                "every bound highlight becomes a rendered Rectangle");
+
+            // Each rendered highlight is actually POSITIONED (the ReflectionBinding
+            // Canvas.Left/Top ran) at its bound page-local X — translating the
+            // Rectangle into the page Border (page-local space) lands near a bound
+            // X, not collapsed to 0. (~2px slack for the Border thickness.)
+            var pageBorder = container!.GetVisualDescendants().OfType<Border>().First();
+            var xs = drawn
+                .Select(r => r.TranslatePoint(new Point(0, 0), pageBorder))
+                .Where(p => p.HasValue).Select(p => p!.Value.X).ToList();
+            xs.Should().HaveCount(drawn.Count, "every highlight resolves into the page border");
+            xs.Should().Contain(v => v > 1,
+                "highlight Rectangles are offset horizontally, not collapsed to x=0");
+            xs.Should().OnlyContain(
+                v => target.SelectionRects.Any(r => Math.Abs(r.X - v) < 2.5),
+                "each rendered highlight's position matches a bound highlight X");
+        });
+
+        await Dispatcher.UIThread.InvokeAsync(() =>
+        {
+            control.ClearContinuousSelectionHighlight();
+            items.ItemsSource!.Cast<PdfPageSlot>()
+                .Should().OnlyContain(s => s.SelectionRects.Count == 0,
+                    "ClearContinuousSelectionHighlight empties every page's highlight");
+
+            window.Close();
+            doc.Dispose();
+        });
+    }
+
+    [FixedAvaloniaFact]
+    public async Task ContinuousViewSelection_DoesNotForceSinglePage_AndStaysOnAnchorPageAcrossPages()
+    {
+        // A two-page doc; dragging from page 1 into page 2 must not throw and the
+        // bounded first version keeps the selection on the anchor (press) page.
+        var path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"excise_sel_{Guid.NewGuid():N}.pdf");
+        TestPdfGenerator.CreateMultiPagePdf(path, pageCount: 2);
+        var bytes = System.IO.File.ReadAllBytes(path);
+        System.IO.File.Delete(path);
+
+        PdfCoreDocument doc = null!;
+        PdfViewerControl control = null!;
+        Window window = null!;
+
+        await Dispatcher.UIThread.InvokeAsync(() =>
+        {
+            doc = PdfCoreDocument.Open(bytes);
+            control = new PdfViewerControl { Document = doc };
+            control.ViewMode = PdfViewMode.Continuous;
+            window = new Window { Content = control, Width = 900, Height = 1100 };
+            window.Show();
+        });
+
+        ItemsControl items = null!;
+        var deadline = DateTime.UtcNow.AddSeconds(15);
+        while (DateTime.UtcNow < deadline)
+        {
+            bool ready = false;
+            await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                window.UpdateLayout();
+                items = control.FindControl<ItemsControl>("ContinuousItems")!;
+                ready = items.ItemsSource?.Cast<PdfPageSlot>().Count() == 2 && items.Bounds.Width > 1;
+            });
+            if (ready) break;
+            await Task.Delay(100);
+        }
+
+        await Dispatcher.UIThread.InvokeAsync(() =>
+        {
+            control.InteractionMode = InteractionMode.TextSelection;
+            control.ViewMode.Should().Be(PdfViewMode.Continuous,
+                "entering text selection must NOT force single-page in the reading view (#815)");
+
+            var slots = items.ItemsSource!.Cast<PdfPageSlot>().ToList();
+            var p1 = slots[0];
+            var p2 = slots[1];
+            double margin1 = Math.Max(0, (items.Bounds.Width - p1.DisplayWidth) / 2);
+
+            // Press near the top of page 1, drag down into page 2's area. Should
+            // not throw; the selection stays bounded to page 1 (or is empty), and
+            // page 2 is never highlighted.
+            var start = new Point(margin1 + p1.DisplayWidth / 2, p1.TopDip + 20);
+            var end = new Point(margin1 + p2.DisplayWidth / 2, p2.TopDip + p2.DisplayHeight / 2);
+
+            System.Action drag = () => RaiseSelectionDrag(items, start, end);
+            drag.Should().NotThrow("a cross-page drag must not crash the reading view");
+
+            p2.SelectionRects.Count.Should().Be(0,
+                "the bounded first version keeps a selection on its anchor page; page 2 is never highlighted");
+        });
+
+        await Dispatcher.UIThread.InvokeAsync(() =>
+        {
+            window.Close();
+            doc.Dispose();
+        });
+    }
+
+    /// <summary>
+    /// Press → move → release reported relative to <paramref name="rootVisual"/>,
+    /// so GetPosition(rootVisual) is an identity and the injected DIP points are
+    /// exactly what the selection hit-test observes.
+    /// </summary>
+    private static void RaiseSelectionDrag(Control rootVisual, Point start, Point end)
+    {
+        var pointer = new Pointer(Pointer.GetNextFreeId(), PointerType.Mouse, isPrimary: true);
+
+        rootVisual.RaiseEvent(new PointerPressedEventArgs(
+            rootVisual, pointer, rootVisual, start, 0,
+            new PointerPointProperties(RawInputModifiers.LeftMouseButton, PointerUpdateKind.LeftButtonPressed),
+            KeyModifiers.None));
+
+        rootVisual.RaiseEvent(new PointerEventArgs(
+            InputElement.PointerMovedEvent, rootVisual, pointer, rootVisual, end, 0,
+            new PointerPointProperties(RawInputModifiers.LeftMouseButton, PointerUpdateKind.Other),
+            KeyModifiers.None));
+
+        rootVisual.RaiseEvent(new PointerReleasedEventArgs(
+            rootVisual, pointer, rootVisual, end, 0,
+            new PointerPointProperties(RawInputModifiers.None, PointerUpdateKind.LeftButtonReleased),
+            KeyModifiers.None, MouseButton.Left));
+    }
+}

--- a/Excise.App.Tests/UI/ModeSwitchDisplayTests.cs
+++ b/Excise.App.Tests/UI/ModeSwitchDisplayTests.cs
@@ -15,10 +15,12 @@ namespace Excise.App.Tests.UI;
 
 /// <summary>
 /// Display-state invariants for the interaction-mode toolbar buttons
-/// (Redact / Select Text / Typewriter / Form Authoring). Prompted by a live
-/// report of "something weird happens to the display" when clicking these.
+/// (Redact / Typewriter / Form Authoring). Prompted by a live report of
+/// "something weird happens to the display" when clicking these. (Select Text is
+/// excluded since #815: it is a read affordance that works in the continuous
+/// reading view and no longer forces single-page — see PdfViewerSelectionTests.)
 ///
-/// Every editing mode forces the viewer from the default Continuous view into
+/// Every draw/edit mode forces the viewer from the default Continuous view into
 /// SinglePage — which is exactly the render path reworked for device-resolution
 /// output (#682/#683/#685/#686). Those changes are a functional no-op at
 /// devicePixelRatio 1 (all the headless test host reports), so this battery
@@ -40,7 +42,11 @@ public class ModeSwitchDisplayTests
     public static TheoryData<string, double> ModeByDpr()
     {
         var data = new TheoryData<string, double>();
-        foreach (var mode in new[] { "redact", "select-text", "typewriter", "form-authoring" })
+        // select-text is intentionally absent (#815): text selection is a read
+        // affordance that now works in the continuous reading view and no longer
+        // forces single-page, so it does not belong in this single-page battery.
+        // Its continuous behavior is covered in PdfViewerSelectionTests.
+        foreach (var mode in new[] { "redact", "typewriter", "form-authoring" })
         foreach (var dpr in new[] { 1.0, 2.0 })
             data.Add(mode, dpr);
         return data;
@@ -140,7 +146,8 @@ public class ModeSwitchDisplayTests
             var widthInRedact = SinglePageImage(viewer)!.Width;
 
             // Hop directly between editing modes — no bounce through continuous.
-            foreach (var next in new[] { "select-text", "typewriter", "form-authoring", "redact" })
+            // (select-text excluded — it is no longer single-page, #815.)
+            foreach (var next in new[] { "typewriter", "form-authoring", "redact" })
             {
                 ModeCommand(vm, next).Execute().Subscribe();
                 await PumpUntilAsync(window, () => ModeFlag(vm, next));
@@ -213,7 +220,9 @@ public class ModeSwitchDisplayTests
             vm.SetManualZoom(zoom);
             await Task.Delay(200); window.UpdateLayout();
 
-            ModeCommand(vm, "select-text").Execute().Subscribe();
+            // redact is the single-page vehicle here (was select-text, which is
+            // no longer single-page — #815).
+            ModeCommand(vm, "redact").Execute().Subscribe();
             await PumpUntilAsync(window, () => SinglePageImage(viewer)?.Source != null);
             window.UpdateLayout();
 
@@ -321,7 +330,7 @@ public class ModeSwitchDisplayTests
     /// #693 (scroll half): the reading position must survive the mode switch.
     /// Before the fix, entering an editing mode dropped the reader at the top
     /// of the page (singleOffset 0/…) and switching back re-anchored to the
-    /// page top. Round-trip: continuous → select-text → continuous must come
+    /// page top. Round-trip: continuous → an editing mode → continuous must come
     /// back to (about) the same scroll offset, and the intermediate
     /// single-page view must be scrolled into the page, not at its top.
     /// </summary>
@@ -351,7 +360,9 @@ public class ModeSwitchDisplayTests
             var pageBefore = vm.CurrentPageIndex;
             offBefore.Should().BeGreaterThan(100, "the test must start scrolled into the document");
 
-            ModeCommand(vm, "select-text").Execute().Subscribe();
+            // redact is the single-page editing-mode vehicle (was select-text,
+            // which no longer forces single-page — #815).
+            ModeCommand(vm, "redact").Execute().Subscribe();
             await PumpUntilAsync(window, () => SinglePageImage(viewer)?.Source != null);
             var single = viewer.FindControl<ScrollViewer>("PdfScrollViewer")!;
             // The carried fraction applies via bounded deferred retries once
@@ -376,7 +387,7 @@ public class ModeSwitchDisplayTests
             (single.Offset.Y / single.Extent.Height).Should().BeGreaterThan(0.05,
                 "the single-page view must open at the carried reading position, not the page top (#693)");
 
-            ModeCommand(vm, "select-text").Execute().Subscribe();
+            ModeCommand(vm, "redact").Execute().Subscribe();
             await PumpUntilAsync(window, () => cont.IsVisible);
             await PumpUntilAsync(window, () => Math.Abs(cont.Offset.Y - offBefore) < 40,
                 timeoutMs: 10000);

--- a/Excise.App.Tests/UI/MouseInputTests.cs
+++ b/Excise.App.Tests/UI/MouseInputTests.cs
@@ -378,6 +378,7 @@ public class MouseInputTests
         var focus = ordered[4];
 
         vm.CurrentPageIndex = targetPageNumber - 1;
+        vm.ViewMode = PdfViewMode.SinglePage; // #815: selection no longer forces single-page; these exercise the single-page path
         vm.IsTextSelectionMode = true;
         for (int i = 0; i < 10; i++) { await Task.Delay(150); window.UpdateLayout(); }
 
@@ -496,6 +497,7 @@ public class MouseInputTests
         var focus = ordered[9];
 
         vm.CurrentPageIndex = targetPageNumber - 1;
+        vm.ViewMode = PdfViewMode.SinglePage; // #815: selection no longer forces single-page; these exercise the single-page path
         vm.IsTextSelectionMode = true;
         for (int i = 0; i < 10; i++) { await Task.Delay(150); window.UpdateLayout(); }
 
@@ -566,6 +568,7 @@ public class MouseInputTests
         var singleLetter = ordered[0];
 
         vm.CurrentPageIndex = targetPageNumber - 1;
+        vm.ViewMode = PdfViewMode.SinglePage; // #815: selection no longer forces single-page; these exercise the single-page path
         vm.IsTextSelectionMode = true;
         for (int i = 0; i < 10; i++) { await Task.Delay(150); window.UpdateLayout(); }
 
@@ -617,6 +620,7 @@ public class MouseInputTests
         var clickLetter = ordered[2]; // Middle of a word
 
         vm.CurrentPageIndex = targetPageNumber - 1;
+        vm.ViewMode = PdfViewMode.SinglePage; // #815: selection no longer forces single-page; these exercise the single-page path
         vm.IsTextSelectionMode = true;
         for (int i = 0; i < 10; i++) { await Task.Delay(150); window.UpdateLayout(); }
 
@@ -781,6 +785,7 @@ public class MouseInputTests
         vm.CurrentPageIndex = targetPageNumber - 1;
 
         // Step 3: Enable text-selection mode
+        vm.ViewMode = PdfViewMode.SinglePage; // #815: selection no longer forces single-page; these exercise the single-page path
         vm.IsTextSelectionMode = true;
         for (int i = 0; i < 10; i++) { await Task.Delay(150); window.UpdateLayout(); }
 

--- a/Excise.App.Tests/UI/TextSelectionAlignmentTests.cs
+++ b/Excise.App.Tests/UI/TextSelectionAlignmentTests.cs
@@ -65,6 +65,7 @@ public class TextSelectionAlignmentTests
 
             // Enter select-text mode (forces single-page) on a body-text page.
             vm.ToggleTextSelectionModeCommand.Execute().Subscribe();
+            vm.ViewMode = PdfViewMode.SinglePage; // #815: selection no longer forces single-page; this battery covers the single-page highlight
             vm.CurrentPageIndex = 19; // page 20: paragraphs of body text
             await PumpUntilAsync(window, () =>
                 viewer.FindControl<Image>("PdfImage")?.Source != null && !viewer.IsLoading);
@@ -146,6 +147,7 @@ public class TextSelectionAlignmentTests
             viewer.RenderScalingOverride = dpr;
 
             vm.ToggleTextSelectionModeCommand.Execute().Subscribe();
+            vm.ViewMode = PdfViewMode.SinglePage; // #815: selection no longer forces single-page; this battery covers the single-page highlight
             vm.CurrentPageIndex = 19;
             await PumpUntilAsync(window, () =>
                 viewer.FindControl<Image>("PdfImage")?.Source != null && !viewer.IsLoading);
@@ -297,6 +299,7 @@ public class TextSelectionAlignmentTests
             vm.SetManualZoom(0.42);
             await Task.Delay(400); window.UpdateLayout();
             vm.ToggleTextSelectionModeCommand.Execute().Subscribe();
+            vm.ViewMode = PdfViewMode.SinglePage; // #815: selection no longer forces single-page; this battery covers the single-page highlight
             await PumpUntilAsync(window, () =>
                 viewer.FindControl<Image>("PdfImage")?.Source != null && !viewer.IsLoading);
             await SettleAsync(window, viewer, viewer.ZoomLevel, dpr);

--- a/Excise.App.Tests/Unit/MainWindowViewModelTests.cs
+++ b/Excise.App.Tests/Unit/MainWindowViewModelTests.cs
@@ -957,15 +957,16 @@ public class MainWindowViewModelTests
 
     [Theory]
     [InlineData(EditingMode.Redaction)]
-    [InlineData(EditingMode.TextSelection)]
     [InlineData(EditingMode.FormAuthoring)]
     [InlineData(EditingMode.Typewriter)]
     public void ExitingEditingMode_RestoresSavedContinuousScrollPreference(EditingMode mode)
     {
+        // Text selection is excluded (#815): it no longer forces single-page, so
+        // it never "exits" back to continuous — see TextSelection_StaysInContinuous.
         _viewModel.ApplyContinuousScrollPreference(true);
 
         SetEditingMode(mode, true);
-        _viewModel.IsContinuousView.Should().BeFalse("editing modes are single-page only");
+        _viewModel.IsContinuousView.Should().BeFalse("draw/edit modes are single-page only");
 
         SetEditingMode(mode, false);
 
@@ -977,7 +978,6 @@ public class MainWindowViewModelTests
 
     [Theory]
     [InlineData(EditingMode.Redaction)]
-    [InlineData(EditingMode.TextSelection)]
     [InlineData(EditingMode.FormAuthoring)]
     [InlineData(EditingMode.Typewriter)]
     public void ExitingEditingMode_DoesNotForceContinuousWhenPreferenceIsSinglePage(EditingMode mode)
@@ -990,6 +990,26 @@ public class MainWindowViewModelTests
         _viewModel.ViewMode.Should().Be(PdfViewMode.SinglePage);
         _viewModel.IsContinuousView.Should().BeFalse(
             "restoring must honour the saved preference, not unconditionally switch to continuous");
+    }
+
+    [Fact]
+    public void EnteringTextSelection_KeepsContinuousReadingView()
+    {
+        // #815: text selection is a read affordance, not a draw/edit mode, so it
+        // must NOT force single-page — that is what made selecting undiscoverable
+        // in the default continuous view.
+        _viewModel.ApplyContinuousScrollPreference(true);
+        _viewModel.ViewMode.Should().Be(PdfViewMode.Continuous);
+
+        _viewModel.IsTextSelectionMode = true;
+
+        _viewModel.ViewMode.Should().Be(PdfViewMode.Continuous,
+            "entering text selection stays in the continuous reading view");
+        _viewModel.IsContinuousView.Should().BeTrue();
+
+        _viewModel.IsTextSelectionMode = false;
+        _viewModel.ViewMode.Should().Be(PdfViewMode.Continuous,
+            "leaving text selection also leaves the reading view untouched");
     }
 
     public enum EditingMode

--- a/Excise.App/ViewModels/MainWindowViewModel.cs
+++ b/Excise.App/ViewModels/MainWindowViewModel.cs
@@ -296,8 +296,9 @@ public partial class MainWindowViewModel : ViewModelBase
             this.RaiseAndSetIfChanged(ref _viewMode, value);
             if (value == PdfViewMode.Continuous)
             {
+                // Text selection survives the switch to continuous (#815): it now
+                // works in the reading view. The draw/edit modes still do not.
                 if (_isRedactionMode) IsRedactionMode = false;
-                if (_isTextSelectionMode) IsTextSelectionMode = false;
                 if (_isFormAuthoringMode) IsFormAuthoringMode = false;
                 if (_isTypewriterMode) IsTypewriterMode = false;
             }
@@ -323,11 +324,13 @@ public partial class MainWindowViewModel : ViewModelBase
     }
 
     /// <summary>
-    /// True while an editing mode owns the viewport. These modes are single-page
+    /// True while a draw/edit mode owns the viewport. These modes are single-page
     /// only, so each one forces <see cref="PdfViewMode.SinglePage"/> on entry.
+    /// Text selection is excluded (#815): it now works in the continuous reading
+    /// view, so it neither forces single-page nor blocks restoring continuous.
     /// </summary>
     private bool IsEditingModeActive =>
-        _isRedactionMode || _isTextSelectionMode || _isFormAuthoringMode || _isTypewriterMode;
+        _isRedactionMode || _isFormAuthoringMode || _isTypewriterMode;
 
     /// <summary>
     /// Re-applies the saved continuous-scroll preference once the last editing mode
@@ -636,15 +639,10 @@ public partial class MainWindowViewModel : ViewModelBase
         set
         {
             this.RaiseAndSetIfChanged(ref _isTextSelectionMode, value);
-            if (value)
-            {
-                ViewMode = PdfViewMode.SinglePage;
-            }
-            else
-            {
-                RestoreViewModeFromPreference();
-            }
-            // Turn off redaction mode when entering text selection mode
+            // Text selection does NOT change the view mode (#815): it works in
+            // both single-page and the continuous reading view. Turning off the
+            // draw/edit modes below may restore continuous via their own setters.
+            // Turn off the draw/edit modes when entering text selection mode.
             if (value && _isRedactionMode)
                 IsRedactionMode = false;
             if (value && _isFormAuthoringMode)

--- a/Excise.Avalonia.Tests/PublicApi/Excise.Avalonia.approved.txt
+++ b/Excise.Avalonia.Tests/PublicApi/Excise.Avalonia.approved.txt
@@ -131,6 +131,7 @@ namespace Excise.Avalonia.Controls
         public void AddSearchHighlight(Excise.Core.Document.PdfPageRect area) { }
         public void ClearAllOverlays() { }
         public void ClearAppliedRedactions() { }
+        public void ClearContinuousSelectionHighlight() { }
         public void ClearPendingRedactions() { }
         public void ClearSearchHighlights() { }
         public void ClearSelectionHighlight() { }

--- a/Excise.Avalonia/Controls/PdfViewerControl.Continuous.cs
+++ b/Excise.Avalonia/Controls/PdfViewerControl.Continuous.cs
@@ -356,6 +356,14 @@ public partial class PdfViewerControl
         foreach (var entry in _continuousCache) entry.Bitmap.Dispose();
         _continuousCache.Clear();
         _continuousPageLinks.Clear();
+        // Selection state is per-document/page; drop the letter cache and any
+        // in-flight selection so a document or render change can't reuse stale
+        // glyphs (#815). Highlight rects live on the slots and are discarded when
+        // the slots are rebuilt.
+        _continuousPageLetterCache.Clear();
+        _continuousSelectionAnchor = null;
+        _continuousSelectionFocus = null;
+        _continuousSelectionPage = 0;
     }
 
     /// <summary>
@@ -994,6 +1002,14 @@ public sealed class PdfPageSlot : INotifyPropertyChanged
     public int PageNumber { get; }
     public double WidthPt { get; }
     public double HeightPt { get; }
+
+    /// <summary>
+    /// Text-selection highlight rectangles for this page, in page-local DIPs
+    /// (the Border's own coordinate space), bound by the continuous-view
+    /// DataTemplate to a Canvas overlay (#815). Populated by the continuous
+    /// selection gesture; empty when nothing on this page is selected.
+    /// </summary>
+    internal System.Collections.ObjectModel.ObservableCollection<PdfSelectionHighlight> SelectionRects { get; } = new();
 
     internal double TopDip { get => _topDip; private set => Set(ref _topDip, value); }
     public double DisplayWidth { get => _displayWidth; private set => Set(ref _displayWidth, value); }

--- a/Excise.Avalonia/Controls/PdfViewerControl.ContinuousSelection.cs
+++ b/Excise.Avalonia/Controls/PdfViewerControl.ContinuousSelection.cs
@@ -1,0 +1,231 @@
+using System.Collections.Generic;
+using System.Linq;
+using Avalonia;
+using Avalonia.Input;
+using Excise.Avalonia.Services;
+using Excise.Core.Document;
+using Excise.Core.Text;
+
+namespace Excise.Avalonia.Controls;
+
+/// <summary>
+/// Text selection in the continuous (reading) view (#815).
+///
+/// Single-page selection draws onto the <c>TextSelectionLayer</c> overlay above
+/// the one rendered page. The continuous view has no such single overlay — it is
+/// a virtualized stack of page bitmaps — so the highlight is drawn per page: each
+/// <see cref="PdfPageSlot"/> carries an observable list of highlight rectangles
+/// (page-local DIPs) that the DataTemplate binds to a Canvas overlay on that
+/// page's Border.
+///
+/// The gesture reuses the exact single-page engine (<see cref="TextSelectionEngine"/>)
+/// and the exact continuous pointer→page mapping the link hit-test uses
+/// (<see cref="TryMapContinuousPointToPage"/> +
+/// <see cref="PdfCoordinateMapper"/>'s ContinuousDips space). Nothing is
+/// duplicated.
+///
+/// Bounded, correct first version (#815): a selection lives on a SINGLE page —
+/// the page the press landed on. A drag that wanders onto another page is
+/// clamped (moves that map to a different page are ignored) rather than drawing a
+/// broken cross-page range the engine cannot express. Cross-page selection is
+/// deferred.
+/// </summary>
+public partial class PdfViewerControl
+{
+    private int _continuousSelectionPage;
+    private Letter? _continuousSelectionAnchor;
+    private Letter? _continuousSelectionFocus;
+
+    /// <summary>Per-page letter caches for continuous selection, cleared with the tile cache.</summary>
+    private readonly Dictionary<int, ContinuousPageLetters> _continuousPageLetterCache = new();
+
+    private sealed record ContinuousPageLetters(
+        IReadOnlyList<Letter> Raw, List<Letter> Reading, double ColumnGap)
+    {
+        public static readonly ContinuousPageLetters Empty =
+            new(System.Array.Empty<Letter>(), new List<Letter>(), double.PositiveInfinity);
+    }
+
+    private ContinuousPageLetters GetContinuousPageLetters(int pageNumber)
+    {
+        if (_continuousPageLetterCache.TryGetValue(pageNumber, out var cached))
+            return cached;
+
+        ContinuousPageLetters result;
+        try
+        {
+            var page = Document!.GetPage(pageNumber);
+            var raw = page.Letters?.ToList() ?? new List<Letter>();
+            var reading = TextSelectionEngine.SortReadingOrder(raw);
+            var gap = TextSelectionEngine.EstimateColumnGap(reading);
+            result = new ContinuousPageLetters(raw, reading, gap);
+        }
+        catch
+        {
+            result = ContinuousPageLetters.Empty;
+        }
+        _continuousPageLetterCache[pageNumber] = result;
+        return result;
+    }
+
+    /// <summary>
+    /// Map a continuous-view pointer event to the page under it and the letter (if
+    /// any) at that point, plus that page's cached letters. Uses the same slot
+    /// geometry + ContinuousDips content mapping as the link hit-test (#667).
+    /// </summary>
+    private bool TryContinuousPointToLetter(
+        PointerEventArgs e, out int pageNumber, out Letter? letter, out ContinuousPageLetters letters)
+    {
+        pageNumber = 0;
+        letter = null;
+        letters = ContinuousPageLetters.Empty;
+
+        var doc = Document;
+        if (doc == null || _continuousItems == null || _continuousSlots == null) return false;
+        var zoom = ZoomLevel;
+        if (zoom <= 0) return false;
+
+        var itemsPoint = e.GetPosition(_continuousItems);
+        if (!TryMapContinuousPointToPage(
+                _continuousSlots, _continuousItems.Bounds.Width, itemsPoint,
+                out pageNumber, out var pagePointDip))
+            return false;
+        if (pageNumber < 1 || pageNumber > doc.PageCount) return false;
+
+        var page = doc.GetPage(pageNumber);
+        var contentPoint = PdfCoordinateMapper.ToContentPoints(
+            page,
+            new PdfPageRect(pageNumber, pagePointDip.X, pagePointDip.Y, 0, 0,
+                PdfCoordinateSpace.ContinuousDips, PointsToDip * zoom));
+
+        letters = GetContinuousPageLetters(pageNumber);
+        letter = TextSelectionEngine.HitTest(letters.Raw, contentPoint.X, contentPoint.Y);
+        return true;
+    }
+
+    private void BeginContinuousTextSelection(PointerEventArgs e)
+    {
+        ClearContinuousSelectionHighlight();
+        _continuousSelectionAnchor = null;
+        _continuousSelectionFocus = null;
+        _continuousSelectionPage = 0;
+
+        if (!TryContinuousPointToLetter(e, out var page, out var letter, out _))
+            return;
+
+        // Remember the page even if the press missed a glyph, so a drag that
+        // starts in a margin and moves onto text on the SAME page can still begin.
+        _continuousSelectionPage = page;
+        if (letter == null) return;
+
+        _continuousSelectionAnchor = letter;
+        _continuousSelectionFocus = letter;
+        DrawContinuousSelection(page, new[] { letter });
+    }
+
+    private void UpdateContinuousTextSelection(PointerEventArgs e)
+    {
+        if (!TryContinuousPointToLetter(e, out var page, out var letter, out var letters))
+            return;
+
+        // Bounded to the anchor page (#815). A move onto a different page is
+        // ignored rather than drawing a cross-page range.
+        if (_continuousSelectionAnchor == null)
+        {
+            // The press missed a glyph but latched the page; adopt the first
+            // glyph the drag reaches on that same page as the anchor.
+            if (page != _continuousSelectionPage || letter == null) return;
+            _continuousSelectionAnchor = letter;
+            _continuousSelectionFocus = letter;
+            DrawContinuousSelection(page, new[] { letter });
+            return;
+        }
+
+        if (page != _continuousSelectionPage || letter == null) return;
+        if (ReferenceEquals(letter, _continuousSelectionFocus)) return;
+
+        _continuousSelectionFocus = letter;
+        var range = TextSelectionEngine.ColumnAwareRange(
+            letters.Reading, _continuousSelectionAnchor, _continuousSelectionFocus, letters.ColumnGap);
+        DrawContinuousSelection(page, range);
+    }
+
+    private void EndContinuousTextSelection()
+    {
+        if (Document == null ||
+            _continuousSelectionAnchor == null || _continuousSelectionFocus == null ||
+            _continuousSelectionPage < 1)
+            return;
+
+        var letters = GetContinuousPageLetters(_continuousSelectionPage);
+        var selection = TextSelectionEngine.BuildSelection(
+            letters.Reading, letters.Raw,
+            _continuousSelectionAnchor, _continuousSelectionFocus, letters.ColumnGap);
+
+        var page = Document.GetPage(_continuousSelectionPage);
+        var dipRects = selection.VisualRange
+            .Select(l => ContinuousGlyphToPageLocalRect(page, l.GlyphRectangle))
+            .ToList();
+        Rect? bbox = dipRects.Count > 0 ? UnionRects(dipRects) : null;
+        TextSelected?.Invoke(this, new TextSelectedEventArgs(bbox ?? new Rect(), selection.Text, dipRects));
+    }
+
+    private void DrawContinuousSelection(int pageNumber, IReadOnlyList<Letter> letters)
+    {
+        ClearContinuousSelectionHighlight();
+        if (Document == null || _continuousSlots == null ||
+            pageNumber < 1 || pageNumber > _continuousSlots.Count)
+            return;
+
+        var slot = _continuousSlots[pageNumber - 1];
+        PdfPage page;
+        try { page = Document.GetPage(pageNumber); }
+        catch { return; }
+
+        foreach (var l in letters)
+        {
+            var r = ContinuousGlyphToPageLocalRect(page, l.GlyphRectangle);
+            slot.SelectionRects.Add(new PdfSelectionHighlight(r.X, r.Y, r.Width, r.Height));
+        }
+    }
+
+    /// <summary>A glyph's content rectangle as page-local continuous-view DIPs (the slot Border's space).</summary>
+    private Rect ContinuousGlyphToPageLocalRect(PdfPage page, PdfRectangle glyph)
+    {
+        var dips = PdfCoordinateMapper.ToContinuousDips(
+            page,
+            PdfPageRect.FromContentPoints(page.PageNumber, glyph),
+            PointsToDip * ZoomLevel);
+        return new Rect(dips.X, dips.Y, dips.Width, dips.Height);
+    }
+
+    /// <summary>Clear every page's continuous selection highlight.</summary>
+    public void ClearContinuousSelectionHighlight()
+    {
+        if (_continuousSlots == null) return;
+        foreach (var slot in _continuousSlots)
+            if (slot.SelectionRects.Count > 0)
+                slot.SelectionRects.Clear();
+    }
+}
+
+/// <summary>
+/// One text-selection highlight rectangle in a continuous-view page's local DIP
+/// space (#815). Immutable; bound by the DataTemplate to a Rectangle on the
+/// page's Canvas overlay.
+/// </summary>
+internal sealed class PdfSelectionHighlight
+{
+    public PdfSelectionHighlight(double x, double y, double width, double height)
+    {
+        X = x;
+        Y = y;
+        Width = width;
+        Height = height;
+    }
+
+    public double X { get; }
+    public double Y { get; }
+    public double Width { get; }
+    public double Height { get; }
+}

--- a/Excise.Avalonia/Controls/PdfViewerControl.Interaction.cs
+++ b/Excise.Avalonia/Controls/PdfViewerControl.Interaction.cs
@@ -59,15 +59,24 @@ public partial class PdfViewerControl
 
         if (InteractionMode == InteractionMode.TextSelection)
         {
-            // Text-selection mode: hit-test letters instead of drawing a
-            // 2-D rectangle. Anchor is the letter under (or nearest to)
-            // the press point; focus tracks pointer-moved.
-            EnsurePageLettersLoaded();
-            _selectionAnchor = HitTestLetterAt(point);
-            _selectionFocus = _selectionAnchor;
-            ClearSelectionHighlight();
-            if (_selectionAnchor != null)
-                DrawSelectionRange(new[] { _selectionAnchor });
+            if (ViewMode == PdfViewMode.Continuous)
+            {
+                // Continuous reading view: select on the page under the pointer,
+                // drawing onto that page's own overlay (#815).
+                BeginContinuousTextSelection(e);
+            }
+            else
+            {
+                // Single-page: hit-test letters instead of drawing a 2-D
+                // rectangle. Anchor is the letter under (or nearest to) the press
+                // point; focus tracks pointer-moved.
+                EnsurePageLettersLoaded();
+                _selectionAnchor = HitTestLetterAt(point);
+                _selectionFocus = _selectionAnchor;
+                ClearSelectionHighlight();
+                if (_selectionAnchor != null)
+                    DrawSelectionRange(new[] { _selectionAnchor });
+            }
         }
 
         e.Handled = true;
@@ -110,6 +119,11 @@ public partial class PdfViewerControl
         else if (InteractionMode == InteractionMode.Typewriter)
         {
             DrawTemporaryTypewriterRectangle(_dragStart, currentPoint);
+        }
+        else if (InteractionMode == InteractionMode.TextSelection && ViewMode == PdfViewMode.Continuous)
+        {
+            // Continuous reading view: extend the per-page highlight (#815).
+            UpdateContinuousTextSelection(e);
         }
         else if (InteractionMode == InteractionMode.TextSelection)
         {
@@ -180,6 +194,11 @@ public partial class PdfViewerControl
             // post-normalize rect, which is never sub-4, so a click already
             // slipped through — now it is an intentional, documented path.
             CreateTypewriterTextFromPointer(_dragStart, endPoint);
+        }
+        else if (InteractionMode == InteractionMode.TextSelection && ViewMode == PdfViewMode.Continuous)
+        {
+            // Continuous reading view: finalize the per-page selection (#815).
+            EndContinuousTextSelection();
         }
         else if (InteractionMode == InteractionMode.TextSelection &&
                  _selectionAnchor != null && _selectionFocus != null &&
@@ -443,6 +462,16 @@ public partial class PdfViewerControl
         var page = Document.GetPage(CurrentPage);
         return ToAvaloniaRect(ToViewerDips(PdfPageRect.FromContentPoints(page.PageNumber, r)));
     }
+
+    /// <summary>
+    /// Test seam (#815): the single-page content-points → viewer-DIP mapping used
+    /// to position a glyph's selection highlight. Exposed so a GUI test can compute
+    /// the pointer position of a known glyph to drive a real selection gesture. It
+    /// is deliberately NOT the on-screen-position oracle — the test verifies the
+    /// drawn highlight's real layout geometry (origin share + MediaBox fraction in
+    /// the page image), which this method cannot vouch for.
+    /// </summary>
+    internal Rect GlyphRectToViewerDipsForTest(PdfRectangle glyphRect) => PdfRectangleToDips(glyphRect);
 
     private static Rect UnionRects(IReadOnlyList<Rect> rects)
     {

--- a/Excise.Avalonia/Controls/PdfViewerControl.axaml
+++ b/Excise.Avalonia/Controls/PdfViewerControl.axaml
@@ -91,16 +91,49 @@
                                 HorizontalAlignment="Center"
                                 BorderBrush="#40000000"
                                 BorderThickness="1">
-                            <Canvas Width="{Binding DisplayWidth}"
-                                    Height="{Binding DisplayHeight}"
-                                    ClipToBounds="True">
-                                <Image Source="{Binding Bitmap}"
-                                       Stretch="Fill"
-                                       Width="{Binding TileDisplayWidth}"
-                                       Height="{Binding TileDisplayHeight}"
-                                       Canvas.Left="{Binding TileDisplayX}"
-                                       Canvas.Top="{Binding TileDisplayY}" />
-                            </Canvas>
+                            <Panel ClipToBounds="True">
+                                <Canvas Width="{Binding DisplayWidth}"
+                                        Height="{Binding DisplayHeight}">
+                                    <Image Source="{Binding Bitmap}"
+                                           Stretch="Fill"
+                                           Width="{Binding TileDisplayWidth}"
+                                           Height="{Binding TileDisplayHeight}"
+                                           Canvas.Left="{Binding TileDisplayX}"
+                                           Canvas.Top="{Binding TileDisplayY}" />
+                                </Canvas>
+                                <!-- Text-selection highlight overlay (#815): one
+                                     semi-transparent blue rect per selected glyph,
+                                     positioned in page-local DIPs on a Canvas
+                                     panel. Hit-test-transparent so it never eats
+                                     the selection/link pointer gestures. -->
+                                <ItemsControl ItemsSource="{Binding SelectionRects}"
+                                              IsHitTestVisible="False">
+                                    <ItemsControl.ItemsPanel>
+                                        <ItemsPanelTemplate>
+                                            <Canvas />
+                                        </ItemsPanelTemplate>
+                                    </ItemsControl.ItemsPanel>
+                                    <ItemsControl.Styles>
+                                        <!-- Position each item's container in
+                                             page-local DIPs. ReflectionBinding
+                                             (not compiled) so X/Y resolve against
+                                             the item (PdfSelectionHighlight), not
+                                             the outer PdfPageSlot compiled-binding
+                                             scope this Style sits in. -->
+                                        <Style Selector="ItemsControl > ContentPresenter">
+                                            <Setter Property="Canvas.Left" Value="{ReflectionBinding X}" />
+                                            <Setter Property="Canvas.Top" Value="{ReflectionBinding Y}" />
+                                        </Style>
+                                    </ItemsControl.Styles>
+                                    <ItemsControl.ItemTemplate>
+                                        <DataTemplate x:DataType="controls:PdfSelectionHighlight">
+                                            <Rectangle Width="{Binding Width}"
+                                                       Height="{Binding Height}"
+                                                       Fill="#603399FF" />
+                                        </DataTemplate>
+                                    </ItemsControl.ItemTemplate>
+                                </ItemsControl>
+                            </Panel>
                         </Border>
                     </DataTemplate>
                 </ItemsControl.ItemTemplate>

--- a/Excise.Avalonia/Controls/PdfViewerControl.axaml.cs
+++ b/Excise.Avalonia/Controls/PdfViewerControl.axaml.cs
@@ -412,9 +412,16 @@ public partial class PdfViewerControl : UserControl
         }
     }
 
-    /// <summary>An interaction mode that draws/edits and therefore needs single-page layout.</summary>
+    /// <summary>
+    /// An interaction mode that DRAWS/EDITS onto a single rendered page and
+    /// therefore needs single-page layout, so entering it in the continuous
+    /// reading view auto-switches back to single-page. Text selection is
+    /// deliberately excluded (#815): it is a read affordance like link clicking,
+    /// not an edit, and now works in the continuous view via a per-page selection
+    /// overlay — so it must NOT force single-page.
+    /// </summary>
     private static bool IsEditingMode(InteractionMode m) =>
-        m is InteractionMode.Redaction or InteractionMode.TextSelection or InteractionMode.FormAuthoring or InteractionMode.Typewriter;
+        m is InteractionMode.Redaction or InteractionMode.FormAuthoring or InteractionMode.Typewriter;
 
     private System.Collections.Specialized.INotifyCollectionChanged? _watchedHighlights;
     private System.Collections.Specialized.INotifyCollectionChanged? _watchedTypewriterTextOperations;


### PR DESCRIPTION
Closes #815.

## Problem
Selecting text in the GUI showed no highlight, and selection didn't work at all in the **default continuous reading view**. Text selection was a mode toggle that forced single-page layout (`IsTextSelectionMode` → `ViewMode=SinglePage`); the continuous view had no selection wiring, and the single-page "selection box" drawing had **no GUI-level test**, so any coordinate/z-order regression could ship silently.

## Was single-page rendering actually buggy?
**No — it was already correct.** New GUI tests drive a real pointer press→drag and verify the highlight lands on the selected glyphs, checked against an **independent layout-geometry oracle** (the overlay and page image share an origin; each drawn rect sits at its glyph's MediaBox fraction inside the page image) rather than `PdfRectangleToDips` vouching for itself. The historic "highlight far to the left" origin offset would trip these; current code passes. The tests now lock it in.

## What's implemented
**Continuous-view text selection (the real fix).** Text selection is now a *read affordance* (like link clicking), not a draw/edit mode:
- Decoupled `TextSelection` from single-page in the control (`IsEditingMode`) and the VM (`IsTextSelectionMode` / `ViewMode` / `IsEditingModeActive`). Redaction / Typewriter / Form-authoring still force single-page.
- Each `PdfPageSlot` carries highlight rectangles bound to a per-page `Canvas` overlay in the reading-view template. The gesture **reuses** the single-page `TextSelectionEngine` and the same continuous pointer→page mapping the link hit-test uses (`TryMapContinuousPointToPage` + `PdfCoordinateMapper.ToContinuousDips`) — no duplicated engine or coordinate math.

**Covered vs deferred:** a selection lives on the **single page the press landed on**; a drag onto another page is **clamped** (ignored), never drawing a broken cross-page range or crashing. Cross-page selection is **deferred** (a test pins the clamp behavior).

## Tests added (`Excise.App.Tests/Controls/PdfViewerSelectionTests.cs`)
- Single-page drag draws a highlight over the selected glyphs at correct on-page positions (layout-geometry oracle).
- `ClearSelectionHighlight` empties the layer.
- Continuous-view drag draws a per-page highlight over the glyphs; verified both as bound data **and** as real, positioned rendered `Rectangle`s.
- Continuous selection does not force single-page and stays on the anchor page across a cross-page drag (no throw).

Existing tests that encoded the old TextSelection→single-page contract were updated to the new contract (control, VM, ModeSwitchDisplay, MouseInput, TextSelectionAlignment).

## Gates
- Full `Excise.App.Tests` (foreground, alone): **1115 passed, 0 failed, 26 skipped**, no host crash.
- `Excise.Avalonia.Tests`: 87 passed. `scripts/test-tier.sh t0`: all green. Build: 0 warnings.
- `Excise.Avalonia.approved.txt` regenerated for one new public method `ClearContinuousSelectionHighlight()` (the highlight type + slot collection stayed internal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
