### PR TITLE
test: execute-and-assert GUI coverage for annotate/style + dialog/misc commands (#816 batch 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,34 @@ semantic versioning.
 
 ## [Unreleased]
 
+### Added
+- **GUI test coverage: annotate/style + dialog/misc commands, batch 4 (#816)**
+  — `AnnotateAndDialogCommandTests.cs` executes the real `ReactiveCommand`
+  behind ten toolbar/menu entries and asserts the real effect, closing a
+  false-coverage gap where these were previously proven only by calling the
+  underlying viewmodel method directly or by a `NotBeNull` wiring check (the
+  same pattern that hid #815's bug): `AddHighlightAnnotationFromSelectionCommand`
+  and `AddStickyNoteAnnotationCommand` now assert a real annotation lands on
+  the saved page's `/Annots`; `SetTypewriterColorCommand` asserts the active
+  box's `Style.Color` changes; `VerifySignaturesCommand` asserts the
+  verification summary is actually surfaced; `SecurityCommand`,
+  `ShowPreferencesCommand`, and `AboutCommand` assert the real dialog/window
+  opens; `ShowDocumentationCommand` and `ShowShortcutsCommand` assert the
+  real open/show path fires without launching a real external app or driving
+  headless overlay internals; `GoToPageCommand` asserts `CurrentPageIndex`
+  actually moves. `KeyboardShortcutTests.Ctrl2_FitsEntirePage`'s vacuous
+  `ZoomLevel > 0` assertion is replaced with a real fit-page-vs-fit-width
+  distinction, and a new `ZoomFitPageCommand` test asserts the exact computed
+  fit-page ratio on a non-square page. Two of these commands had no
+  observable test seam at all — `ShowDocumentationCommand` shelled out to
+  `Process.Start` directly, and `GetMainWindow()` resolved
+  `Application.Current.ApplicationLifetime`, which the headless test host
+  never sets (and which Avalonia refuses to set a second time, so a test
+  can't stand one up itself) — so `MainWindowViewModel` gains three small
+  internal test seams (`DocumentationOpener`, `MainWindowResolver`,
+  `KeyboardShortcutsDialogRequested`), each defaulting to the real production
+  path.
+
 ## [3.4.0] - 2026-07-27
 
 ### Added

--- a/Excise.App.Tests/UI/AnnotateAndDialogCommandTests.cs
+++ b/Excise.App.Tests/UI/AnnotateAndDialogCommandTests.cs
@@ -1,0 +1,373 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using AwesomeAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Excise.Core.Document;
+using Excise.Core.Graphics;
+using Excise.App.Services;
+using Excise.App.Tests.Utilities;
+using Excise.App.ViewModels;
+using Excise.App.Views;
+using Xunit;
+
+namespace Excise.App.Tests.UI;
+
+/// <summary>
+/// #816 batch 4: annotate/style + dialog/misc toolbar-menu commands.
+///
+/// The gap this closes: these effects were previously proven only by calling
+/// the underlying VIEWMODEL METHOD directly (<c>vm.AddStickyNoteAnnotationAsync(...)</c>,
+/// <c>vm.SetTypewriterColor(...)</c>) or via a <c>CommandBindingSweep</c>/
+/// <c>NotBeNull</c> check — never by executing the actual
+/// <c>ReactiveCommand</c> the toolbar/menu is bound to. A button mis-wired to
+/// the wrong method would pass every one of those tests (the same
+/// false-coverage pattern #815 hid a real bug behind). Every test here
+/// executes the real <c>*Command.Execute()</c> and asserts the real effect.
+/// </summary>
+[Collection("AvaloniaTests")]
+public class AnnotateAndDialogCommandTests
+{
+    // ---------------------------------------------------------------
+    // Annotate / style
+    // ---------------------------------------------------------------
+
+    [FixedAvaloniaFact]
+    public async Task AddHighlightAnnotationFromSelectionCommand_WithActiveSelection_CreatesHighlightAnnotation()
+    {
+        var (source, output, dir) = MakePaths();
+        TestPdfGenerator.CreateSimpleTextPdf(source, "Selectable clause text");
+
+        var vm = new MainWindowViewModel();
+        var window = new MainWindow { DataContext = vm, Width = 1280, Height = 900 };
+        window.Show();
+        await vm.LoadDocumentAsync(source);
+
+        vm.CurrentTextSelectionPageArea = PdfPageRect.ViewerDips(
+            1, x: 120, y: 120, width: 180, height: 30,
+            renderDpi: MainWindowViewModel.DefaultViewerRenderDpi);
+        vm.SelectedText = "Selected clause";
+
+        await vm.AddHighlightAnnotationFromSelectionCommand.Execute();
+
+        await vm.SaveFileAsAsync(output);
+        using var saved = PdfDocument.Open(output);
+        saved.GetPage(1).GetAnnotations().Should().Contain(a =>
+            a.Subtype == PdfAnnotationSubtype.Highlight && a.Contents == "Selected clause",
+            "executing the real command must produce a real Highlight annotation on the page, not just prove the underlying method works");
+
+        window.Close();
+        Cleanup(dir);
+    }
+
+    [FixedAvaloniaFact]
+    public async Task AddStickyNoteAnnotationCommand_CreatesTextAnnotation()
+    {
+        var (source, output, dir) = MakePaths();
+        TestPdfGenerator.CreateSimpleTextPdf(source, "Body text");
+
+        var vm = new MainWindowViewModel();
+        var window = new MainWindow { DataContext = vm, Width = 1280, Height = 900 };
+        window.Show();
+        await vm.LoadDocumentAsync(source);
+
+        // No override parameter — this is exactly what the toolbar button and
+        // menu item invoke. The default (null) dialog service's PromptTextAsync
+        // returns the passed-through default text, so the command must still
+        // create a sticky note end to end.
+        await vm.AddStickyNoteAnnotationCommand.Execute();
+
+        await vm.SaveFileAsAsync(output);
+        using var saved = PdfDocument.Open(output);
+        saved.GetPage(1).GetAnnotations().Should().Contain(a =>
+            a.Subtype == PdfAnnotationSubtype.Text && a.Contents == MainWindowViewModel.DefaultStickyNoteText,
+            "executing the real toolbar command (no override) must create a real Text annotation on the page");
+
+        window.Close();
+        Cleanup(dir);
+    }
+
+    [FixedAvaloniaFact]
+    public async Task SetTypewriterColorCommand_AppliesHexColorToTheActiveBox()
+    {
+        var (source, _, dir) = MakePaths();
+        TestPdfGenerator.CreateSimpleTextPdf(source, "Original text");
+
+        var vm = new MainWindowViewModel();
+        var window = new MainWindow { DataContext = vm, Width = 1280, Height = 900 };
+        window.Show();
+        await vm.LoadDocumentAsync(source);
+
+        vm.IsTypewriterMode = true;
+        vm.OnTypewriterTextCreated(new PdfRectangle(72, 620, 300, 660), 1);
+
+        await vm.SetTypewriterColorCommand.Execute("#00FF00");
+
+        var op = vm.TypewriterTextOperations.Single();
+        op.Style.Color.R.Should().BeApproximately(0.0, 0.01);
+        op.Style.Color.G.Should().BeApproximately(1.0, 0.01);
+        op.Style.Color.B.Should().BeApproximately(0.0, 0.01);
+
+        window.Close();
+        Cleanup(dir);
+    }
+
+    // ---------------------------------------------------------------
+    // Dialogs
+    // ---------------------------------------------------------------
+
+    [FixedAvaloniaFact]
+    public async Task VerifySignaturesCommand_OnLoadedDocument_SurfacesVerificationSummary()
+    {
+        var (source, _, dir) = MakePaths();
+        TestPdfGenerator.CreateSimpleTextPdf(source, "Unsigned content");
+
+        var dialog = new RecordingDialogService();
+        var vm = CreateViewModelWithDialog(dialog);
+        var window = new MainWindow { DataContext = vm, Width = 1280, Height = 900 };
+        window.Show();
+        await vm.LoadDocumentAsync(source);
+
+        await vm.VerifySignaturesCommand.Execute();
+
+        dialog.Messages.Should().ContainSingle(m => m.Title == "Verify Signatures",
+            "executing the real command must run the verification workflow, not merely exist");
+        dialog.Messages.Single().Message.Should().Contain("No digital signatures were found",
+            "the results surface must actually be populated with the real verification outcome");
+
+        window.Close();
+        Cleanup(dir);
+    }
+
+    [FixedAvaloniaFact]
+    public async Task SecurityCommand_OnLoadedDocument_OpensTheSecurityDialogWindow()
+    {
+        var (source, _, dir) = MakePaths();
+        TestPdfGenerator.CreateSimpleTextPdf(source, "Body");
+
+        var vm = new MainWindowViewModel();
+        var window = new MainWindow { DataContext = vm, Width = 1280, Height = 900 };
+        window.Show();
+        await vm.LoadDocumentAsync(source);
+
+        vm.MainWindowResolver = () => window;
+
+        // ShowSecurityDialogAsync awaits ShowDialog(owner) until the dialog
+        // closes, so awaiting Execute() directly here would hang the test
+        // until we've already closed the window we haven't found yet. Fire
+        // it and pump the dispatcher instead.
+        vm.SecurityCommand.Execute().Subscribe();
+        await KeyboardTestHelpers.FlushDispatcherAsync();
+        await KeyboardTestHelpers.FlushDispatcherAsync();
+
+        var securityDialog = window.OwnedWindows.OfType<SecurityDialog>().SingleOrDefault();
+        securityDialog.Should().NotBeNull(
+            "executing SecurityCommand must open the real Security dialog window, not just be wired to something");
+
+        securityDialog!.Close();
+        await KeyboardTestHelpers.FlushDispatcherAsync();
+
+        window.Close();
+        Cleanup(dir);
+    }
+
+    [FixedAvaloniaFact]
+    public async Task ShowPreferencesCommand_OpensThePreferencesWindow()
+    {
+        var (source, _, dir) = MakePaths();
+        TestPdfGenerator.CreateSimpleTextPdf(source, "Body");
+
+        var vm = new MainWindowViewModel();
+        var window = new MainWindow { DataContext = vm, Width = 1280, Height = 900 };
+        window.Show();
+        await vm.LoadDocumentAsync(source);
+
+        vm.MainWindowResolver = () => window;
+
+        await vm.ShowPreferencesCommand.Execute();
+        await KeyboardTestHelpers.FlushDispatcherAsync();
+
+        var preferencesWindow = window.OwnedWindows.OfType<PreferencesWindow>().SingleOrDefault();
+        preferencesWindow.Should().NotBeNull(
+            "executing ShowPreferencesCommand must open the real Preferences window, not just be wired to something");
+
+        preferencesWindow!.Close();
+        await KeyboardTestHelpers.FlushDispatcherAsync();
+
+        window.Close();
+        Cleanup(dir);
+    }
+
+    [FixedAvaloniaFact]
+    public async Task AboutCommand_OpensTheAboutWindow()
+    {
+        var vm = new MainWindowViewModel();
+        var window = new MainWindow { DataContext = vm, Width = 1280, Height = 900 };
+        window.Show();
+
+        vm.MainWindowResolver = () => window;
+
+        await vm.AboutCommand.Execute();
+        await KeyboardTestHelpers.FlushDispatcherAsync();
+
+        var aboutWindow = window.OwnedWindows.OfType<AboutWindow>().SingleOrDefault();
+        aboutWindow.Should().NotBeNull(
+            "executing AboutCommand must open the real About window, not just be wired to something");
+
+        aboutWindow!.Close();
+        await KeyboardTestHelpers.FlushDispatcherAsync();
+
+        window.Close();
+    }
+
+    [FixedAvaloniaFact]
+    public async Task ShowShortcutsCommand_RequestsTheKeyboardShortcutsDialog()
+    {
+        var vm = new MainWindowViewModel();
+        var window = new MainWindow { DataContext = vm, Width = 1280, Height = 900 };
+        window.Show();
+
+        vm.MainWindowResolver = () => window;
+
+        FluentAvalonia.UI.Controls.FAContentDialog? requested = null;
+        vm.KeyboardShortcutsDialogRequested = dialog => requested = dialog;
+
+        await vm.ShowShortcutsCommand.Execute();
+
+        requested.Should().NotBeNull(
+            "executing ShowShortcutsCommand must actually construct and request the real shortcuts dialog, not just be wired to something");
+        requested!.Title.Should().Be("Keyboard Shortcuts");
+        requested.Content.Should().BeOfType<string>()
+            .Which.Should().Contain("Ctrl+F - Find");
+
+        window.Close();
+    }
+
+    [FixedAvaloniaFact]
+    public async Task ShowDocumentationCommand_InvokesTheDocumentationOpenPath()
+    {
+        var vm = new MainWindowViewModel();
+        var opened = new System.Collections.Generic.List<string>();
+        vm.DocumentationOpener = target => opened.Add(target);
+
+        await vm.ShowDocumentationCommand.Execute();
+
+        opened.Should().ContainSingle(
+            "executing the real command must invoke the doc-open path exactly once, without launching a real external app/browser in the test host");
+        opened[0].Should().Match(t => t.EndsWith("README.md", StringComparison.Ordinal) ||
+                                       t.Contains("github.com/marctjones/excise", StringComparison.Ordinal),
+            "the invoked target must be the README path or the GitHub fallback URL the command documents");
+    }
+
+    // ---------------------------------------------------------------
+    // Misc
+    // ---------------------------------------------------------------
+
+    [FixedAvaloniaFact]
+    public async Task ZoomFitPageCommand_ComputesTheFitPageRatio_DistinctFromFitWidth()
+    {
+        var (source, _, dir) = MakePaths();
+        const double widthPoints = 400;
+        const double heightPoints = 800;
+        TestPdfGenerator.CreateCustomSizePdf(source, widthPoints, heightPoints);
+
+        var vm = new MainWindowViewModel();
+        var window = new MainWindow { DataContext = vm, Width = 1280, Height = 900 };
+        window.Show();
+        await vm.LoadDocumentAsync(source);
+
+        vm.ViewportWidth = 1000;
+        vm.ViewportHeight = 700;
+
+        const double dipsPerPoint = 96.0 / 72.0;
+        var pageWidthDip = widthPoints * dipsPerPoint;
+        var pageHeightDip = heightPoints * dipsPerPoint;
+        const double margin = 8;
+        var expectedFitWidth = Math.Clamp((vm.ViewportWidth - margin) / pageWidthDip, 0.25, 5.0);
+        var expectedFitPage = Math.Clamp(
+            Math.Min((vm.ViewportWidth - margin) / pageWidthDip, (vm.ViewportHeight - margin) / pageHeightDip),
+            0.25, 5.0);
+        Math.Abs(expectedFitPage - expectedFitWidth).Should().BeGreaterThan(0.1,
+            "the fixture must be a non-square page/viewport combination or this test can't tell fit-page from fit-width apart");
+
+        await vm.ZoomFitPageCommand.Execute();
+
+        vm.ZoomLevel.Should().BeApproximately(expectedFitPage, 0.01,
+            "ZoomFitPageCommand must compute the fit-PAGE ratio (bound by whichever dimension is the tighter constraint), not merely leave zoom > 0");
+        Math.Abs(vm.ZoomLevel - expectedFitWidth).Should().BeGreaterThan(0.1,
+            "on this non-square page, fit-page and fit-width must produce genuinely different zoom levels");
+
+        window.Close();
+        Cleanup(dir);
+    }
+
+    [FixedAvaloniaFact]
+    public async Task GoToPageCommand_NavigatesToTheRequestedPage()
+    {
+        var (source, _, dir) = MakePaths();
+        TestPdfGenerator.CreateMultiPagePdf(source, 5);
+
+        var vm = new MainWindowViewModel();
+        var window = new MainWindow { DataContext = vm, Width = 1280, Height = 900 };
+        window.Show();
+        await vm.LoadDocumentAsync(source);
+
+        vm.CurrentPageIndex.Should().Be(0);
+
+        await vm.GoToPageCommand.Execute(3);
+
+        vm.CurrentPageIndex.Should().Be(3,
+            "executing the real command must move CurrentPageIndex, not just accept the call");
+
+        window.Close();
+        Cleanup(dir);
+    }
+
+    // ---------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------
+
+    private sealed class RecordingDialogService : IUserDialogService
+    {
+        public System.Collections.Generic.List<(string Title, string Message)> Messages { get; } = new();
+
+        public Task ShowMessageAsync(string title, string message)
+        {
+            Messages.Add((title, message));
+            return Task.CompletedTask;
+        }
+    }
+
+    private static MainWindowViewModel CreateViewModelWithDialog(IUserDialogService dialogService)
+    {
+        var loggerFactory = NullLoggerFactory.Instance;
+        return new MainWindowViewModel(
+            NullLogger<MainWindowViewModel>.Instance,
+            loggerFactory,
+            new PdfDocumentService(NullLogger<PdfDocumentService>.Instance),
+            new PdfRenderService(NullLogger<PdfRenderService>.Instance),
+            new RedactionService(NullLogger<RedactionService>.Instance, loggerFactory),
+            new PdfTextExtractionService(NullLogger<PdfTextExtractionService>.Instance),
+            new PdfSearchService(NullLogger<PdfSearchService>.Instance),
+            new SignatureVerificationService(NullLogger<SignatureVerificationService>.Instance),
+            new FilenameSuggestionService(),
+            new ToastService(),
+            dialogService: dialogService);
+    }
+
+    private static (string source, string output, string dir) MakePaths()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "Excise.AppAnnotateDialogTests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        return (Path.Combine(tempDir, "source.pdf"), Path.Combine(tempDir, "output.pdf"), tempDir);
+    }
+
+    private static void Cleanup(string dir)
+    {
+        try { if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true); }
+        catch { }
+    }
+}

--- a/Excise.App.Tests/UI/KeyboardShortcutTests.cs
+++ b/Excise.App.Tests/UI/KeyboardShortcutTests.cs
@@ -704,9 +704,29 @@ public class KeyboardShortcutTests
         await window.PressKeyAsync(Key.D2, RawInputModifiers.Control);
         await KeyboardTestHelpers.FlushDispatcherAsync();
         await Task.Delay(100);
+        var fitPageZoom = vm.ZoomLevel;
 
-        // Assert
-        vm.ZoomLevel.Should().BeGreaterThan(0, "Ctrl+2 should fit entire page");
+        // Assert: `BeGreaterThan(0)` alone is vacuous — ZoomLevel is >0 by
+        // construction/clamping in every zoom path, so it can't tell a
+        // correctly-computed fit-page ratio apart from a no-op or a
+        // fit-WIDTH ratio landing here by mistake (#816). The default
+        // multi-page fixture's page is portrait (non-square), so on a
+        // non-square viewport fit-page (constrained by height too) must
+        // differ from fit-width (constrained by width alone) — assert that
+        // distinction directly using the real ZoomFitWidthCommand as the
+        // comparison, not a hard-coded geometry recomputation (the exact
+        // ratio math is covered independently by
+        // AnnotateAndDialogCommandTests.ZoomFitPageCommand_ComputesTheFitPageRatio_DistinctFromFitWidth).
+        fitPageZoom.Should().BeGreaterThan(0, "Ctrl+2 should fit entire page");
+
+        vm.ZoomFitWidthCommand.Execute().Subscribe();
+        await KeyboardTestHelpers.FlushDispatcherAsync();
+        await Task.Delay(100);
+        var fitWidthZoom = vm.ZoomLevel;
+
+        Math.Abs(fitPageZoom - fitWidthZoom).Should().BeGreaterThan(0.01,
+            "Ctrl+2 must route to the fit-PAGE ratio, which is distinct from fit-width on this non-square page — " +
+            "not merely leave ZoomLevel at some positive value");
     }
 
     #endregion

--- a/Excise.App/ViewModels/MainWindowViewModel.cs
+++ b/Excise.App/ViewModels/MainWindowViewModel.cs
@@ -3261,40 +3261,65 @@ public partial class MainWindowViewModel : ViewModelBase
         _ = dialog.ShowDialog(owner);
     }
 
-    private async void ShowKeyboardShortcuts()
+    /// <summary>
+    /// Seam for #816: the real path calls <c>FAContentDialog.ShowAsync()</c>,
+    /// which is not a <see cref="global::Avalonia.Controls.Window"/> (it
+    /// renders into an overlay layer rather than
+    /// <c>Window.OwnedWindows</c>) and awaits until the user dismisses it —
+    /// there is no way for a headless test to observe or close it without
+    /// driving overlay/adorner internals that no other test in this suite
+    /// touches. Test-settable so <see cref="ShowShortcutsCommand"/> can be
+    /// executed for real and the constructed dialog inspected without
+    /// actually presenting/blocking on the overlay. Defaults to the real
+    /// show so production behaviour is unchanged.
+    /// </summary>
+    internal Action<FluentAvalonia.UI.Controls.FAContentDialog> KeyboardShortcutsDialogRequested { get; set; } =
+        dialog => _ = dialog.ShowAsync();
+
+    private void ShowKeyboardShortcuts()
     {
         _logger.LogInformation("Keyboard shortcuts dialog requested");
 
         var window = GetMainWindow();
-        if (window != null)
-        {
-            var messageBox = new FluentAvalonia.UI.Controls.FAContentDialog
-            {
-                Title = "Keyboard Shortcuts",
-                Content = "File:\n" +
-                          "  Ctrl+O - Open PDF\n" +
-                          "  Ctrl+S - Save\n" +
-                          "  Ctrl+Shift+S - Save As\n" +
-                          "  Ctrl+W - Close Document\n\n" +
-                          "Edit:\n" +
-                          "  Ctrl+F - Find\n" +
-                          "  F3 - Find Next\n" +
-                          "  Shift+F3 - Find Previous\n" +
-                          "  T - Toggle Text Selection Mode\n" +
-                          "  R - Toggle Redaction Mode\n\n" +
-                          "View:\n" +
-                          "  Ctrl++ - Zoom In\n" +
-                          "  Ctrl+- - Zoom Out\n" +
-                          "  Ctrl+0 - Actual Size\n\n" +
-                          "Navigation:\n" +
-                          "  PgUp/PgDn - Previous/Next Page",
-                CloseButtonText = "Close",
-                DefaultButton = FluentAvalonia.UI.Controls.FAContentDialogButton.Close
-            };
+        if (window == null) return;
 
-            await messageBox.ShowAsync();
-        }
+        var messageBox = new FluentAvalonia.UI.Controls.FAContentDialog
+        {
+            Title = "Keyboard Shortcuts",
+            Content = "File:\n" +
+                      "  Ctrl+O - Open PDF\n" +
+                      "  Ctrl+S - Save\n" +
+                      "  Ctrl+Shift+S - Save As\n" +
+                      "  Ctrl+W - Close Document\n\n" +
+                      "Edit:\n" +
+                      "  Ctrl+F - Find\n" +
+                      "  F3 - Find Next\n" +
+                      "  Shift+F3 - Find Previous\n" +
+                      "  T - Toggle Text Selection Mode\n" +
+                      "  R - Toggle Redaction Mode\n\n" +
+                      "View:\n" +
+                      "  Ctrl++ - Zoom In\n" +
+                      "  Ctrl+- - Zoom Out\n" +
+                      "  Ctrl+0 - Actual Size\n\n" +
+                      "Navigation:\n" +
+                      "  PgUp/PgDn - Previous/Next Page",
+            CloseButtonText = "Close",
+            DefaultButton = FluentAvalonia.UI.Controls.FAContentDialogButton.Close
+        };
+
+        KeyboardShortcutsDialogRequested(messageBox);
     }
+
+    /// <summary>
+    /// Seam for #816: the real path shells out to the OS default handler
+    /// (via <see cref="Services.UrlOpener"/>), which is not an observable
+    /// effect a headless test can assert on without actually launching a
+    /// real external app/browser. Test-settable so
+    /// <see cref="ShowDocumentationCommand"/> can be executed for real and
+    /// the open request asserted without that side effect. Defaults to the
+    /// real opener so production behaviour is unchanged.
+    /// </summary>
+    internal Action<string> DocumentationOpener { get; set; } = Services.UrlOpener.Open;
 
     private void ShowDocumentation()
     {
@@ -3304,26 +3329,9 @@ public partial class MainWindowViewModel : ViewModelBase
         {
             var readmePath = System.IO.Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "README.md");
 
-            if (System.IO.File.Exists(readmePath))
-            {
-                // Open README.md with default application
-                var psi = new System.Diagnostics.ProcessStartInfo
-                {
-                    FileName = readmePath,
-                    UseShellExecute = true
-                };
-                System.Diagnostics.Process.Start(psi);
-            }
-            else
-            {
-                // Fallback to GitHub repository
-                var psi = new System.Diagnostics.ProcessStartInfo
-                {
-                    FileName = "https://github.com/marctjones/excise",
-                    UseShellExecute = true
-                };
-                System.Diagnostics.Process.Start(psi);
-            }
+            DocumentationOpener(System.IO.File.Exists(readmePath)
+                ? readmePath
+                : "https://github.com/marctjones/excise");
         }
         catch (Exception ex)
         {
@@ -3331,13 +3339,32 @@ public partial class MainWindowViewModel : ViewModelBase
         }
     }
 
-    private global::Avalonia.Controls.Window? GetMainWindow()
+    /// <summary>
+    /// Seam for #816: dialog commands (Security/Preferences/About/…) resolve
+    /// their owner window through this, normally reading
+    /// <c>Application.Current.ApplicationLifetime</c>. Avalonia allows
+    /// <c>ApplicationLifetime</c> to be set exactly once — a headless test
+    /// cannot stand up a desktop lifetime after <c>SetupWithoutStarting</c>
+    /// has already initialized the app (attempting it throws
+    /// <see cref="InvalidOperationException"/>) — so without this seam the
+    /// real owner-window path is unreachable from a test and these
+    /// commands' dialogs go untested (see <see cref="GetMainWindow"/>'s
+    /// previous no-desktop-lifetime-in-headless-tests comment history).
+    /// Test-settable so the real command can be executed and the real
+    /// dialog window observed. Defaults to the real lookup so production
+    /// behaviour is unchanged.
+    /// </summary>
+    internal Func<global::Avalonia.Controls.Window?> MainWindowResolver { get; set; } = DefaultMainWindowResolver;
+
+    private static global::Avalonia.Controls.Window? DefaultMainWindowResolver()
     {
         var lifetime = global::Avalonia.Application.Current?.ApplicationLifetime
             as IClassicDesktopStyleApplicationLifetime;
 
         return lifetime?.MainWindow;
     }
+
+    private global::Avalonia.Controls.Window? GetMainWindow() => MainWindowResolver();
 
     private IStorageProvider? GetStorageProvider()
     {


### PR DESCRIPTION
## Summary
- Closes the batch-4 slice of #816: ten toolbar/menu commands (annotate/style + dialogs/misc) were previously proven only by calling the underlying viewmodel method directly or via a `NotBeNull` wiring check — never by executing the actual `ReactiveCommand` the button/menu item is bound to. New `AnnotateAndDialogCommandTests.cs` executes the real command and asserts the real effect for all ten.
- Two commands had no observable test seam at all (`ShowDocumentationCommand` shelled out to `Process.Start` directly; the Security/Preferences/About dialogs resolve their owner window via `Application.Current.ApplicationLifetime`, which the headless test host never sets and which Avalonia refuses to set a second time — confirmed empirically before committing to the approach). `MainWindowViewModel` gains three small internal test seams (`DocumentationOpener`, `MainWindowResolver`, `KeyboardShortcutsDialogRequested`), each defaulting to the real production path.
- Replaces the vacuous `ZoomLevel > 0` assertion in `KeyboardShortcutTests.Ctrl2_FitsEntirePage` with a real fit-page-vs-fit-width distinction, plus a new dedicated `ZoomFitPageCommand` test asserting the exact computed fit-page ratio on a non-square page.
- No command was found mis-wired to the wrong method — all ten route correctly to their intended effect.

## Command → test → assertion
| Command | Test | Real assertion |
|---|---|---|
| `AddHighlightAnnotationFromSelectionCommand` | `AddHighlightAnnotationFromSelectionCommand_WithActiveSelection_CreatesHighlightAnnotation` | Saved page's `/Annots` contains a Highlight annotation with the selected text |
| `AddStickyNoteAnnotationCommand` | `AddStickyNoteAnnotationCommand_CreatesTextAnnotation` | Saved page's `/Annots` contains a Text annotation (default text, no override param — exactly what the toolbar invokes) |
| `SetTypewriterColorCommand` | `SetTypewriterColorCommand_AppliesHexColorToTheActiveBox` | Active typewriter box's `Style.Color` matches the hex param |
| `VerifySignaturesCommand` | `VerifySignaturesCommand_OnLoadedDocument_SurfacesVerificationSummary` | Dialog service receives the real verification summary text |
| `SecurityCommand` | `SecurityCommand_OnLoadedDocument_OpensTheSecurityDialogWindow` | Real `SecurityDialog` window appears in `window.OwnedWindows` |
| `ShowPreferencesCommand` | `ShowPreferencesCommand_OpensThePreferencesWindow` | Real `PreferencesWindow` appears in `window.OwnedWindows` |
| `AboutCommand` | `AboutCommand_OpensTheAboutWindow` | Real `AboutWindow` appears in `window.OwnedWindows` |
| `ShowShortcutsCommand` | `ShowShortcutsCommand_RequestsTheKeyboardShortcutsDialog` | Real `FAContentDialog` constructed with correct title/content, via the new `KeyboardShortcutsDialogRequested` seam (FAContentDialog isn't a `Window`, so it can't be observed via `OwnedWindows`) |
| `ShowDocumentationCommand` | `ShowDocumentationCommand_InvokesTheDocumentationOpenPath` | `DocumentationOpener` invoked once with the README path or GitHub fallback URL, without launching a real external app |
| `ZoomFitPageCommand` | `ZoomFitPageCommand_ComputesTheFitPageRatio_DistinctFromFitWidth` | `ZoomLevel` equals the computed fit-page ratio and differs from fit-width on a non-square page |
| `GoToPageCommand` | `GoToPageCommand_NavigatesToTheRequestedPage` | `CurrentPageIndex` moves to the requested index |

## Test plan
- [x] `dotnet test Excise.App.Tests` (foreground, serial, full suite): **1150 total, 1124 passed, 26 skipped, 0 failed**, no host crash (#363)
- [x] `scripts/test-tier.sh t0`: all green (build, Core/Cli/Avalonia tests, doc-claims, gate-asymmetry, redaction-architecture guard, testdata-sync, skip-budget-selftest)
- [x] `dotnet test --filter DocumentationClaimTests`: 21/21 passed (no menu-text/`MacNativeMenuBuilder` changes, but ran it anyway since it's cheap)
- [x] Build: 0 warnings, 0 errors
- [x] `CHANGELOG.md` `[Unreleased]` entry added
- [x] No TODO comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)