### PR TITLE
test: interactive GUI tests for page-organization commands (#816, batch 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ semantic versioning.
 
 ## [Unreleased]
 
+### Added
+- **Interactive GUI tests for page-organization toolbar/menu commands** (#816)
+  — a new `PageOrganizationCommandTests` suite executes the real
+  `MainWindowViewModel` commands a user clicks (Combine, Split, Add/Insert
+  Before/After, Extract Current/Selected, Remove/Move/Clear Selected, Move
+  Current Earlier/Later, Rotate Left/180) and asserts the resulting page
+  order, count, rotation, or saved-file content — closing an audit gap where
+  these effects were proven only by calling the underlying async methods, so a
+  button mis-wired to the wrong method would have passed. To make the
+  file/folder-picker commands drivable headlessly (no desktop lifetime, and
+  Avalonia's storage interfaces are sealed against user implementation), the
+  view-model gained internal picked-path test seams (`PickPdfFilesOverride`,
+  `PickSavePdfPathOverride`, `PickFolderOverride`) that the picker helpers
+  honor; all null in production, so the real storage provider is always used.
+  No command mis-wiring was found.
+
 ## [3.4.0] - 2026-07-27
 
 ### Added

--- a/Excise.App.Tests/UI/PageOrganizationCommandTests.cs
+++ b/Excise.App.Tests/UI/PageOrganizationCommandTests.cs
@@ -1,0 +1,368 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using AwesomeAssertions;
+using Excise.App.Services;
+using Excise.App.Tests.Utilities;
+using Excise.App.ViewModels;
+using Excise.App.Views;
+using Excise.Core.Document;
+using Xunit;
+
+namespace Excise.App.Tests.UI;
+
+/// <summary>
+/// #816 batch 1 — executes the REAL page-organization toolbar/menu COMMANDS
+/// (not the underlying async methods) and asserts the real page-level effect.
+/// Prior coverage proved these methods only by calling them directly or by
+/// asserting the command object is non-null; a button mis-wired to the wrong
+/// method would have passed. Each test here does
+/// <c>await vm.&lt;Name&gt;Command.Execute()</c> and verifies order/count/rotation
+/// or the saved output.
+///
+/// The file/folder-picker commands (Add/Insert/Combine/Split/Extract) reach the
+/// dialog through the picker seams on the view-model
+/// (<c>PickPdfFilesOverride</c> / <c>PickSavePdfPathOverride</c> /
+/// <c>PickFolderOverride</c>, #816) — headless Avalonia has no desktop lifetime
+/// and its storage interfaces are sealed against user implementation, so these
+/// path-returning delegates are the injection point.
+/// </summary>
+[Collection("AvaloniaTests")]
+public class PageOrganizationCommandTests
+{
+    // ── Rotation — the audit canary. Assert the exact task-specified values. ──
+    [FixedAvaloniaFact]
+    public async Task RotatePageLeftCommand_RotatesCurrentPageMinus90()
+    {
+        var (dir, src) = NewDir("rot-left");
+        TestPdfGenerator.CreateSimpleTextPdf(src, "Rotate me");
+        var (vm, window) = await OpenAsync(src);
+
+        var before = vm.PdfCoreDocument!.GetPage(1).Rotation;
+        await vm.RotatePageLeftCommand.Execute();
+        vm.PdfCoreDocument!.GetPage(1).Rotation.Should().Be((before + 270) % 360);
+
+        Close(window, dir);
+    }
+
+    [FixedAvaloniaFact]
+    public async Task RotatePage180Command_RotatesCurrentPage180()
+    {
+        var (dir, src) = NewDir("rot-180");
+        TestPdfGenerator.CreateSimpleTextPdf(src, "Rotate me");
+        var (vm, window) = await OpenAsync(src);
+
+        var before = vm.PdfCoreDocument!.GetPage(1).Rotation;
+        await vm.RotatePage180Command.Execute();
+        vm.PdfCoreDocument!.GetPage(1).Rotation.Should().Be((before + 180) % 360);
+
+        Close(window, dir);
+    }
+
+    // ── Move current page ─────────────────────────────────────────────────────
+    [FixedAvaloniaFact]
+    public async Task MoveCurrentPageEarlierCommand_MovesCurrentPageToPriorIndex()
+    {
+        var (dir, src) = NewDir("move-cur-earlier");
+        TestPdfGenerator.CreateMultiPagePdf(src, pageCount: 3);
+        var (vm, window) = await OpenAsync(src);
+        vm.CurrentPageIndex = 2; // Page 3
+
+        await vm.MoveCurrentPageEarlierCommand.Execute();
+
+        // [P1, P2, P3] → move P3 earlier ⇒ [P1, P3, P2]
+        PageText(vm, 2).Should().Contain("Page 3 Content");
+        vm.CurrentPageIndex.Should().Be(1, "the moved page follows itself to its new index");
+
+        Close(window, dir);
+    }
+
+    [FixedAvaloniaFact]
+    public async Task MoveCurrentPageLaterCommand_MovesCurrentPageToNextIndex()
+    {
+        var (dir, src) = NewDir("move-cur-later");
+        TestPdfGenerator.CreateMultiPagePdf(src, pageCount: 3);
+        var (vm, window) = await OpenAsync(src);
+        vm.CurrentPageIndex = 1; // Page 2
+
+        await vm.MoveCurrentPageLaterCommand.Execute();
+
+        // [P1, P2, P3] → move P2 later ⇒ [P1, P3, P2]
+        PageText(vm, 3).Should().Contain("Page 2 Content");
+        vm.CurrentPageIndex.Should().Be(2);
+
+        Close(window, dir);
+    }
+
+    // ── Selected-page operations ─────────────────────────────────────────────
+    [FixedAvaloniaFact]
+    public async Task RemoveSelectedPagesCommand_RemovesTheMarkedPages()
+    {
+        var (dir, src) = NewDir("remove-selected");
+        TestPdfGenerator.CreateMultiPagePdf(src, pageCount: 4);
+        var (vm, window) = await OpenAsync(src);
+        Select(vm, 1); // mark Page 2
+
+        await vm.RemoveSelectedPagesCommand.Execute();
+
+        vm.TotalPages.Should().Be(3);
+        // [P1, P2, P3, P4] − P2 ⇒ [P1, P3, P4]
+        PageText(vm, 2).Should().Contain("Page 3 Content");
+        AllText(vm).Should().NotContain("Page 2 Content");
+
+        Close(window, dir);
+    }
+
+    [FixedAvaloniaFact]
+    public async Task MoveSelectedPagesEarlierCommand_MovesMarkedPageEarlier()
+    {
+        var (dir, src) = NewDir("move-selected-earlier");
+        TestPdfGenerator.CreateMultiPagePdf(src, pageCount: 4);
+        var (vm, window) = await OpenAsync(src);
+        Select(vm, 2); // mark Page 3 (index 2)
+
+        await vm.MoveSelectedPagesEarlierCommand.Execute();
+
+        // Page 3 moves from index 2 → index 1 ⇒ 1-based page 2 is now Page 3
+        PageText(vm, 2).Should().Contain("Page 3 Content");
+
+        Close(window, dir);
+    }
+
+    [FixedAvaloniaFact]
+    public async Task MoveSelectedPagesLaterCommand_MovesMarkedPageLater()
+    {
+        var (dir, src) = NewDir("move-selected-later");
+        TestPdfGenerator.CreateMultiPagePdf(src, pageCount: 4);
+        var (vm, window) = await OpenAsync(src);
+        Select(vm, 1); // mark Page 2 (index 1)
+
+        await vm.MoveSelectedPagesLaterCommand.Execute();
+
+        // Page 2 moves from index 1 → index 2 ⇒ 1-based page 3 is now Page 2
+        PageText(vm, 3).Should().Contain("Page 2 Content");
+
+        Close(window, dir);
+    }
+
+    [FixedAvaloniaFact]
+    public async Task ClearSelectedPagesCommand_UnmarksAllSelections()
+    {
+        var (dir, src) = NewDir("clear-selected");
+        TestPdfGenerator.CreateMultiPagePdf(src, pageCount: 3);
+        var (vm, window) = await OpenAsync(src);
+        Select(vm, 0);
+        Select(vm, 2);
+        vm.SelectedPageCount.Should().Be(2);
+
+        await vm.ClearSelectedPagesCommand.Execute();
+
+        vm.SelectedPageCount.Should().Be(0);
+        vm.PageThumbnails.Should().OnlyContain(t => !t.IsMarkedForPageOperation);
+
+        Close(window, dir);
+    }
+
+    // ── Add / Insert (picker-driven, seam-injected source path) ──────────────
+    [FixedAvaloniaFact]
+    public async Task AddPagesCommand_AppendsInsertedPageAtEnd()
+    {
+        var (dir, src) = NewDir("add-pages");
+        TestPdfGenerator.CreateMultiPagePdf(src, pageCount: 3);
+        var insertPath = Path.Combine(dir, "insert.pdf");
+        TestPdfGenerator.CreateSimpleTextPdf(insertPath, "INSERTED_MARKER");
+        var (vm, window) = await OpenAsync(src);
+        vm.PickPdfFilesOverride = _ => Task.FromResult<IReadOnlyList<string>>(new[] { insertPath });
+
+        await vm.AddPagesCommand.Execute();
+
+        vm.TotalPages.Should().Be(4);
+        PageText(vm, 4).Should().Contain("INSERTED_MARKER", "AddPages appends at the end");
+
+        Close(window, dir);
+    }
+
+    [FixedAvaloniaFact]
+    public async Task InsertPagesBeforeCurrentCommand_InsertsAtCurrentIndex()
+    {
+        var (dir, src) = NewDir("insert-before");
+        TestPdfGenerator.CreateMultiPagePdf(src, pageCount: 3);
+        var insertPath = Path.Combine(dir, "insert.pdf");
+        TestPdfGenerator.CreateSimpleTextPdf(insertPath, "INSERTED_MARKER");
+        var (vm, window) = await OpenAsync(src);
+        vm.CurrentPageIndex = 1; // before Page 2 ⇒ new index 1
+        vm.PickPdfFilesOverride = _ => Task.FromResult<IReadOnlyList<string>>(new[] { insertPath });
+
+        await vm.InsertPagesBeforeCurrentCommand.Execute();
+
+        vm.TotalPages.Should().Be(4);
+        // [P1, INSERTED, P2, P3]
+        PageText(vm, 2).Should().Contain("INSERTED_MARKER");
+        PageText(vm, 3).Should().Contain("Page 2 Content");
+
+        Close(window, dir);
+    }
+
+    [FixedAvaloniaFact]
+    public async Task InsertPagesAfterCurrentCommand_InsertsAfterCurrentIndex()
+    {
+        var (dir, src) = NewDir("insert-after");
+        TestPdfGenerator.CreateMultiPagePdf(src, pageCount: 3);
+        var insertPath = Path.Combine(dir, "insert.pdf");
+        TestPdfGenerator.CreateSimpleTextPdf(insertPath, "INSERTED_MARKER");
+        var (vm, window) = await OpenAsync(src);
+        vm.CurrentPageIndex = 1; // after Page 2 ⇒ new index 2
+        vm.PickPdfFilesOverride = _ => Task.FromResult<IReadOnlyList<string>>(new[] { insertPath });
+
+        await vm.InsertPagesAfterCurrentCommand.Execute();
+
+        vm.TotalPages.Should().Be(4);
+        // [P1, P2, INSERTED, P3]
+        PageText(vm, 3).Should().Contain("INSERTED_MARKER");
+        PageText(vm, 4).Should().Contain("Page 3 Content");
+
+        Close(window, dir);
+    }
+
+    // ── Extract ──────────────────────────────────────────────────────────────
+    [FixedAvaloniaFact]
+    public async Task ExtractCurrentPageCommand_WritesOnlyTheCurrentPage()
+    {
+        var (dir, src) = NewDir("extract-current");
+        TestPdfGenerator.CreateMultiPagePdf(src, pageCount: 3);
+        var outPath = Path.Combine(dir, "extracted.pdf");
+        var (vm, window) = await OpenAsync(src);
+        vm.CurrentPageIndex = 1; // Page 2
+        vm.PickSavePdfPathOverride = () => Task.FromResult<string?>(outPath);
+
+        await vm.ExtractCurrentPageCommand.Execute();
+
+        File.Exists(outPath).Should().BeTrue();
+        using var extracted = PdfDocument.Open(outPath);
+        extracted.PageCount.Should().Be(1);
+        extracted.GetPage(1).Text.Should().Contain("Page 2 Content");
+        extracted.GetPage(1).Text.Should().NotContain("Page 1 Content");
+
+        Close(window, dir);
+    }
+
+    [FixedAvaloniaFact]
+    public async Task ExtractSelectedPagesCommand_WritesExactlyTheMarkedPages()
+    {
+        var (dir, src) = NewDir("extract-selected");
+        TestPdfGenerator.CreateMultiPagePdf(src, pageCount: 4);
+        var outPath = Path.Combine(dir, "extracted.pdf");
+        var (vm, window) = await OpenAsync(src);
+        Select(vm, 0); // Page 1
+        Select(vm, 2); // Page 3
+        vm.PickSavePdfPathOverride = () => Task.FromResult<string?>(outPath);
+
+        await vm.ExtractSelectedPagesCommand.Execute();
+
+        File.Exists(outPath).Should().BeTrue();
+        using var extracted = PdfDocument.Open(outPath);
+        extracted.PageCount.Should().Be(2);
+        var text = extracted.GetPage(1).Text + "|" + extracted.GetPage(2).Text;
+        text.Should().Contain("Page 1 Content");
+        text.Should().Contain("Page 3 Content");
+        text.Should().NotContain("Page 2 Content");
+
+        Close(window, dir);
+    }
+
+    // ── Combine ──────────────────────────────────────────────────────────────
+    [FixedAvaloniaFact]
+    public async Task CombineDocumentsCommand_MergesBothSourcesIntoOneFile()
+    {
+        var (dir, src) = NewDir("combine");
+        var a = Path.Combine(dir, "a.pdf");
+        var b = Path.Combine(dir, "b.pdf");
+        TestPdfGenerator.CreateTextOnlyPdf(a, "ALPHA_DOC");
+        TestPdfGenerator.CreateTextOnlyPdf(b, "BRAVO_DOC");
+        var outPath = Path.Combine(dir, "combined.pdf");
+
+        var vm = new MainWindowViewModel();
+        var window = new MainWindow { DataContext = vm, Width = 1280, Height = 900 };
+        window.Show();
+        vm.PickPdfFilesOverride = _ => Task.FromResult<IReadOnlyList<string>>(new[] { a, b });
+        vm.PickSavePdfPathOverride = () => Task.FromResult<string?>(outPath);
+
+        await vm.CombineDocumentsCommand.Execute();
+
+        File.Exists(outPath).Should().BeTrue();
+        using var combined = PdfDocument.Open(outPath);
+        combined.PageCount.Should().Be(2, "combine sums the source page counts");
+        var text = combined.GetPage(1).Text + "|" + combined.GetPage(2).Text;
+        text.Should().Contain("ALPHA_DOC");
+        text.Should().Contain("BRAVO_DOC");
+
+        Close(window, dir);
+    }
+
+    // ── Split (default split spec "1" ⇒ one page per file, via NullDialog) ────
+    [FixedAvaloniaFact]
+    public async Task SplitDocumentCommand_WritesOnePageFilePerPage()
+    {
+        var (dir, src) = NewDir("split");
+        TestPdfGenerator.CreateMultiPagePdf(src, pageCount: 4);
+        var outFolder = Path.Combine(dir, "out");
+        Directory.CreateDirectory(outFolder);
+        var (vm, window) = await OpenAsync(src);
+        vm.PickFolderOverride = () => Task.FromResult<string?>(outFolder);
+
+        await vm.SplitDocumentCommand.Execute();
+
+        var files = Directory.GetFiles(outFolder, "*.pdf").OrderBy(f => f).ToList();
+        files.Should().HaveCount(4, "the default \"1\" spec splits one page per file");
+        var allText = string.Empty;
+        foreach (var f in files)
+        {
+            using var part = PdfDocument.Open(f);
+            part.PageCount.Should().Be(1, "each split file carries exactly one page");
+            allText += part.GetPage(1).Text + "|";
+        }
+        allText.Should().Contain("Page 1 Content");
+        allText.Should().Contain("Page 4 Content");
+
+        Close(window, dir);
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+    private static (string dir, string src) NewDir(string tag)
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "ExcisePageOrgCmd", $"{tag}-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dir);
+        return (dir, Path.Combine(dir, "source.pdf"));
+    }
+
+    private static async Task<(MainWindowViewModel vm, MainWindow window)> OpenAsync(string path)
+    {
+        var vm = new MainWindowViewModel();
+        var window = new MainWindow { DataContext = vm, Width = 1280, Height = 900 };
+        window.Show();
+        await vm.LoadDocumentAsync(path);
+        return (vm, window);
+    }
+
+    private static void Select(MainWindowViewModel vm, int pageIndex)
+    {
+        vm.PageThumbnails.Single(t => t.PageIndex == pageIndex).IsMarkedForPageOperation = true;
+    }
+
+    private static string PageText(MainWindowViewModel vm, int oneBasedPage) =>
+        vm.PdfCoreDocument!.GetPage(oneBasedPage).Text;
+
+    private static string AllText(MainWindowViewModel vm) =>
+        string.Join("|", Enumerable.Range(1, vm.TotalPages)
+            .Select(n => vm.PdfCoreDocument!.GetPage(n).Text));
+
+    private static void Close(MainWindow window, string dir)
+    {
+        window.Close();
+        try { if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true); }
+        catch { }
+    }
+}

--- a/Excise.App/ViewModels/MainWindowViewModel.cs
+++ b/Excise.App/ViewModels/MainWindowViewModel.cs
@@ -1333,40 +1333,14 @@ public partial class MainWindowViewModel : ViewModelBase
             return;
         }
 
-        var storageProvider = GetStorageProvider();
-        if (storageProvider == null)
-        {
-            _logger.LogWarning("Storage provider unavailable, cannot show Add Pages dialog");
-            return;
-        }
-
-        var files = await storageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
-        {
-            Title = "Select PDF to Add Pages From",
-            AllowMultiple = false,
-            FileTypeFilter = new[]
-            {
-                new FilePickerFileType("PDF Files")
-                {
-                    Patterns = new[] { "*.pdf" }
-                }
-            }
-        });
-
+        var files = await PickPdfFilesAsync("Select PDF to Add Pages From", allowMultiple: false);
         if (files.Count == 0)
         {
             _logger.LogInformation("Add pages dialog cancelled");
             return;
         }
 
-        var filePath = files[0].Path.LocalPath;
-        if (string.IsNullOrWhiteSpace(filePath))
-        {
-            _logger.LogWarning("Selected file has no local path");
-            return;
-        }
-
-        await AddPagesFromFileAsync(filePath);
+        await AddPagesFromFileAsync(files[0]);
     }
 
     public async Task AddPagesFromFileAsync(string sourcePdfPath)
@@ -1416,61 +1390,14 @@ public partial class MainWindowViewModel : ViewModelBase
     {
         _logger.LogInformation("Combine documents command triggered");
 
-        var storageProvider = GetStorageProvider();
-        if (storageProvider == null)
-        {
-            _logger.LogWarning("Storage provider unavailable, cannot show Combine Documents dialog");
-            return;
-        }
-
-        var files = await storageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
-        {
-            Title = "Select PDFs to Combine",
-            AllowMultiple = true,
-            FileTypeFilter = new[]
-            {
-                new FilePickerFileType("PDF Files")
-                {
-                    Patterns = new[] { "*.pdf" }
-                }
-            }
-        });
-
-        if (files.Count == 0)
+        var sourcePaths = await PickPdfFilesAsync("Select PDFs to Combine", allowMultiple: true);
+        if (sourcePaths.Count == 0)
         {
             _logger.LogInformation("Combine Documents dialog cancelled");
             return;
         }
 
-        var sourcePaths = files
-            .Select(f => f.Path.LocalPath)
-            .Where(p => !string.IsNullOrWhiteSpace(p))
-            .ToList();
-
-        if (sourcePaths.Count == 0)
-        {
-            _logger.LogWarning("No selected files have a local path");
-            return;
-        }
-
-        var outputFile = await storageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
-        {
-            Title = "Save Combined PDF",
-            DefaultExtension = "pdf",
-            SuggestedFileName = "combined.pdf",
-            FileTypeChoices = new[]
-            {
-                new FilePickerFileType("PDF Files")
-                {
-                    Patterns = new[] { "*.pdf" }
-                }
-            }
-        });
-
-        if (outputFile == null)
-            return;
-
-        var outputPath = outputFile.Path.LocalPath;
+        var outputPath = await PickSavePdfPathAsync("Save Combined PDF", "combined.pdf");
         if (string.IsNullOrWhiteSpace(outputPath))
             return;
 
@@ -1493,13 +1420,6 @@ public partial class MainWindowViewModel : ViewModelBase
         if (!_documentService.IsDocumentLoaded)
         {
             _logger.LogWarning("Cannot split: No document loaded");
-            return;
-        }
-
-        var storageProvider = GetStorageProvider();
-        if (storageProvider == null)
-        {
-            _logger.LogWarning("Storage provider unavailable, cannot show Split Document dialog");
             return;
         }
 
@@ -1557,22 +1477,10 @@ public partial class MainWindowViewModel : ViewModelBase
             return;
         }
 
-        var folder = await storageProvider.OpenFolderPickerAsync(new FolderPickerOpenOptions
-        {
-            Title = "Select Folder for Split PDFs",
-            AllowMultiple = false
-        });
-
-        if (folder.Count == 0)
-        {
-            _logger.LogInformation("Split Document dialog cancelled");
-            return;
-        }
-
-        var folderPath = folder[0].Path.LocalPath;
+        var folderPath = await PickFolderAsync("Select Folder for Split PDFs");
         if (string.IsNullOrWhiteSpace(folderPath))
         {
-            _logger.LogWarning("Split target folder has no local path");
+            _logger.LogInformation("Split Document dialog cancelled");
             return;
         }
 
@@ -1593,35 +1501,11 @@ public partial class MainWindowViewModel : ViewModelBase
         if (!_documentService.IsDocumentLoaded)
             return;
 
-        var storageProvider = GetStorageProvider();
-        if (storageProvider == null)
-        {
-            _logger.LogWarning("Storage provider unavailable, cannot show Extract Page dialog");
-            return;
-        }
-
         var suggestedName = string.IsNullOrWhiteSpace(DocumentName)
             ? $"page-{DisplayPageNumber}.pdf"
             : $"{Path.GetFileNameWithoutExtension(DocumentName)}_page{DisplayPageNumber}.pdf";
 
-        var file = await storageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
-        {
-            Title = "Extract Current Page",
-            DefaultExtension = "pdf",
-            SuggestedFileName = suggestedName,
-            FileTypeChoices = new[]
-            {
-                new FilePickerFileType("PDF Files")
-                {
-                    Patterns = new[] { "*.pdf" }
-                }
-            }
-        });
-
-        if (file == null)
-            return;
-
-        var path = file.Path.LocalPath;
+        var path = await PickSavePdfPathAsync("Extract Current Page", suggestedName);
         if (!string.IsNullOrWhiteSpace(path))
             await ExtractPagesToFileAsync(path, new[] { CurrentPageIndex });
     }
@@ -1649,35 +1533,11 @@ public partial class MainWindowViewModel : ViewModelBase
         if (!_documentService.IsDocumentLoaded || selected.Count == 0)
             return;
 
-        var storageProvider = GetStorageProvider();
-        if (storageProvider == null)
-        {
-            _logger.LogWarning("Storage provider unavailable, cannot show Extract Selected Pages dialog");
-            return;
-        }
-
         var suggestedName = string.IsNullOrWhiteSpace(DocumentName)
             ? "selected-pages.pdf"
             : $"{Path.GetFileNameWithoutExtension(DocumentName)}_selected_pages.pdf";
 
-        var file = await storageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
-        {
-            Title = "Extract Selected Pages",
-            DefaultExtension = "pdf",
-            SuggestedFileName = suggestedName,
-            FileTypeChoices = new[]
-            {
-                new FilePickerFileType("PDF Files")
-                {
-                    Patterns = new[] { "*.pdf" }
-                }
-            }
-        });
-
-        if (file == null)
-            return;
-
-        var path = file.Path.LocalPath;
+        var path = await PickSavePdfPathAsync("Extract Selected Pages", suggestedName);
         if (!string.IsNullOrWhiteSpace(path))
             await ExtractPagesToFileAsync(path, selected);
     }
@@ -1806,27 +1666,8 @@ public partial class MainWindowViewModel : ViewModelBase
 
     private async Task<string?> PickPdfForPageInsertionAsync(string title)
     {
-        var storageProvider = GetStorageProvider();
-        if (storageProvider == null)
-        {
-            _logger.LogWarning("Storage provider unavailable, cannot show page insertion dialog");
-            return null;
-        }
-
-        var files = await storageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
-        {
-            Title = title,
-            AllowMultiple = false,
-            FileTypeFilter = new[]
-            {
-                new FilePickerFileType("PDF Files")
-                {
-                    Patterns = new[] { "*.pdf" }
-                }
-            }
-        });
-
-        return files.Count == 0 ? null : files[0].Path.LocalPath;
+        var files = await PickPdfFilesAsync(title, allowMultiple: false);
+        return files.Count == 0 ? null : files[0];
     }
 
     private void MarkPageOrganizationChanged(bool removedPage = false, int removedPageCount = 1)
@@ -3342,6 +3183,118 @@ public partial class MainWindowViewModel : ViewModelBase
     private IStorageProvider? GetStorageProvider()
     {
         return GetMainWindow()?.StorageProvider;
+    }
+
+    // ── Test seams for the file/folder-picker page-organization commands (#816).
+    //    Headless tests have no desktop ApplicationLifetime (GetMainWindow →
+    //    null) AND Avalonia's IStorageProvider/IStorageFile are sealed against
+    //    user implementation, so a fake provider is impossible. Instead these
+    //    delegates intercept at the picked-PATH boundary: when set, the picker
+    //    helpers below return the injected paths and skip the real dialog,
+    //    letting a test drive the actual COMMAND end-to-end. All null in
+    //    production — the real storage provider is always used. ────────────────
+    internal Func<bool, Task<IReadOnlyList<string>>>? PickPdfFilesOverride { get; set; }
+    internal Func<Task<string?>>? PickSavePdfPathOverride { get; set; }
+    internal Func<Task<string?>>? PickFolderOverride { get; set; }
+
+    /// <summary>
+    /// Shows the "open PDF(s)" picker and returns the selected local paths, or
+    /// an empty list if cancelled / unavailable. Honors
+    /// <see cref="PickPdfFilesOverride"/> in tests.
+    /// </summary>
+    private async Task<IReadOnlyList<string>> PickPdfFilesAsync(string title, bool allowMultiple)
+    {
+        if (PickPdfFilesOverride != null)
+            return await PickPdfFilesOverride(allowMultiple);
+
+        var storageProvider = GetStorageProvider();
+        if (storageProvider == null)
+        {
+            _logger.LogWarning("Storage provider unavailable, cannot show open-PDF dialog");
+            return Array.Empty<string>();
+        }
+
+        var files = await storageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
+        {
+            Title = title,
+            AllowMultiple = allowMultiple,
+            FileTypeFilter = new[]
+            {
+                new FilePickerFileType("PDF Files")
+                {
+                    Patterns = new[] { "*.pdf" }
+                }
+            }
+        });
+
+        return files
+            .Select(f => f.Path.LocalPath)
+            .Where(p => !string.IsNullOrWhiteSpace(p))
+            .ToList();
+    }
+
+    /// <summary>
+    /// Shows the "save PDF as" picker and returns the chosen local path, or
+    /// null if cancelled / unavailable. Honors
+    /// <see cref="PickSavePdfPathOverride"/> in tests.
+    /// </summary>
+    private async Task<string?> PickSavePdfPathAsync(string title, string suggestedName)
+    {
+        if (PickSavePdfPathOverride != null)
+            return await PickSavePdfPathOverride();
+
+        var storageProvider = GetStorageProvider();
+        if (storageProvider == null)
+        {
+            _logger.LogWarning("Storage provider unavailable, cannot show save-PDF dialog");
+            return null;
+        }
+
+        var file = await storageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
+        {
+            Title = title,
+            DefaultExtension = "pdf",
+            SuggestedFileName = suggestedName,
+            FileTypeChoices = new[]
+            {
+                new FilePickerFileType("PDF Files")
+                {
+                    Patterns = new[] { "*.pdf" }
+                }
+            }
+        });
+
+        var path = file?.Path.LocalPath;
+        return string.IsNullOrWhiteSpace(path) ? null : path;
+    }
+
+    /// <summary>
+    /// Shows the folder picker and returns the chosen local path, or null if
+    /// cancelled / unavailable. Honors <see cref="PickFolderOverride"/> in tests.
+    /// </summary>
+    private async Task<string?> PickFolderAsync(string title)
+    {
+        if (PickFolderOverride != null)
+            return await PickFolderOverride();
+
+        var storageProvider = GetStorageProvider();
+        if (storageProvider == null)
+        {
+            _logger.LogWarning("Storage provider unavailable, cannot show folder dialog");
+            return null;
+        }
+
+        var folder = await storageProvider.OpenFolderPickerAsync(new FolderPickerOpenOptions
+        {
+            Title = title,
+            AllowMultiple = false
+        });
+
+        if (folder.Count == 0)
+            return null;
+
+        var path = folder[0].Path.LocalPath;
+        return string.IsNullOrWhiteSpace(path) ? null : path;
     }
 
     private async Task<IStorageFile?> ShowSaveRedactedFileDialog(global::Avalonia.Controls.Window mainWindow, string suggestedPath)


### PR DESCRIPTION
## What

Closes the batch-1 coverage gap from the #816 audit: the page-organization
toolbar/menu **commands** a user actually clicks were proven only by calling the
underlying async methods (`MoveCurrentPageAsync`, `MovePageAsync`, …) or not at
all. A button mis-wired to the wrong method passed every existing test.

New `Excise.App.Tests/UI/PageOrganizationCommandTests.cs` executes the real
`vm.<Name>Command.Execute()` and asserts the real effect:

| Command | Assertion |
|---|---|
| `RotatePageLeftCommand` | `Rotation == (before+270)%360` |
| `RotatePage180Command` | `Rotation == (before+180)%360` |
| `MoveCurrentPageEarlier/LaterCommand` | moved page lands at prior/next index; `CurrentPageIndex` follows |
| `RemoveSelectedPagesCommand` | marked page gone; count −1; order correct |
| `MoveSelectedPagesEarlier/LaterCommand` | marked page relocated one slot |
| `ClearSelectedPagesCommand` | all selections unmarked |
| `AddPagesCommand` | source page appended at end |
| `InsertPagesBefore/AfterCurrentCommand` | inserted at current / current+1 index |
| `ExtractCurrentPageCommand` | output file = exactly the current page's text |
| `ExtractSelectedPagesCommand` | output = exactly the marked pages |
| `CombineDocumentsCommand` | merged page count = sum; text from **both** sources survives |
| `SplitDocumentCommand` | N one-page files written with correct content |

## Production change (test seam)

The file/folder-picker commands were undrivable headlessly: no desktop
`ApplicationLifetime` (so `GetMainWindow()` is null) **and** Avalonia's
`IStorageProvider`/`IStorageFile` are sealed against user implementation, so a
fake provider is impossible. Added three internal picked-**path** seams on
`MainWindowViewModel` — `PickPdfFilesOverride`, `PickSavePdfPathOverride`,
`PickFolderOverride` — consumed by new private picker helpers
(`PickPdfFilesAsync`/`PickSavePdfPathAsync`/`PickFolderAsync`) that the
Add/Insert/Combine/Split/Extract commands now route through. All three are null
in production, so the real storage provider is always used; the picker option
dictionaries (titles, filters, suggested names) are unchanged.

**No command mis-wiring was found** — every command routes to the correct method.

## Tests
- New suite: 15/15 pass.
- Full `Excise.App.Tests` **foreground, serial**: no host crash; 1127 passed,
  26 skipped, 1 unrelated false-red (`MouseInputTests.HoverOverLinkAnnotation_IndicatesInteractivity`,
  a contention-sensitive headless mouse-hover test — passes in isolation, does
  not touch page-organization code).
- `scripts/test-tier.sh t0`: green. Build: 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)