### PR TITLE
test(#816): GUI command coverage — page-org, file-ops, redaction+search, annotate/dialogs (batches 1-4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,21 @@ semantic versioning.
 
 ## [Unreleased]
 
-## [3.4.0] - 2026-07-27
+### Added
+- **Interactive GUI-command coverage for redaction and search (#816, batch 3)**
+  — `RedactionAndSearchCommandTests` executes the real ReactiveCommands behind
+  the redaction buttons and search bar (`ApplyAllRedactionsCommand`,
+  `ApplyRedactionCommand`, `ClearAllRedactionsCommand`,
+  `RemovePendingRedactionCommand`, `FindCommand`, `FindNextCommand`,
+  `FindPreviousCommand`, `JumpToSearchMatchCommand`, `CloseSearchCommand`) and
+  asserts their real effects — closing a gap where redaction removal had only
+  been proven through the scripting path / "doc still open", never by executing
+  the actual Apply command. `ApplyAllRedactionsCommand` now runs end-to-end in
+  headless tests via a small test-only save-path seam
+  (`SetRedactedSavePathProviderForTests`), and removal is verified with
+  independent oracles per the no-self-oracle rule: a carrier-agnostic saved-bytes
+  scan (ASCII + UTF-16BE) with an in-file negative control, plus an independent
+  mutool extraction (skips cleanly on tool-less CI, allow-listed).
 
 ### Added
 - **PDF/UA-1 and PDF/A conformance checker** (#772) — a new

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ semantic versioning.
 
 ## [Unreleased]
 
+### Added
+- **Interactive GUI tests for page-organization toolbar/menu commands** (#816)
+  — a new `PageOrganizationCommandTests` suite executes the real
+  `MainWindowViewModel` commands a user clicks (Combine, Split, Add/Insert
+  Before/After, Extract Current/Selected, Remove/Move/Clear Selected, Move
+  Current Earlier/Later, Rotate Left/180) and asserts the resulting page
+  order, count, rotation, or saved-file content — closing an audit gap where
+  these effects were proven only by calling the underlying async methods, so a
+  button mis-wired to the wrong method would have passed. To make the
+  file/folder-picker commands drivable headlessly (no desktop lifetime, and
+  Avalonia's storage interfaces are sealed against user implementation), the
+  view-model gained internal picked-path test seams (`PickPdfFilesOverride`,
+  `PickSavePdfPathOverride`, `PickFolderOverride`) that the picker helpers
+  honor; all null in production, so the real storage provider is always used.
+  No command mis-wiring was found.
+
 ## [3.4.0] - 2026-07-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,34 @@ semantic versioning.
 
 ## [Unreleased]
 
+### Added
+- **GUI test coverage: annotate/style + dialog/misc commands, batch 4 (#816)**
+  — `AnnotateAndDialogCommandTests.cs` executes the real `ReactiveCommand`
+  behind ten toolbar/menu entries and asserts the real effect, closing a
+  false-coverage gap where these were previously proven only by calling the
+  underlying viewmodel method directly or by a `NotBeNull` wiring check (the
+  same pattern that hid #815's bug): `AddHighlightAnnotationFromSelectionCommand`
+  and `AddStickyNoteAnnotationCommand` now assert a real annotation lands on
+  the saved page's `/Annots`; `SetTypewriterColorCommand` asserts the active
+  box's `Style.Color` changes; `VerifySignaturesCommand` asserts the
+  verification summary is actually surfaced; `SecurityCommand`,
+  `ShowPreferencesCommand`, and `AboutCommand` assert the real dialog/window
+  opens; `ShowDocumentationCommand` and `ShowShortcutsCommand` assert the
+  real open/show path fires without launching a real external app or driving
+  headless overlay internals; `GoToPageCommand` asserts `CurrentPageIndex`
+  actually moves. `KeyboardShortcutTests.Ctrl2_FitsEntirePage`'s vacuous
+  `ZoomLevel > 0` assertion is replaced with a real fit-page-vs-fit-width
+  distinction, and a new `ZoomFitPageCommand` test asserts the exact computed
+  fit-page ratio on a non-square page. Two of these commands had no
+  observable test seam at all — `ShowDocumentationCommand` shelled out to
+  `Process.Start` directly, and `GetMainWindow()` resolved
+  `Application.Current.ApplicationLifetime`, which the headless test host
+  never sets (and which Avalonia refuses to set a second time, so a test
+  can't stand one up itself) — so `MainWindowViewModel` gains three small
+  internal test seams (`DocumentationOpener`, `MainWindowResolver`,
+  `KeyboardShortcutsDialogRequested`), each defaulting to the real production
+  path.
+
 ## [3.4.0] - 2026-07-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ semantic versioning.
 
 ## [Unreleased]
 
+### Added
+- **Interactive GUI tests for file-ops toolbar/menu commands** (#816 batch 2)
+  — `Excise.App.Tests/UI/FileOpsCommandTests.cs` executes the real
+  `ReactiveCommand` behind Save/SaveAs/SaveFlattenedFormCopy/Open/LoadRecent/
+  ExportCurrentPage/ExportPages/Print and asserts the effect (bytes on disk,
+  loaded-document state, exported PNGs, or the shown dialog message), closing
+  a false-coverage gap where these were previously only exercised via their
+  underlying async method with an already-known path — a mis-wired command
+  would have passed every existing test. `MainWindowViewModel` gained a small
+  test seam, `StorageProviderOverride`, since the headless test host runs
+  with no desktop lifetime and `GetStorageProvider()` otherwise always
+  resolves to null.
+
 ## [3.4.0] - 2026-07-27
 
 ### Added

--- a/Excise.App.Tests/UI/AnnotateAndDialogCommandTests.cs
+++ b/Excise.App.Tests/UI/AnnotateAndDialogCommandTests.cs
@@ -1,0 +1,373 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using AwesomeAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Excise.Core.Document;
+using Excise.Core.Graphics;
+using Excise.App.Services;
+using Excise.App.Tests.Utilities;
+using Excise.App.ViewModels;
+using Excise.App.Views;
+using Xunit;
+
+namespace Excise.App.Tests.UI;
+
+/// <summary>
+/// #816 batch 4: annotate/style + dialog/misc toolbar-menu commands.
+///
+/// The gap this closes: these effects were previously proven only by calling
+/// the underlying VIEWMODEL METHOD directly (<c>vm.AddStickyNoteAnnotationAsync(...)</c>,
+/// <c>vm.SetTypewriterColor(...)</c>) or via a <c>CommandBindingSweep</c>/
+/// <c>NotBeNull</c> check — never by executing the actual
+/// <c>ReactiveCommand</c> the toolbar/menu is bound to. A button mis-wired to
+/// the wrong method would pass every one of those tests (the same
+/// false-coverage pattern #815 hid a real bug behind). Every test here
+/// executes the real <c>*Command.Execute()</c> and asserts the real effect.
+/// </summary>
+[Collection("AvaloniaTests")]
+public class AnnotateAndDialogCommandTests
+{
+    // ---------------------------------------------------------------
+    // Annotate / style
+    // ---------------------------------------------------------------
+
+    [FixedAvaloniaFact]
+    public async Task AddHighlightAnnotationFromSelectionCommand_WithActiveSelection_CreatesHighlightAnnotation()
+    {
+        var (source, output, dir) = MakePaths();
+        TestPdfGenerator.CreateSimpleTextPdf(source, "Selectable clause text");
+
+        var vm = new MainWindowViewModel();
+        var window = new MainWindow { DataContext = vm, Width = 1280, Height = 900 };
+        window.Show();
+        await vm.LoadDocumentAsync(source);
+
+        vm.CurrentTextSelectionPageArea = PdfPageRect.ViewerDips(
+            1, x: 120, y: 120, width: 180, height: 30,
+            renderDpi: MainWindowViewModel.DefaultViewerRenderDpi);
+        vm.SelectedText = "Selected clause";
+
+        await vm.AddHighlightAnnotationFromSelectionCommand.Execute();
+
+        await vm.SaveFileAsAsync(output);
+        using var saved = PdfDocument.Open(output);
+        saved.GetPage(1).GetAnnotations().Should().Contain(a =>
+            a.Subtype == PdfAnnotationSubtype.Highlight && a.Contents == "Selected clause",
+            "executing the real command must produce a real Highlight annotation on the page, not just prove the underlying method works");
+
+        window.Close();
+        Cleanup(dir);
+    }
+
+    [FixedAvaloniaFact]
+    public async Task AddStickyNoteAnnotationCommand_CreatesTextAnnotation()
+    {
+        var (source, output, dir) = MakePaths();
+        TestPdfGenerator.CreateSimpleTextPdf(source, "Body text");
+
+        var vm = new MainWindowViewModel();
+        var window = new MainWindow { DataContext = vm, Width = 1280, Height = 900 };
+        window.Show();
+        await vm.LoadDocumentAsync(source);
+
+        // No override parameter — this is exactly what the toolbar button and
+        // menu item invoke. The default (null) dialog service's PromptTextAsync
+        // returns the passed-through default text, so the command must still
+        // create a sticky note end to end.
+        await vm.AddStickyNoteAnnotationCommand.Execute();
+
+        await vm.SaveFileAsAsync(output);
+        using var saved = PdfDocument.Open(output);
+        saved.GetPage(1).GetAnnotations().Should().Contain(a =>
+            a.Subtype == PdfAnnotationSubtype.Text && a.Contents == MainWindowViewModel.DefaultStickyNoteText,
+            "executing the real toolbar command (no override) must create a real Text annotation on the page");
+
+        window.Close();
+        Cleanup(dir);
+    }
+
+    [FixedAvaloniaFact]
+    public async Task SetTypewriterColorCommand_AppliesHexColorToTheActiveBox()
+    {
+        var (source, _, dir) = MakePaths();
+        TestPdfGenerator.CreateSimpleTextPdf(source, "Original text");
+
+        var vm = new MainWindowViewModel();
+        var window = new MainWindow { DataContext = vm, Width = 1280, Height = 900 };
+        window.Show();
+        await vm.LoadDocumentAsync(source);
+
+        vm.IsTypewriterMode = true;
+        vm.OnTypewriterTextCreated(new PdfRectangle(72, 620, 300, 660), 1);
+
+        await vm.SetTypewriterColorCommand.Execute("#00FF00");
+
+        var op = vm.TypewriterTextOperations.Single();
+        op.Style.Color.R.Should().BeApproximately(0.0, 0.01);
+        op.Style.Color.G.Should().BeApproximately(1.0, 0.01);
+        op.Style.Color.B.Should().BeApproximately(0.0, 0.01);
+
+        window.Close();
+        Cleanup(dir);
+    }
+
+    // ---------------------------------------------------------------
+    // Dialogs
+    // ---------------------------------------------------------------
+
+    [FixedAvaloniaFact]
+    public async Task VerifySignaturesCommand_OnLoadedDocument_SurfacesVerificationSummary()
+    {
+        var (source, _, dir) = MakePaths();
+        TestPdfGenerator.CreateSimpleTextPdf(source, "Unsigned content");
+
+        var dialog = new RecordingDialogService();
+        var vm = CreateViewModelWithDialog(dialog);
+        var window = new MainWindow { DataContext = vm, Width = 1280, Height = 900 };
+        window.Show();
+        await vm.LoadDocumentAsync(source);
+
+        await vm.VerifySignaturesCommand.Execute();
+
+        dialog.Messages.Should().ContainSingle(m => m.Title == "Verify Signatures",
+            "executing the real command must run the verification workflow, not merely exist");
+        dialog.Messages.Single().Message.Should().Contain("No digital signatures were found",
+            "the results surface must actually be populated with the real verification outcome");
+
+        window.Close();
+        Cleanup(dir);
+    }
+
+    [FixedAvaloniaFact]
+    public async Task SecurityCommand_OnLoadedDocument_OpensTheSecurityDialogWindow()
+    {
+        var (source, _, dir) = MakePaths();
+        TestPdfGenerator.CreateSimpleTextPdf(source, "Body");
+
+        var vm = new MainWindowViewModel();
+        var window = new MainWindow { DataContext = vm, Width = 1280, Height = 900 };
+        window.Show();
+        await vm.LoadDocumentAsync(source);
+
+        vm.MainWindowResolver = () => window;
+
+        // ShowSecurityDialogAsync awaits ShowDialog(owner) until the dialog
+        // closes, so awaiting Execute() directly here would hang the test
+        // until we've already closed the window we haven't found yet. Fire
+        // it and pump the dispatcher instead.
+        vm.SecurityCommand.Execute().Subscribe();
+        await KeyboardTestHelpers.FlushDispatcherAsync();
+        await KeyboardTestHelpers.FlushDispatcherAsync();
+
+        var securityDialog = window.OwnedWindows.OfType<SecurityDialog>().SingleOrDefault();
+        securityDialog.Should().NotBeNull(
+            "executing SecurityCommand must open the real Security dialog window, not just be wired to something");
+
+        securityDialog!.Close();
+        await KeyboardTestHelpers.FlushDispatcherAsync();
+
+        window.Close();
+        Cleanup(dir);
+    }
+
+    [FixedAvaloniaFact]
+    public async Task ShowPreferencesCommand_OpensThePreferencesWindow()
+    {
+        var (source, _, dir) = MakePaths();
+        TestPdfGenerator.CreateSimpleTextPdf(source, "Body");
+
+        var vm = new MainWindowViewModel();
+        var window = new MainWindow { DataContext = vm, Width = 1280, Height = 900 };
+        window.Show();
+        await vm.LoadDocumentAsync(source);
+
+        vm.MainWindowResolver = () => window;
+
+        await vm.ShowPreferencesCommand.Execute();
+        await KeyboardTestHelpers.FlushDispatcherAsync();
+
+        var preferencesWindow = window.OwnedWindows.OfType<PreferencesWindow>().SingleOrDefault();
+        preferencesWindow.Should().NotBeNull(
+            "executing ShowPreferencesCommand must open the real Preferences window, not just be wired to something");
+
+        preferencesWindow!.Close();
+        await KeyboardTestHelpers.FlushDispatcherAsync();
+
+        window.Close();
+        Cleanup(dir);
+    }
+
+    [FixedAvaloniaFact]
+    public async Task AboutCommand_OpensTheAboutWindow()
+    {
+        var vm = new MainWindowViewModel();
+        var window = new MainWindow { DataContext = vm, Width = 1280, Height = 900 };
+        window.Show();
+
+        vm.MainWindowResolver = () => window;
+
+        await vm.AboutCommand.Execute();
+        await KeyboardTestHelpers.FlushDispatcherAsync();
+
+        var aboutWindow = window.OwnedWindows.OfType<AboutWindow>().SingleOrDefault();
+        aboutWindow.Should().NotBeNull(
+            "executing AboutCommand must open the real About window, not just be wired to something");
+
+        aboutWindow!.Close();
+        await KeyboardTestHelpers.FlushDispatcherAsync();
+
+        window.Close();
+    }
+
+    [FixedAvaloniaFact]
+    public async Task ShowShortcutsCommand_RequestsTheKeyboardShortcutsDialog()
+    {
+        var vm = new MainWindowViewModel();
+        var window = new MainWindow { DataContext = vm, Width = 1280, Height = 900 };
+        window.Show();
+
+        vm.MainWindowResolver = () => window;
+
+        FluentAvalonia.UI.Controls.FAContentDialog? requested = null;
+        vm.KeyboardShortcutsDialogRequested = dialog => requested = dialog;
+
+        await vm.ShowShortcutsCommand.Execute();
+
+        requested.Should().NotBeNull(
+            "executing ShowShortcutsCommand must actually construct and request the real shortcuts dialog, not just be wired to something");
+        requested!.Title.Should().Be("Keyboard Shortcuts");
+        requested.Content.Should().BeOfType<string>()
+            .Which.Should().Contain("Ctrl+F - Find");
+
+        window.Close();
+    }
+
+    [FixedAvaloniaFact]
+    public async Task ShowDocumentationCommand_InvokesTheDocumentationOpenPath()
+    {
+        var vm = new MainWindowViewModel();
+        var opened = new System.Collections.Generic.List<string>();
+        vm.DocumentationOpener = target => opened.Add(target);
+
+        await vm.ShowDocumentationCommand.Execute();
+
+        opened.Should().ContainSingle(
+            "executing the real command must invoke the doc-open path exactly once, without launching a real external app/browser in the test host");
+        opened[0].Should().Match(t => t.EndsWith("README.md", StringComparison.Ordinal) ||
+                                       t.Contains("github.com/marctjones/excise", StringComparison.Ordinal),
+            "the invoked target must be the README path or the GitHub fallback URL the command documents");
+    }
+
+    // ---------------------------------------------------------------
+    // Misc
+    // ---------------------------------------------------------------
+
+    [FixedAvaloniaFact]
+    public async Task ZoomFitPageCommand_ComputesTheFitPageRatio_DistinctFromFitWidth()
+    {
+        var (source, _, dir) = MakePaths();
+        const double widthPoints = 400;
+        const double heightPoints = 800;
+        TestPdfGenerator.CreateCustomSizePdf(source, widthPoints, heightPoints);
+
+        var vm = new MainWindowViewModel();
+        var window = new MainWindow { DataContext = vm, Width = 1280, Height = 900 };
+        window.Show();
+        await vm.LoadDocumentAsync(source);
+
+        vm.ViewportWidth = 1000;
+        vm.ViewportHeight = 700;
+
+        const double dipsPerPoint = 96.0 / 72.0;
+        var pageWidthDip = widthPoints * dipsPerPoint;
+        var pageHeightDip = heightPoints * dipsPerPoint;
+        const double margin = 8;
+        var expectedFitWidth = Math.Clamp((vm.ViewportWidth - margin) / pageWidthDip, 0.25, 5.0);
+        var expectedFitPage = Math.Clamp(
+            Math.Min((vm.ViewportWidth - margin) / pageWidthDip, (vm.ViewportHeight - margin) / pageHeightDip),
+            0.25, 5.0);
+        Math.Abs(expectedFitPage - expectedFitWidth).Should().BeGreaterThan(0.1,
+            "the fixture must be a non-square page/viewport combination or this test can't tell fit-page from fit-width apart");
+
+        await vm.ZoomFitPageCommand.Execute();
+
+        vm.ZoomLevel.Should().BeApproximately(expectedFitPage, 0.01,
+            "ZoomFitPageCommand must compute the fit-PAGE ratio (bound by whichever dimension is the tighter constraint), not merely leave zoom > 0");
+        Math.Abs(vm.ZoomLevel - expectedFitWidth).Should().BeGreaterThan(0.1,
+            "on this non-square page, fit-page and fit-width must produce genuinely different zoom levels");
+
+        window.Close();
+        Cleanup(dir);
+    }
+
+    [FixedAvaloniaFact]
+    public async Task GoToPageCommand_NavigatesToTheRequestedPage()
+    {
+        var (source, _, dir) = MakePaths();
+        TestPdfGenerator.CreateMultiPagePdf(source, 5);
+
+        var vm = new MainWindowViewModel();
+        var window = new MainWindow { DataContext = vm, Width = 1280, Height = 900 };
+        window.Show();
+        await vm.LoadDocumentAsync(source);
+
+        vm.CurrentPageIndex.Should().Be(0);
+
+        await vm.GoToPageCommand.Execute(3);
+
+        vm.CurrentPageIndex.Should().Be(3,
+            "executing the real command must move CurrentPageIndex, not just accept the call");
+
+        window.Close();
+        Cleanup(dir);
+    }
+
+    // ---------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------
+
+    private sealed class RecordingDialogService : IUserDialogService
+    {
+        public System.Collections.Generic.List<(string Title, string Message)> Messages { get; } = new();
+
+        public Task ShowMessageAsync(string title, string message)
+        {
+            Messages.Add((title, message));
+            return Task.CompletedTask;
+        }
+    }
+
+    private static MainWindowViewModel CreateViewModelWithDialog(IUserDialogService dialogService)
+    {
+        var loggerFactory = NullLoggerFactory.Instance;
+        return new MainWindowViewModel(
+            NullLogger<MainWindowViewModel>.Instance,
+            loggerFactory,
+            new PdfDocumentService(NullLogger<PdfDocumentService>.Instance),
+            new PdfRenderService(NullLogger<PdfRenderService>.Instance),
+            new RedactionService(NullLogger<RedactionService>.Instance, loggerFactory),
+            new PdfTextExtractionService(NullLogger<PdfTextExtractionService>.Instance),
+            new PdfSearchService(NullLogger<PdfSearchService>.Instance),
+            new SignatureVerificationService(NullLogger<SignatureVerificationService>.Instance),
+            new FilenameSuggestionService(),
+            new ToastService(),
+            dialogService: dialogService);
+    }
+
+    private static (string source, string output, string dir) MakePaths()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "Excise.AppAnnotateDialogTests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        return (Path.Combine(tempDir, "source.pdf"), Path.Combine(tempDir, "output.pdf"), tempDir);
+    }
+
+    private static void Cleanup(string dir)
+    {
+        try { if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true); }
+        catch { }
+    }
+}

--- a/Excise.App.Tests/UI/FileOpsCommandTests.cs
+++ b/Excise.App.Tests/UI/FileOpsCommandTests.cs
@@ -1,0 +1,405 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Avalonia.Platform.Storage;
+using AwesomeAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Excise.Core.Document;
+using Excise.App.Services;
+using Excise.App.Tests.Utilities;
+using Excise.App.ViewModels;
+using Xunit;
+
+namespace Excise.App.Tests.UI;
+
+/// <summary>
+/// #816 batch 2: execute the actual file-ops toolbar/menu COMMANDS
+/// (SaveFileCommand, SaveAsCommand, SaveFlattenedFormCopyCommand,
+/// OpenFileCommand, LoadRecentFileCommand, ExportCurrentPageCommand,
+/// ExportPagesCommand, PrintCommand) and assert the real effect — not the
+/// underlying async method with an already-known path/target, which is all
+/// the existing suite (EncryptedDocumentSaveWarningTests, FormWorkflowTests,
+/// DocumentPermissionEnforcementTests, ...) exercises. A command mis-wired to
+/// the wrong handler, or wired to nothing, would pass every one of those
+/// tests and only show up here.
+///
+/// Open/SaveAs/SaveFlattenedFormCopy/ExportCurrentPage/ExportPages all read
+/// their target path/folder from a native file dialog via
+/// <c>GetStorageProvider()</c>, which resolves the classic-desktop-lifetime
+/// MainWindow's <see cref="IStorageProvider"/>. The headless test host has no
+/// desktop lifetime (Avalonia.Headless <c>SetupWithoutStarting</c>), so that
+/// path always returned null and none of these commands could previously be
+/// driven end to end — the only reachable seam was the underlying method.
+/// <see cref="MainWindowViewModel.StorageProviderOverride"/> is a new test
+/// seam (#816) that <c>GetStorageProvider()</c> now prefers when set;
+/// <c>CreateStorageProviderStub</c> below (a Moq mock — see its own doc comment
+/// for why) answers picker calls with real temp-dir paths.
+/// </summary>
+[Collection("AvaloniaTests")]
+public class FileOpsCommandTests
+{
+    // ── OpenFileCommand ──────────────────────────────────────────────────
+    [FixedAvaloniaFact]
+    public async Task OpenFileCommand_Execute_StubbedDialog_LoadsDocument()
+    {
+        var (sourcePath, _, tempDir) = MakePaths();
+        TestPdfGenerator.CreateMultiPagePdf(sourcePath, pageCount: 3);
+
+        var vm = new MainWindowViewModel();
+        vm.StorageProviderOverride = CreateStorageProviderStub(openFiles: new[] { sourcePath });
+
+        vm.IsDocumentLoaded.Should().BeFalse();
+        await vm.OpenFileCommand.Execute();
+
+        vm.IsDocumentLoaded.Should().BeTrue("the Open command must actually load the file the dialog returned");
+        vm.TotalPages.Should().Be(3);
+
+        Cleanup(tempDir);
+    }
+
+    // ── LoadRecentFileCommand ────────────────────────────────────────────
+    [FixedAvaloniaFact]
+    public async Task LoadRecentFileCommand_Execute_LoadsTheGivenRecentPath()
+    {
+        var (sourcePath, _, tempDir) = MakePaths();
+        TestPdfGenerator.CreateMultiPagePdf(sourcePath, pageCount: 2);
+
+        var vm = new MainWindowViewModel();
+
+        await vm.LoadRecentFileCommand.Execute(sourcePath);
+
+        vm.IsDocumentLoaded.Should().BeTrue();
+        vm.TotalPages.Should().Be(2);
+
+        Cleanup(tempDir);
+    }
+
+    // ── SaveAsCommand ────────────────────────────────────────────────────
+    [FixedAvaloniaFact]
+    public async Task SaveAsCommand_Execute_StubbedDialog_PersistsChangeToNewPath()
+    {
+        var (sourcePath, outputPath, tempDir) = MakePaths();
+        TestPdfGenerator.CreateSimpleTextPdf(sourcePath, "Original text");
+
+        var vm = new MainWindowViewModel();
+        await vm.LoadDocumentAsync(sourcePath);
+        var before = vm.PdfCoreDocument!.GetPage(1).Rotation;
+
+        await vm.RotatePageRightCommand.Execute();
+
+        vm.StorageProviderOverride = CreateStorageProviderStub(saveFile: outputPath);
+
+        await vm.SaveAsCommand.Execute();
+
+        vm.DocumentName.Should().Be(Path.GetFileName(outputPath),
+            "Save As must switch the current document to the dialog's chosen path");
+        vm.FileState.HasUnsavedChanges.Should().BeFalse();
+        File.Exists(outputPath).Should().BeTrue("the Save As command must actually write the file, not just close the dialog");
+
+        using var reopened = PdfDocument.Open(outputPath);
+        reopened.GetPage(1).Rotation.Should().Be((before + 90) % 360,
+            "the rotation made before Save As must be in the bytes written to disk");
+
+        Cleanup(tempDir);
+    }
+
+    // ── SaveFileCommand ──────────────────────────────────────────────────
+    [FixedAvaloniaFact]
+    public async Task SaveFileCommand_Execute_OnNonOriginalFile_PersistsChangeDirectly()
+    {
+        var (sourcePath, outputPath, tempDir) = MakePaths();
+        TestPdfGenerator.CreateSimpleTextPdf(sourcePath, "Original text");
+
+        var vm = new MainWindowViewModel();
+        await vm.LoadDocumentAsync(sourcePath);
+
+        // Escape the "original file" branch of SaveFileCommand (which redirects
+        // to Save As / the redaction workflow) the same way a real user would:
+        // Save As once first.
+        vm.StorageProviderOverride = CreateStorageProviderStub(saveFile: outputPath);
+        await vm.SaveAsCommand.Execute();
+        vm.FileState.IsOriginalFile.Should().BeFalse("Save As must make the current path distinct from the original");
+
+        var before = vm.PdfCoreDocument!.GetPage(1).Rotation;
+        await vm.RotatePageRightCommand.Execute();
+        vm.FileState.HasUnsavedChanges.Should().BeTrue();
+
+        await vm.SaveFileCommand.Execute();
+
+        vm.FileState.HasUnsavedChanges.Should().BeFalse("SaveFileCommand must clear dirty state on a real save");
+        using var reopened = PdfDocument.Open(outputPath);
+        reopened.GetPage(1).Rotation.Should().Be((before + 90) % 360,
+            "SaveFileCommand must write the post-Save-As rotation to the SAME path, proving it executed a real save " +
+            "rather than being a no-op or misrouted to Save As again");
+
+        Cleanup(tempDir);
+    }
+
+    // ── SaveFlattenedFormCopyCommand ─────────────────────────────────────
+    [FixedAvaloniaFact]
+    public async Task SaveFlattenedFormCopyCommand_Execute_StubbedDialog_BakesValueAndDropsAcroForm()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "ExciseFileOpsTests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        var sourcePath = Path.Combine(tempDir, "form.pdf");
+        var outputPath = Path.Combine(tempDir, "form_flattened.pdf");
+        File.WriteAllBytes(sourcePath, BuildFormPdf());
+
+        var vm = new MainWindowViewModel();
+        await vm.LoadDocumentAsync(sourcePath);
+
+        var field = vm.PdfCoreDocument!.GetAcroForm()!.FindField("Name")!;
+        field.SetValue("Dana");
+        vm.OnFormFieldEdited("Name", "Dana");
+
+        vm.StorageProviderOverride = CreateStorageProviderStub(saveFile: outputPath);
+
+        await vm.SaveFlattenedFormCopyCommand.Execute();
+
+        File.Exists(outputPath).Should().BeTrue("the command must actually write the flattened copy the dialog targeted");
+        using var reopened = PdfDocument.Open(outputPath);
+        reopened.GetAcroForm().Should().BeNull("a flattened copy must not retain interactive form fields");
+        Encoding.Latin1.GetString(reopened.GetPage(1).GetContentStreamBytes())
+            .Should().Contain("(Dana) Tj", "the filled value must be baked into the page content stream");
+        reopened.GetPage(1).GetAnnotations().Should().BeEmpty();
+
+        Cleanup(tempDir);
+    }
+
+    // ── ExportCurrentPageCommand ─────────────────────────────────────────
+    [FixedAvaloniaFact]
+    public async Task ExportCurrentPageCommand_Execute_StubbedDialog_WritesNonEmptyPng()
+    {
+        var (sourcePath, _, tempDir) = MakePaths();
+        TestPdfGenerator.CreateSimpleTextPdf(sourcePath, "Export me");
+        var outputPath = Path.Combine(tempDir, "page1.png");
+
+        var vm = new MainWindowViewModel();
+        await vm.LoadDocumentAsync(sourcePath);
+
+        vm.StorageProviderOverride = CreateStorageProviderStub(saveFile: outputPath);
+
+        await vm.ExportCurrentPageCommand.Execute();
+
+        File.Exists(outputPath).Should().BeTrue("the Export Current Page command must write to the dialog's chosen path");
+        new FileInfo(outputPath).Length.Should().BeGreaterThan(0);
+
+        Cleanup(tempDir);
+    }
+
+    // ── ExportPagesCommand ───────────────────────────────────────────────
+    [FixedAvaloniaFact]
+    public async Task ExportPagesCommand_Execute_StubbedDialog_WritesOnePngPerPage()
+    {
+        var (sourcePath, _, tempDir) = MakePaths();
+        TestPdfGenerator.CreateMultiPagePdf(sourcePath, pageCount: 3);
+        var exportDir = Path.Combine(tempDir, "exported");
+        Directory.CreateDirectory(exportDir);
+
+        var vm = new MainWindowViewModel();
+        await vm.LoadDocumentAsync(sourcePath);
+
+        vm.StorageProviderOverride = CreateStorageProviderStub(folder: exportDir);
+
+        await vm.ExportPagesCommand.Execute();
+
+        for (int i = 1; i <= 3; i++)
+        {
+            var expected = Path.Combine(exportDir, $"page_{i:D3}.png");
+            File.Exists(expected).Should().BeTrue($"page {i} must be exported to the dialog's chosen folder");
+            new FileInfo(expected).Length.Should().BeGreaterThan(0);
+        }
+
+        Cleanup(tempDir);
+    }
+
+    // ── PrintCommand ─────────────────────────────────────────────────────
+    // #621: excise deliberately does not print. The command's real effect is
+    // showing that explanation via IUserDialogService — verify it actually
+    // does that (as opposed to silently no-op'ing) rather than asserting
+    // print output that was never meant to exist.
+    [FixedAvaloniaFact]
+    public async Task PrintCommand_Execute_DocumentLoaded_ShowsPrintNotSupportedMessage()
+    {
+        var (sourcePath, _, tempDir) = MakePaths();
+        TestPdfGenerator.CreateSimpleTextPdf(sourcePath, "Print me");
+
+        var dialog = new RecordingUserDialogService();
+        var vm = CreateViewModelWithDialogSpy(dialog);
+        await vm.LoadDocumentAsync(sourcePath);
+
+        await vm.PrintCommand.Execute();
+
+        dialog.Messages.Should().ContainSingle();
+        dialog.Messages[0].title.Should().Be("Print");
+        dialog.Messages[0].message.Should().Contain("doesn't print directly",
+            "the command must surface the real, deliberate #621 explanation, not a generic/blank message");
+
+        Cleanup(tempDir);
+    }
+
+    [FixedAvaloniaFact]
+    public async Task PrintCommand_Execute_NoDocumentLoaded_ShowsOpenPdfFirstMessage()
+    {
+        var dialog = new RecordingUserDialogService();
+        var vm = CreateViewModelWithDialogSpy(dialog);
+
+        await vm.PrintCommand.Execute();
+
+        dialog.Messages.Should().ContainSingle();
+        dialog.Messages[0].message.Should().Contain("Open a PDF before printing");
+
+        await Task.CompletedTask;
+    }
+
+    // ── Fakes ────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Builds a Moq-backed <see cref="IStorageProvider"/> that answers picker
+    /// calls with a stubbed <see cref="IStorageFile"/>/<see cref="IStorageFolder"/>
+    /// whose <c>Path</c> resolves to a real temp-dir path, so the command under
+    /// test round-trips through the exact same <c>IStorageFile.Path.LocalPath</c>
+    /// extraction the production code uses. Mocked rather than hand-implemented
+    /// (and using a mocked file/folder rather than Avalonia's own internal
+    /// <c>BclStorageFile</c>/<c>BclStorageFolder</c>) because Avalonia marks
+    /// these storage interfaces <c>[NotClientImplementable]</c> — a Roslyn
+    /// analyzer rejects a source-level "class X : IStorageProvider", and the
+    /// concrete BCL wrappers are internal to Avalonia.Base. Moq's
+    /// runtime-generated proxy is unaffected by the analyzer since no such
+    /// class appears in source. Only the members
+    /// OpenFileCommand/SaveAsCommand/SaveFlattenedFormCopyCommand/
+    /// ExportCurrentPageCommand/ExportPagesCommand actually call are stubbed.
+    /// </summary>
+    private static IStorageProvider CreateStorageProviderStub(
+        string[]? openFiles = null, string? saveFile = null, string? folder = null)
+    {
+        var mock = new Mock<IStorageProvider>();
+
+        IReadOnlyList<IStorageFile> files = (openFiles ?? Array.Empty<string>())
+            .Select(MockStorageFile)
+            .ToList();
+        mock.Setup(p => p.OpenFilePickerAsync(It.IsAny<FilePickerOpenOptions>()))
+            .ReturnsAsync(files);
+
+        IStorageFile? saveResult = saveFile is null ? null : MockStorageFile(saveFile);
+        mock.Setup(p => p.SaveFilePickerAsync(It.IsAny<FilePickerSaveOptions>()))
+            .ReturnsAsync(saveResult);
+
+        IReadOnlyList<IStorageFolder> folders = folder is null
+            ? Array.Empty<IStorageFolder>()
+            : new List<IStorageFolder> { MockStorageFolder(folder) };
+        mock.Setup(p => p.OpenFolderPickerAsync(It.IsAny<FolderPickerOpenOptions>()))
+            .ReturnsAsync(folders);
+
+        return mock.Object;
+    }
+
+    private static IStorageFile MockStorageFile(string path)
+    {
+        var mock = new Mock<IStorageFile>();
+        mock.Setup(f => f.Path).Returns(new Uri(new FileInfo(path).FullName));
+        mock.Setup(f => f.Name).Returns(Path.GetFileName(path));
+        return mock.Object;
+    }
+
+    private static IStorageFolder MockStorageFolder(string path)
+    {
+        var mock = new Mock<IStorageFolder>();
+        mock.Setup(f => f.Path).Returns(new Uri(new DirectoryInfo(path).FullName));
+        mock.Setup(f => f.Name).Returns(Path.GetFileName(path.TrimEnd(Path.DirectorySeparatorChar)));
+        return mock.Object;
+    }
+
+    private sealed class RecordingUserDialogService : IUserDialogService
+    {
+        public List<(string title, string message)> Messages { get; } = new();
+
+        public Task ShowMessageAsync(string title, string message)
+        {
+            Messages.Add((title, message));
+            return Task.CompletedTask;
+        }
+
+        public Task<bool> ShowConfirmAsync(string title, string message) => Task.FromResult(false);
+    }
+
+    private static MainWindowViewModel CreateViewModelWithDialogSpy(IUserDialogService dialog)
+    {
+        var loggerFactory = NullLoggerFactory.Instance;
+        return new MainWindowViewModel(
+            NullLogger<MainWindowViewModel>.Instance,
+            loggerFactory,
+            new PdfDocumentService(NullLogger<PdfDocumentService>.Instance),
+            new PdfRenderService(NullLogger<PdfRenderService>.Instance),
+            new RedactionService(NullLogger<RedactionService>.Instance, loggerFactory),
+            new PdfTextExtractionService(NullLogger<PdfTextExtractionService>.Instance),
+            new PdfSearchService(NullLogger<PdfSearchService>.Instance),
+            new SignatureVerificationService(NullLogger<SignatureVerificationService>.Instance),
+            new FilenameSuggestionService(),
+            new ToastService(),
+            dialogService: dialog);
+    }
+
+    // ── Fixture helpers ──────────────────────────────────────────────────
+
+    /// <summary>Minimal hand-built single-field AcroForm PDF (mirrors FormWorkflowTests' fixture).</summary>
+    private static byte[] BuildFormPdf()
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("%PDF-1.7");
+        long o1 = sb.Length;
+        sb.AppendLine("1 0 obj");
+        sb.AppendLine("<< /Type /Catalog /Pages 2 0 R /AcroForm << /Fields [5 0 R] >> >>");
+        sb.AppendLine("endobj");
+        long o2 = sb.Length;
+        sb.AppendLine("2 0 obj");
+        sb.AppendLine("<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+        sb.AppendLine("endobj");
+        long o3 = sb.Length;
+        sb.AppendLine("3 0 obj");
+        sb.AppendLine("<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Annots [5 0 R] >>");
+        sb.AppendLine("endobj");
+        long o4 = sb.Length;
+        sb.AppendLine("4 0 obj");
+        sb.AppendLine("<< /Length 0 >>");
+        sb.AppendLine("stream");
+        sb.AppendLine("endstream");
+        sb.AppendLine("endobj");
+        long o5 = sb.Length;
+        sb.AppendLine("5 0 obj");
+        sb.AppendLine("<< /Type /Annot /Subtype /Widget /FT /Tx /T (Name) /V (Alice) /Rect [72 700 300 720] /P 3 0 R >>");
+        sb.AppendLine("endobj");
+        long xref = sb.Length;
+        sb.AppendLine("xref");
+        sb.AppendLine("0 6");
+        sb.AppendLine("0000000000 65535 f ");
+        sb.AppendLine($"{o1:D10} 00000 n ");
+        sb.AppendLine($"{o2:D10} 00000 n ");
+        sb.AppendLine($"{o3:D10} 00000 n ");
+        sb.AppendLine($"{o4:D10} 00000 n ");
+        sb.AppendLine($"{o5:D10} 00000 n ");
+        sb.AppendLine("trailer << /Size 6 /Root 1 0 R >>");
+        sb.AppendLine("startxref");
+        sb.AppendLine(xref.ToString());
+        sb.AppendLine("%%EOF");
+        return Encoding.Latin1.GetBytes(sb.ToString());
+    }
+
+    private static (string source, string output, string dir) MakePaths()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "ExciseFileOpsTests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        return (Path.Combine(tempDir, "source.pdf"), Path.Combine(tempDir, "output.pdf"), tempDir);
+    }
+
+    private static void Cleanup(string dir)
+    {
+        try { if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true); }
+        catch { }
+    }
+}

--- a/Excise.App.Tests/UI/KeyboardShortcutTests.cs
+++ b/Excise.App.Tests/UI/KeyboardShortcutTests.cs
@@ -704,9 +704,29 @@ public class KeyboardShortcutTests
         await window.PressKeyAsync(Key.D2, RawInputModifiers.Control);
         await KeyboardTestHelpers.FlushDispatcherAsync();
         await Task.Delay(100);
+        var fitPageZoom = vm.ZoomLevel;
 
-        // Assert
-        vm.ZoomLevel.Should().BeGreaterThan(0, "Ctrl+2 should fit entire page");
+        // Assert: `BeGreaterThan(0)` alone is vacuous — ZoomLevel is >0 by
+        // construction/clamping in every zoom path, so it can't tell a
+        // correctly-computed fit-page ratio apart from a no-op or a
+        // fit-WIDTH ratio landing here by mistake (#816). The default
+        // multi-page fixture's page is portrait (non-square), so on a
+        // non-square viewport fit-page (constrained by height too) must
+        // differ from fit-width (constrained by width alone) — assert that
+        // distinction directly using the real ZoomFitWidthCommand as the
+        // comparison, not a hard-coded geometry recomputation (the exact
+        // ratio math is covered independently by
+        // AnnotateAndDialogCommandTests.ZoomFitPageCommand_ComputesTheFitPageRatio_DistinctFromFitWidth).
+        fitPageZoom.Should().BeGreaterThan(0, "Ctrl+2 should fit entire page");
+
+        vm.ZoomFitWidthCommand.Execute().Subscribe();
+        await KeyboardTestHelpers.FlushDispatcherAsync();
+        await Task.Delay(100);
+        var fitWidthZoom = vm.ZoomLevel;
+
+        Math.Abs(fitPageZoom - fitWidthZoom).Should().BeGreaterThan(0.01,
+            "Ctrl+2 must route to the fit-PAGE ratio, which is distinct from fit-width on this non-square page — " +
+            "not merely leave ZoomLevel at some positive value");
     }
 
     #endregion

--- a/Excise.App.Tests/UI/PageOrganizationCommandTests.cs
+++ b/Excise.App.Tests/UI/PageOrganizationCommandTests.cs
@@ -1,0 +1,368 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using AwesomeAssertions;
+using Excise.App.Services;
+using Excise.App.Tests.Utilities;
+using Excise.App.ViewModels;
+using Excise.App.Views;
+using Excise.Core.Document;
+using Xunit;
+
+namespace Excise.App.Tests.UI;
+
+/// <summary>
+/// #816 batch 1 — executes the REAL page-organization toolbar/menu COMMANDS
+/// (not the underlying async methods) and asserts the real page-level effect.
+/// Prior coverage proved these methods only by calling them directly or by
+/// asserting the command object is non-null; a button mis-wired to the wrong
+/// method would have passed. Each test here does
+/// <c>await vm.&lt;Name&gt;Command.Execute()</c> and verifies order/count/rotation
+/// or the saved output.
+///
+/// The file/folder-picker commands (Add/Insert/Combine/Split/Extract) reach the
+/// dialog through the picker seams on the view-model
+/// (<c>PickPdfFilesOverride</c> / <c>PickSavePdfPathOverride</c> /
+/// <c>PickFolderOverride</c>, #816) — headless Avalonia has no desktop lifetime
+/// and its storage interfaces are sealed against user implementation, so these
+/// path-returning delegates are the injection point.
+/// </summary>
+[Collection("AvaloniaTests")]
+public class PageOrganizationCommandTests
+{
+    // ── Rotation — the audit canary. Assert the exact task-specified values. ──
+    [FixedAvaloniaFact]
+    public async Task RotatePageLeftCommand_RotatesCurrentPageMinus90()
+    {
+        var (dir, src) = NewDir("rot-left");
+        TestPdfGenerator.CreateSimpleTextPdf(src, "Rotate me");
+        var (vm, window) = await OpenAsync(src);
+
+        var before = vm.PdfCoreDocument!.GetPage(1).Rotation;
+        await vm.RotatePageLeftCommand.Execute();
+        vm.PdfCoreDocument!.GetPage(1).Rotation.Should().Be((before + 270) % 360);
+
+        Close(window, dir);
+    }
+
+    [FixedAvaloniaFact]
+    public async Task RotatePage180Command_RotatesCurrentPage180()
+    {
+        var (dir, src) = NewDir("rot-180");
+        TestPdfGenerator.CreateSimpleTextPdf(src, "Rotate me");
+        var (vm, window) = await OpenAsync(src);
+
+        var before = vm.PdfCoreDocument!.GetPage(1).Rotation;
+        await vm.RotatePage180Command.Execute();
+        vm.PdfCoreDocument!.GetPage(1).Rotation.Should().Be((before + 180) % 360);
+
+        Close(window, dir);
+    }
+
+    // ── Move current page ─────────────────────────────────────────────────────
+    [FixedAvaloniaFact]
+    public async Task MoveCurrentPageEarlierCommand_MovesCurrentPageToPriorIndex()
+    {
+        var (dir, src) = NewDir("move-cur-earlier");
+        TestPdfGenerator.CreateMultiPagePdf(src, pageCount: 3);
+        var (vm, window) = await OpenAsync(src);
+        vm.CurrentPageIndex = 2; // Page 3
+
+        await vm.MoveCurrentPageEarlierCommand.Execute();
+
+        // [P1, P2, P3] → move P3 earlier ⇒ [P1, P3, P2]
+        PageText(vm, 2).Should().Contain("Page 3 Content");
+        vm.CurrentPageIndex.Should().Be(1, "the moved page follows itself to its new index");
+
+        Close(window, dir);
+    }
+
+    [FixedAvaloniaFact]
+    public async Task MoveCurrentPageLaterCommand_MovesCurrentPageToNextIndex()
+    {
+        var (dir, src) = NewDir("move-cur-later");
+        TestPdfGenerator.CreateMultiPagePdf(src, pageCount: 3);
+        var (vm, window) = await OpenAsync(src);
+        vm.CurrentPageIndex = 1; // Page 2
+
+        await vm.MoveCurrentPageLaterCommand.Execute();
+
+        // [P1, P2, P3] → move P2 later ⇒ [P1, P3, P2]
+        PageText(vm, 3).Should().Contain("Page 2 Content");
+        vm.CurrentPageIndex.Should().Be(2);
+
+        Close(window, dir);
+    }
+
+    // ── Selected-page operations ─────────────────────────────────────────────
+    [FixedAvaloniaFact]
+    public async Task RemoveSelectedPagesCommand_RemovesTheMarkedPages()
+    {
+        var (dir, src) = NewDir("remove-selected");
+        TestPdfGenerator.CreateMultiPagePdf(src, pageCount: 4);
+        var (vm, window) = await OpenAsync(src);
+        Select(vm, 1); // mark Page 2
+
+        await vm.RemoveSelectedPagesCommand.Execute();
+
+        vm.TotalPages.Should().Be(3);
+        // [P1, P2, P3, P4] − P2 ⇒ [P1, P3, P4]
+        PageText(vm, 2).Should().Contain("Page 3 Content");
+        AllText(vm).Should().NotContain("Page 2 Content");
+
+        Close(window, dir);
+    }
+
+    [FixedAvaloniaFact]
+    public async Task MoveSelectedPagesEarlierCommand_MovesMarkedPageEarlier()
+    {
+        var (dir, src) = NewDir("move-selected-earlier");
+        TestPdfGenerator.CreateMultiPagePdf(src, pageCount: 4);
+        var (vm, window) = await OpenAsync(src);
+        Select(vm, 2); // mark Page 3 (index 2)
+
+        await vm.MoveSelectedPagesEarlierCommand.Execute();
+
+        // Page 3 moves from index 2 → index 1 ⇒ 1-based page 2 is now Page 3
+        PageText(vm, 2).Should().Contain("Page 3 Content");
+
+        Close(window, dir);
+    }
+
+    [FixedAvaloniaFact]
+    public async Task MoveSelectedPagesLaterCommand_MovesMarkedPageLater()
+    {
+        var (dir, src) = NewDir("move-selected-later");
+        TestPdfGenerator.CreateMultiPagePdf(src, pageCount: 4);
+        var (vm, window) = await OpenAsync(src);
+        Select(vm, 1); // mark Page 2 (index 1)
+
+        await vm.MoveSelectedPagesLaterCommand.Execute();
+
+        // Page 2 moves from index 1 → index 2 ⇒ 1-based page 3 is now Page 2
+        PageText(vm, 3).Should().Contain("Page 2 Content");
+
+        Close(window, dir);
+    }
+
+    [FixedAvaloniaFact]
+    public async Task ClearSelectedPagesCommand_UnmarksAllSelections()
+    {
+        var (dir, src) = NewDir("clear-selected");
+        TestPdfGenerator.CreateMultiPagePdf(src, pageCount: 3);
+        var (vm, window) = await OpenAsync(src);
+        Select(vm, 0);
+        Select(vm, 2);
+        vm.SelectedPageCount.Should().Be(2);
+
+        await vm.ClearSelectedPagesCommand.Execute();
+
+        vm.SelectedPageCount.Should().Be(0);
+        vm.PageThumbnails.Should().OnlyContain(t => !t.IsMarkedForPageOperation);
+
+        Close(window, dir);
+    }
+
+    // ── Add / Insert (picker-driven, seam-injected source path) ──────────────
+    [FixedAvaloniaFact]
+    public async Task AddPagesCommand_AppendsInsertedPageAtEnd()
+    {
+        var (dir, src) = NewDir("add-pages");
+        TestPdfGenerator.CreateMultiPagePdf(src, pageCount: 3);
+        var insertPath = Path.Combine(dir, "insert.pdf");
+        TestPdfGenerator.CreateSimpleTextPdf(insertPath, "INSERTED_MARKER");
+        var (vm, window) = await OpenAsync(src);
+        vm.PickPdfFilesOverride = _ => Task.FromResult<IReadOnlyList<string>>(new[] { insertPath });
+
+        await vm.AddPagesCommand.Execute();
+
+        vm.TotalPages.Should().Be(4);
+        PageText(vm, 4).Should().Contain("INSERTED_MARKER", "AddPages appends at the end");
+
+        Close(window, dir);
+    }
+
+    [FixedAvaloniaFact]
+    public async Task InsertPagesBeforeCurrentCommand_InsertsAtCurrentIndex()
+    {
+        var (dir, src) = NewDir("insert-before");
+        TestPdfGenerator.CreateMultiPagePdf(src, pageCount: 3);
+        var insertPath = Path.Combine(dir, "insert.pdf");
+        TestPdfGenerator.CreateSimpleTextPdf(insertPath, "INSERTED_MARKER");
+        var (vm, window) = await OpenAsync(src);
+        vm.CurrentPageIndex = 1; // before Page 2 ⇒ new index 1
+        vm.PickPdfFilesOverride = _ => Task.FromResult<IReadOnlyList<string>>(new[] { insertPath });
+
+        await vm.InsertPagesBeforeCurrentCommand.Execute();
+
+        vm.TotalPages.Should().Be(4);
+        // [P1, INSERTED, P2, P3]
+        PageText(vm, 2).Should().Contain("INSERTED_MARKER");
+        PageText(vm, 3).Should().Contain("Page 2 Content");
+
+        Close(window, dir);
+    }
+
+    [FixedAvaloniaFact]
+    public async Task InsertPagesAfterCurrentCommand_InsertsAfterCurrentIndex()
+    {
+        var (dir, src) = NewDir("insert-after");
+        TestPdfGenerator.CreateMultiPagePdf(src, pageCount: 3);
+        var insertPath = Path.Combine(dir, "insert.pdf");
+        TestPdfGenerator.CreateSimpleTextPdf(insertPath, "INSERTED_MARKER");
+        var (vm, window) = await OpenAsync(src);
+        vm.CurrentPageIndex = 1; // after Page 2 ⇒ new index 2
+        vm.PickPdfFilesOverride = _ => Task.FromResult<IReadOnlyList<string>>(new[] { insertPath });
+
+        await vm.InsertPagesAfterCurrentCommand.Execute();
+
+        vm.TotalPages.Should().Be(4);
+        // [P1, P2, INSERTED, P3]
+        PageText(vm, 3).Should().Contain("INSERTED_MARKER");
+        PageText(vm, 4).Should().Contain("Page 3 Content");
+
+        Close(window, dir);
+    }
+
+    // ── Extract ──────────────────────────────────────────────────────────────
+    [FixedAvaloniaFact]
+    public async Task ExtractCurrentPageCommand_WritesOnlyTheCurrentPage()
+    {
+        var (dir, src) = NewDir("extract-current");
+        TestPdfGenerator.CreateMultiPagePdf(src, pageCount: 3);
+        var outPath = Path.Combine(dir, "extracted.pdf");
+        var (vm, window) = await OpenAsync(src);
+        vm.CurrentPageIndex = 1; // Page 2
+        vm.PickSavePdfPathOverride = () => Task.FromResult<string?>(outPath);
+
+        await vm.ExtractCurrentPageCommand.Execute();
+
+        File.Exists(outPath).Should().BeTrue();
+        using var extracted = PdfDocument.Open(outPath);
+        extracted.PageCount.Should().Be(1);
+        extracted.GetPage(1).Text.Should().Contain("Page 2 Content");
+        extracted.GetPage(1).Text.Should().NotContain("Page 1 Content");
+
+        Close(window, dir);
+    }
+
+    [FixedAvaloniaFact]
+    public async Task ExtractSelectedPagesCommand_WritesExactlyTheMarkedPages()
+    {
+        var (dir, src) = NewDir("extract-selected");
+        TestPdfGenerator.CreateMultiPagePdf(src, pageCount: 4);
+        var outPath = Path.Combine(dir, "extracted.pdf");
+        var (vm, window) = await OpenAsync(src);
+        Select(vm, 0); // Page 1
+        Select(vm, 2); // Page 3
+        vm.PickSavePdfPathOverride = () => Task.FromResult<string?>(outPath);
+
+        await vm.ExtractSelectedPagesCommand.Execute();
+
+        File.Exists(outPath).Should().BeTrue();
+        using var extracted = PdfDocument.Open(outPath);
+        extracted.PageCount.Should().Be(2);
+        var text = extracted.GetPage(1).Text + "|" + extracted.GetPage(2).Text;
+        text.Should().Contain("Page 1 Content");
+        text.Should().Contain("Page 3 Content");
+        text.Should().NotContain("Page 2 Content");
+
+        Close(window, dir);
+    }
+
+    // ── Combine ──────────────────────────────────────────────────────────────
+    [FixedAvaloniaFact]
+    public async Task CombineDocumentsCommand_MergesBothSourcesIntoOneFile()
+    {
+        var (dir, src) = NewDir("combine");
+        var a = Path.Combine(dir, "a.pdf");
+        var b = Path.Combine(dir, "b.pdf");
+        TestPdfGenerator.CreateTextOnlyPdf(a, "ALPHA_DOC");
+        TestPdfGenerator.CreateTextOnlyPdf(b, "BRAVO_DOC");
+        var outPath = Path.Combine(dir, "combined.pdf");
+
+        var vm = new MainWindowViewModel();
+        var window = new MainWindow { DataContext = vm, Width = 1280, Height = 900 };
+        window.Show();
+        vm.PickPdfFilesOverride = _ => Task.FromResult<IReadOnlyList<string>>(new[] { a, b });
+        vm.PickSavePdfPathOverride = () => Task.FromResult<string?>(outPath);
+
+        await vm.CombineDocumentsCommand.Execute();
+
+        File.Exists(outPath).Should().BeTrue();
+        using var combined = PdfDocument.Open(outPath);
+        combined.PageCount.Should().Be(2, "combine sums the source page counts");
+        var text = combined.GetPage(1).Text + "|" + combined.GetPage(2).Text;
+        text.Should().Contain("ALPHA_DOC");
+        text.Should().Contain("BRAVO_DOC");
+
+        Close(window, dir);
+    }
+
+    // ── Split (default split spec "1" ⇒ one page per file, via NullDialog) ────
+    [FixedAvaloniaFact]
+    public async Task SplitDocumentCommand_WritesOnePageFilePerPage()
+    {
+        var (dir, src) = NewDir("split");
+        TestPdfGenerator.CreateMultiPagePdf(src, pageCount: 4);
+        var outFolder = Path.Combine(dir, "out");
+        Directory.CreateDirectory(outFolder);
+        var (vm, window) = await OpenAsync(src);
+        vm.PickFolderOverride = () => Task.FromResult<string?>(outFolder);
+
+        await vm.SplitDocumentCommand.Execute();
+
+        var files = Directory.GetFiles(outFolder, "*.pdf").OrderBy(f => f).ToList();
+        files.Should().HaveCount(4, "the default \"1\" spec splits one page per file");
+        var allText = string.Empty;
+        foreach (var f in files)
+        {
+            using var part = PdfDocument.Open(f);
+            part.PageCount.Should().Be(1, "each split file carries exactly one page");
+            allText += part.GetPage(1).Text + "|";
+        }
+        allText.Should().Contain("Page 1 Content");
+        allText.Should().Contain("Page 4 Content");
+
+        Close(window, dir);
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+    private static (string dir, string src) NewDir(string tag)
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "ExcisePageOrgCmd", $"{tag}-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dir);
+        return (dir, Path.Combine(dir, "source.pdf"));
+    }
+
+    private static async Task<(MainWindowViewModel vm, MainWindow window)> OpenAsync(string path)
+    {
+        var vm = new MainWindowViewModel();
+        var window = new MainWindow { DataContext = vm, Width = 1280, Height = 900 };
+        window.Show();
+        await vm.LoadDocumentAsync(path);
+        return (vm, window);
+    }
+
+    private static void Select(MainWindowViewModel vm, int pageIndex)
+    {
+        vm.PageThumbnails.Single(t => t.PageIndex == pageIndex).IsMarkedForPageOperation = true;
+    }
+
+    private static string PageText(MainWindowViewModel vm, int oneBasedPage) =>
+        vm.PdfCoreDocument!.GetPage(oneBasedPage).Text;
+
+    private static string AllText(MainWindowViewModel vm) =>
+        string.Join("|", Enumerable.Range(1, vm.TotalPages)
+            .Select(n => vm.PdfCoreDocument!.GetPage(n).Text));
+
+    private static void Close(MainWindow window, string dir)
+    {
+        window.Close();
+        try { if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true); }
+        catch { }
+    }
+}

--- a/Excise.App.Tests/UI/RedactionAndSearchCommandTests.cs
+++ b/Excise.App.Tests/UI/RedactionAndSearchCommandTests.cs
@@ -1,0 +1,352 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using AwesomeAssertions;
+using Excise.Core.Document;
+using Excise.Core.Graphics;
+using Excise.Rendering.Differential;
+using Excise.App.Services;
+using Excise.App.Tests.Utilities;
+using Excise.App.ViewModels;
+using Excise.App.Views;
+using Xunit;
+
+namespace Excise.App.Tests.UI;
+
+/// <summary>
+/// #816 batch 3: execute the REAL redaction-button and search-bar ReactiveCommands
+/// (not the scripting methods, not RedactionWorkflow directly) and assert their
+/// real effects.
+///
+/// The prior coverage gap (see GoldenPathTests.GoldenPath_OpenRedactApplyVerifyTextGone):
+/// ApplyAllRedactionsCommand was executed but, because headless has no
+/// desktop-lifetime MainWindow and no interactive save picker, the command bailed
+/// before the pipeline ran — the test only asserted "document still open". Here the
+/// save destination is supplied via the SetRedactedSavePathProviderForTests seam so
+/// the command runs end-to-end, and removal is proven with an INDEPENDENT oracle
+/// (saved bytes + mutool), never excise's own extractor (CLAUDE.md no-self-oracle).
+/// </summary>
+[Collection("AvaloniaTests")]
+public class RedactionAndSearchCommandTests
+{
+    private readonly string _tempDir;
+
+    public RedactionAndSearchCommandTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "excise-816-batch3", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    // ---------------------------------------------------------------------
+    // Redaction button commands
+    // ---------------------------------------------------------------------
+
+    // ApplyAllRedactionsCommand (sidebar "Apply All"): the security-critical one.
+    // Mark a pending over known secret text, execute the COMMAND, then assert the
+    // secret is GONE from the SAVED FILE via a CARRIER-AGNOSTIC independent oracle
+    // (raw saved bytes, ASCII + UTF-16BE — never excise's own extractor). The
+    // survivor token doubles as an in-file negative control: it proves the
+    // byte-scan can actually detect plaintext in this (uncompressed) redacted
+    // content stream, so the "secret absent" assertion means removal, not
+    // compression. This test ALWAYS runs (no tool dependency).
+    [FixedAvaloniaFact(Timeout = 90000)]
+    public async Task ApplyAllRedactionsCommand_RemovesSecretFromSavedFile_SavedBytesOracle()
+    {
+        var (outputPath, savedText, _) = await RunApplyAllRedactionAsync("apply-all");
+
+        // NEGATIVE CONTROL: the survivor is really visible to this byte-scan, so a
+        // "not found" for the secret below means removal — not compression/encoding.
+        savedText.Should().Contain(Survivor,
+            "the un-redacted survivor token must be detectable by the byte-scan (negative control: proves the oracle can fail)");
+
+        // INDEPENDENT, CARRIER-AGNOSTIC ORACLE (saved bytes, ASCII + UTF-16BE).
+        savedText.Should().NotContain(Secret,
+            "the redacted secret must be gone from every carrier in the saved bytes");
+
+        File.Exists(outputPath).Should().BeTrue();
+    }
+
+    // Second, STRONGER oracle: an independent extractor (mutool) — a tool that is
+    // not excise — must not be able to read the redacted secret back out, and must
+    // still read the survivor. Skips cleanly when mutool isn't installed (tool-less
+    // CI); allow-listed in tests/skip-allowlist/Excise.App.Tests.txt.
+    [FixedAvaloniaFact(Timeout = 90000)]
+    public async Task ApplyAllRedactionsCommand_RedactedSecret_NotReadableByIndependentExtractor()
+    {
+        Assert.SkipUnless(MutoolReferenceRenderer.IsAvailable, "mutool not installed");
+
+        var (outputPath, _, _) = await RunApplyAllRedactionAsync("apply-all-mutool");
+
+        var extracted = MutoolTextExtractor.ExtractPage(outputPath, 1);
+        extracted.Should().NotBeNull("mutool must be able to read the redacted copy");
+        extracted!.Should().NotContain(Secret,
+            "an independent extractor must not read the redacted secret out of the saved file");
+        extracted.Should().Contain(Survivor,
+            "redaction must not destroy content outside the marked area");
+    }
+
+    private const string Secret = "TARGETSECRETXYZ816";
+    private const string Survivor = "SURVIVORTOKEN816";
+
+    /// <summary>
+    /// Shared driver: load a two-token PDF, mark a pending over the top secret,
+    /// stub the save-path dialog, execute the REAL ApplyAllRedactionsCommand, and
+    /// return the output path plus the saved bytes as ASCII+UTF-16BE text.
+    /// </summary>
+    private async Task<(string OutputPath, string SavedText, byte[] SavedBytes)> RunApplyAllRedactionAsync(string tag)
+    {
+        var sourcePath = Path.Combine(_tempDir, $"{tag}-source.pdf");
+        var outputPath = Path.Combine(_tempDir, $"{tag}-output.pdf");
+        CreateTwoTokenPdf(sourcePath, Secret, Survivor);
+
+        var vm = new MainWindowViewModel();
+        var window = new MainWindow { DataContext = vm, Width = 1280, Height = 900 };
+        window.Show();
+        await vm.LoadDocumentAsync(sourcePath);
+
+        // Stub the save-path dialog (headless has no picker / desktop MainWindow).
+        vm.SetRedactedSavePathProviderForTests(_ => Task.FromResult<string?>(outputPath));
+
+        // Mark a pending redaction over the top token only, in content space.
+        vm.IsRedactionMode = true;
+        vm.RedactionWorkflow.MarkArea(
+            PdfPageRect.FromContentPoints(1, new PdfRectangle(40, 675, 500, 750)),
+            Secret);
+        vm.RedactionWorkflow.PendingCount.Should().Be(1, "one area was marked");
+
+        // Execute the REAL command (not the scripting ApplyRedactionsCommand()).
+        await vm.ApplyAllRedactionsCommand!.Execute();
+
+        File.Exists(outputPath).Should().BeTrue("the Apply All command must write the redacted copy");
+        vm.RedactionWorkflow.PendingCount.Should().Be(0, "applied redactions move out of pending");
+
+        window.Close();
+        var savedBytes = File.ReadAllBytes(outputPath);
+        var savedText = Encoding.ASCII.GetString(savedBytes) + Encoding.BigEndianUnicode.GetString(savedBytes);
+        return (outputPath, savedText, savedBytes);
+    }
+
+    // ApplyRedactionCommand (toolbar "Apply"). Trace of ApplyRedactionAsync: in
+    // redaction mode with a current area it MARKS a pending and returns (the
+    // immediate-redact branch below it is unreachable in that state). So the real
+    // effect of the toolbar Apply command here is: a pending redaction is created.
+    [FixedAvaloniaFact(Timeout = 60000)]
+    public async Task ApplyRedactionCommand_WithCurrentArea_MarksPendingRedaction()
+    {
+        var sourcePath = Path.Combine(_tempDir, "apply-toolbar-source.pdf");
+        TestPdfGenerator.CreateSimpleTextPdf(sourcePath, "TOOLBARSECRET816");
+
+        var vm = new MainWindowViewModel();
+        var window = new MainWindow { DataContext = vm, Width = 1280, Height = 900 };
+        window.Show();
+        await vm.LoadDocumentAsync(sourcePath);
+
+        vm.IsRedactionMode = true;
+        vm.CurrentRedactionPageArea = PdfPageRect.FromContentPoints(1, new PdfRectangle(40, 660, 500, 740));
+        vm.RedactionWorkflow.PendingCount.Should().Be(0, "nothing marked yet");
+
+        await vm.ApplyRedactionCommand!.Execute();
+
+        vm.RedactionWorkflow.PendingCount.Should().Be(1,
+            "executing the toolbar Apply command in redaction mode marks the drawn area as pending");
+
+        window.Close();
+    }
+
+    // ClearAllRedactionsCommand: mark redactions, execute → pending == 0 and no
+    // redaction was applied to the document (applied list stays empty).
+    [FixedAvaloniaFact(Timeout = 60000)]
+    public async Task ClearAllRedactionsCommand_ClearsPending_WithoutApplying()
+    {
+        var sourcePath = Path.Combine(_tempDir, "clear-source.pdf");
+        TestPdfGenerator.CreateSimpleTextPdf(sourcePath, "CLEARSECRET816");
+
+        var vm = new MainWindowViewModel();
+        var window = new MainWindow { DataContext = vm, Width = 1280, Height = 900 };
+        window.Show();
+        await vm.LoadDocumentAsync(sourcePath);
+
+        vm.RedactionWorkflow.MarkArea(PdfPageRect.FromContentPoints(1, new PdfRectangle(40, 660, 300, 740)), "a");
+        vm.RedactionWorkflow.MarkArea(PdfPageRect.FromContentPoints(1, new PdfRectangle(40, 400, 300, 480)), "b");
+        vm.RedactionWorkflow.PendingCount.Should().Be(2);
+
+        await vm.ClearAllRedactionsCommand!.Execute();
+
+        vm.RedactionWorkflow.PendingCount.Should().Be(0, "clear removes all pending redactions");
+        vm.RedactionWorkflow.AppliedCount.Should().Be(0, "clearing must not apply anything to the document");
+
+        window.Close();
+    }
+
+    // RemovePendingRedactionCommand: mark two, execute with one's Id, assert only
+    // that one is gone (the other remains).
+    [FixedAvaloniaFact(Timeout = 60000)]
+    public async Task RemovePendingRedactionCommand_RemovesOnlyTheTargetedPending()
+    {
+        var sourcePath = Path.Combine(_tempDir, "remove-source.pdf");
+        TestPdfGenerator.CreateSimpleTextPdf(sourcePath, "REMOVESECRET816");
+
+        var vm = new MainWindowViewModel();
+        var window = new MainWindow { DataContext = vm, Width = 1280, Height = 900 };
+        window.Show();
+        await vm.LoadDocumentAsync(sourcePath);
+
+        vm.RedactionWorkflow.MarkArea(PdfPageRect.FromContentPoints(1, new PdfRectangle(40, 660, 300, 740)), "first");
+        vm.RedactionWorkflow.MarkArea(PdfPageRect.FromContentPoints(1, new PdfRectangle(40, 400, 300, 480)), "second");
+        var toRemove = vm.RedactionWorkflow.PendingRedactions[0];
+        var toKeep = vm.RedactionWorkflow.PendingRedactions[1];
+
+        await vm.RemovePendingRedactionCommand!.Execute(toRemove.Id);
+
+        vm.RedactionWorkflow.PendingCount.Should().Be(1, "exactly one pending should be removed");
+        vm.RedactionWorkflow.PendingRedactions.Should().ContainSingle()
+            .Which.Id.Should().Be(toKeep.Id, "the pending that was NOT targeted must remain");
+
+        window.Close();
+    }
+
+    // ---------------------------------------------------------------------
+    // Search bar commands
+    // ---------------------------------------------------------------------
+
+    // FindCommand: execute with search text → matches are found/populated.
+    [FixedAvaloniaFact(Timeout = 60000)]
+    public async Task FindCommand_PopulatesMatches()
+    {
+        var (vm, window) = await OpenMultiPageAsync("find-source.pdf");
+        vm.SearchText = "Content"; // "Page N Content" appears once per page
+
+        await vm.FindCommand!.Execute();
+        await WaitForMatches(vm);
+
+        vm.SearchMatches.Count.Should().BeGreaterThanOrEqualTo(3,
+            "the manual Find command must find the search term on every page");
+        vm.CurrentSearchMatchIndex.Should().Be(0, "the first match is selected after a find");
+
+        window.Close();
+    }
+
+    // FindNextCommand / FindPreviousCommand: index advances and wraps correctly.
+    [FixedAvaloniaFact(Timeout = 60000)]
+    public async Task FindNextAndPreviousCommands_AdvanceAndWrapCurrentMatchIndex()
+    {
+        var (vm, window) = await OpenMultiPageAsync("findnav-source.pdf");
+        vm.SearchText = "Content";
+        await vm.FindCommand!.Execute();
+        await WaitForMatches(vm);
+
+        var total = vm.SearchMatches.Count;
+        total.Should().BeGreaterThanOrEqualTo(2, "need at least two matches to test navigation");
+        vm.CurrentSearchMatchIndex.Should().Be(0);
+
+        await vm.FindNextCommand!.Execute();
+        vm.CurrentSearchMatchIndex.Should().Be(1, "Find Next advances to the next match");
+
+        await vm.FindPreviousCommand!.Execute();
+        vm.CurrentSearchMatchIndex.Should().Be(0, "Find Previous steps back one match");
+
+        await vm.FindPreviousCommand!.Execute();
+        vm.CurrentSearchMatchIndex.Should().Be(total - 1, "Find Previous from the first match wraps to the last");
+
+        await vm.FindNextCommand!.Execute();
+        vm.CurrentSearchMatchIndex.Should().Be(0, "Find Next from the last match wraps back to the first");
+
+        window.Close();
+    }
+
+    // JumpToSearchMatchCommand: execute with a match on another page → current page
+    // changes to that match's page.
+    [FixedAvaloniaFact(Timeout = 60000)]
+    public async Task JumpToSearchMatchCommand_NavigatesToTheMatchPage()
+    {
+        var (vm, window) = await OpenMultiPageAsync("jump-source.pdf");
+        vm.SearchText = "Content";
+        await vm.FindCommand!.Execute();
+        await WaitForMatches(vm);
+
+        // A find auto-navigates to the FIRST match on a Background-priority post.
+        // Let that settle BEFORE we jump, or a late-firing auto-navigate could
+        // clobber CurrentPageIndex after our JumpTo and fail the assertion.
+        await SettleDispatcher();
+
+        // Pick a match on a page other than the current one.
+        var target = vm.SearchMatches.First(m => m.PageIndex != vm.CurrentPageIndex);
+        target.PageIndex.Should().NotBe(vm.CurrentPageIndex);
+
+        await vm.JumpToSearchMatchCommand!.Execute(target);
+
+        vm.CurrentPageIndex.Should().Be(target.PageIndex,
+            "jumping to a search match must navigate the viewer to that match's page");
+
+        window.Close();
+    }
+
+    // CloseSearchCommand: execute → IsSearchVisible == false and results cleared.
+    [FixedAvaloniaFact(Timeout = 60000)]
+    public async Task CloseSearchCommand_HidesSearchAndClearsResults()
+    {
+        var (vm, window) = await OpenMultiPageAsync("close-source.pdf");
+        vm.IsSearchVisible = true;
+        vm.SearchText = "Content";
+        await vm.FindCommand!.Execute();
+        await WaitForMatches(vm);
+        vm.SearchMatches.Count.Should().BeGreaterThan(0);
+
+        await vm.CloseSearchCommand!.Execute();
+
+        vm.IsSearchVisible.Should().BeFalse("Close Search hides the search bar");
+        vm.SearchMatches.Count.Should().Be(0, "Close Search clears the results");
+        vm.CurrentSearchMatchIndex.Should().Be(-1, "no match is selected after closing search");
+
+        window.Close();
+    }
+
+    // ---------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------
+
+    private async Task<(MainWindowViewModel Vm, MainWindow Window)> OpenMultiPageAsync(string fileName, int pageCount = 3)
+    {
+        var sourcePath = Path.Combine(_tempDir, fileName);
+        TestPdfGenerator.CreateMultiPagePdf(sourcePath, pageCount);
+        var vm = new MainWindowViewModel();
+        var window = new MainWindow { DataContext = vm, Width = 1280, Height = 900 };
+        window.Show();
+        await vm.LoadDocumentAsync(sourcePath);
+        return (vm, window);
+    }
+
+    private static async Task WaitForMatches(MainWindowViewModel vm, int timeoutMs = 20000)
+    {
+        var deadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);
+        while (DateTime.UtcNow < deadline)
+        {
+            if (vm.SearchMatches.Count > 0)
+                return;
+            await Task.Delay(100);
+        }
+    }
+
+    // Drain queued Background-priority dispatcher posts (e.g. the auto-navigate
+    // to the first search match) so they cannot fire after a later assertion.
+    private static async Task SettleDispatcher()
+    {
+        for (var i = 0; i < 6; i++)
+            await Task.Delay(100);
+    }
+
+    private static void CreateTwoTokenPdf(string path, string topSecret, string bottomSurvivor)
+    {
+        using var doc = PdfDocument.CreateNew();
+        var page = doc.Pages.AddBlank();
+        using var g = page.GetGraphics();
+        var font = PdfFont.Helvetica(18);
+        g.DrawString(topSecret, font, PdfBrush.Black, 100, 700);   // near the top (PDF y up)
+        g.DrawString(bottomSurvivor, font, PdfBrush.Black, 100, 120); // near the bottom, outside the marked area
+        g.Flush();
+        doc.Save(path);
+    }
+}

--- a/Excise.App/ViewModels/MainWindowViewModel.Redaction.cs
+++ b/Excise.App/ViewModels/MainWindowViewModel.Redaction.cs
@@ -122,21 +122,13 @@ public partial class MainWindowViewModel
         {
             var suggestedPath = _filenameSuggestionService.SuggestRedactedFilename(_currentFilePath);
 
-            var mainWindow = GetMainWindow();
-            if (mainWindow == null)
+            var saveFilePath = await ResolveRedactedSavePathAsync(suggestedPath);
+            if (saveFilePath == null)
             {
-                _logger.LogError("Could not get main window for dialog");
+                _logger.LogInformation("User cancelled save file picker (or no destination available)");
                 return;
             }
 
-            var saveFile = await ShowSaveRedactedFileDialog(mainWindow, suggestedPath);
-            if (saveFile == null)
-            {
-                _logger.LogInformation("User cancelled save file picker");
-                return;
-            }
-
-            var saveFilePath = saveFile.Path.LocalPath;
             _logger.LogInformation("Applying {Count} redactions to create: {Path}", RedactionWorkflow.PendingCount, saveFilePath);
 
             var document = _documentService.GetCurrentDocument();
@@ -283,6 +275,35 @@ public partial class MainWindowViewModel
             CurrentRedactionPageArea = null;
             _logger.LogInformation("<<< ApplyRedactionAsync END. Selection cleared, ready for next redaction.");
         }
+    }
+
+    // Test seam mirroring AppPaths.OverrideForTests: headless UI tests have no
+    // desktop-lifetime MainWindow and no interactive save picker, so the real
+    // ApplyAllRedactionsCommand cannot resolve a destination and would bail
+    // before the redaction pipeline runs. When set, this supplies the save
+    // destination directly (return null to model a cancelled picker). Every
+    // step after path resolution — PrepareRedactedCopy, document.Save,
+    // MoveToApplied, reload — runs unchanged. Unset in production, so behaviour
+    // is identical to the real save dialog. See RedactionAndSearchCommandTests.
+    private Func<string, Task<string?>>? _redactedSavePathProviderForTests;
+
+    internal void SetRedactedSavePathProviderForTests(Func<string, Task<string?>>? provider)
+        => _redactedSavePathProviderForTests = provider;
+
+    private async Task<string?> ResolveRedactedSavePathAsync(string suggestedPath)
+    {
+        if (_redactedSavePathProviderForTests != null)
+            return await _redactedSavePathProviderForTests(suggestedPath);
+
+        var mainWindow = GetMainWindow();
+        if (mainWindow == null)
+        {
+            _logger.LogError("Could not get main window for dialog");
+            return null;
+        }
+
+        var saveFile = await ShowSaveRedactedFileDialog(mainWindow, suggestedPath);
+        return saveFile?.Path.LocalPath;
     }
 
     private int ApplyPendingAreaRedactions(Excise.Core.Document.PdfDocument document)

--- a/Excise.App/ViewModels/MainWindowViewModel.cs
+++ b/Excise.App/ViewModels/MainWindowViewModel.cs
@@ -3339,9 +3339,21 @@ public partial class MainWindowViewModel : ViewModelBase
         return lifetime?.MainWindow;
     }
 
+    /// <summary>
+    /// Test seam (#816): the headless test host runs with no classic desktop
+    /// lifetime (<c>SetupWithoutStarting</c>), so <see cref="GetMainWindow"/>
+    /// always returns null and every file/save/export command that goes
+    /// through <see cref="GetStorageProvider"/> was previously untestable via
+    /// its actual command — only via the underlying method it eventually
+    /// calls with an already-known path. Setting this lets a test execute the
+    /// real ReactiveCommand end to end. Production code never sets it; the
+    /// real <see cref="GetMainWindow"/> path is used unless a test overrides it.
+    /// </summary>
+    public IStorageProvider? StorageProviderOverride { get; set; }
+
     private IStorageProvider? GetStorageProvider()
     {
-        return GetMainWindow()?.StorageProvider;
+        return StorageProviderOverride ?? GetMainWindow()?.StorageProvider;
     }
 
     private async Task<IStorageFile?> ShowSaveRedactedFileDialog(global::Avalonia.Controls.Window mainWindow, string suggestedPath)

--- a/Excise.App/ViewModels/MainWindowViewModel.cs
+++ b/Excise.App/ViewModels/MainWindowViewModel.cs
@@ -3261,40 +3261,65 @@ public partial class MainWindowViewModel : ViewModelBase
         _ = dialog.ShowDialog(owner);
     }
 
-    private async void ShowKeyboardShortcuts()
+    /// <summary>
+    /// Seam for #816: the real path calls <c>FAContentDialog.ShowAsync()</c>,
+    /// which is not a <see cref="global::Avalonia.Controls.Window"/> (it
+    /// renders into an overlay layer rather than
+    /// <c>Window.OwnedWindows</c>) and awaits until the user dismisses it —
+    /// there is no way for a headless test to observe or close it without
+    /// driving overlay/adorner internals that no other test in this suite
+    /// touches. Test-settable so <see cref="ShowShortcutsCommand"/> can be
+    /// executed for real and the constructed dialog inspected without
+    /// actually presenting/blocking on the overlay. Defaults to the real
+    /// show so production behaviour is unchanged.
+    /// </summary>
+    internal Action<FluentAvalonia.UI.Controls.FAContentDialog> KeyboardShortcutsDialogRequested { get; set; } =
+        dialog => _ = dialog.ShowAsync();
+
+    private void ShowKeyboardShortcuts()
     {
         _logger.LogInformation("Keyboard shortcuts dialog requested");
 
         var window = GetMainWindow();
-        if (window != null)
-        {
-            var messageBox = new FluentAvalonia.UI.Controls.FAContentDialog
-            {
-                Title = "Keyboard Shortcuts",
-                Content = "File:\n" +
-                          "  Ctrl+O - Open PDF\n" +
-                          "  Ctrl+S - Save\n" +
-                          "  Ctrl+Shift+S - Save As\n" +
-                          "  Ctrl+W - Close Document\n\n" +
-                          "Edit:\n" +
-                          "  Ctrl+F - Find\n" +
-                          "  F3 - Find Next\n" +
-                          "  Shift+F3 - Find Previous\n" +
-                          "  T - Toggle Text Selection Mode\n" +
-                          "  R - Toggle Redaction Mode\n\n" +
-                          "View:\n" +
-                          "  Ctrl++ - Zoom In\n" +
-                          "  Ctrl+- - Zoom Out\n" +
-                          "  Ctrl+0 - Actual Size\n\n" +
-                          "Navigation:\n" +
-                          "  PgUp/PgDn - Previous/Next Page",
-                CloseButtonText = "Close",
-                DefaultButton = FluentAvalonia.UI.Controls.FAContentDialogButton.Close
-            };
+        if (window == null) return;
 
-            await messageBox.ShowAsync();
-        }
+        var messageBox = new FluentAvalonia.UI.Controls.FAContentDialog
+        {
+            Title = "Keyboard Shortcuts",
+            Content = "File:\n" +
+                      "  Ctrl+O - Open PDF\n" +
+                      "  Ctrl+S - Save\n" +
+                      "  Ctrl+Shift+S - Save As\n" +
+                      "  Ctrl+W - Close Document\n\n" +
+                      "Edit:\n" +
+                      "  Ctrl+F - Find\n" +
+                      "  F3 - Find Next\n" +
+                      "  Shift+F3 - Find Previous\n" +
+                      "  T - Toggle Text Selection Mode\n" +
+                      "  R - Toggle Redaction Mode\n\n" +
+                      "View:\n" +
+                      "  Ctrl++ - Zoom In\n" +
+                      "  Ctrl+- - Zoom Out\n" +
+                      "  Ctrl+0 - Actual Size\n\n" +
+                      "Navigation:\n" +
+                      "  PgUp/PgDn - Previous/Next Page",
+            CloseButtonText = "Close",
+            DefaultButton = FluentAvalonia.UI.Controls.FAContentDialogButton.Close
+        };
+
+        KeyboardShortcutsDialogRequested(messageBox);
     }
+
+    /// <summary>
+    /// Seam for #816: the real path shells out to the OS default handler
+    /// (via <see cref="Services.UrlOpener"/>), which is not an observable
+    /// effect a headless test can assert on without actually launching a
+    /// real external app/browser. Test-settable so
+    /// <see cref="ShowDocumentationCommand"/> can be executed for real and
+    /// the open request asserted without that side effect. Defaults to the
+    /// real opener so production behaviour is unchanged.
+    /// </summary>
+    internal Action<string> DocumentationOpener { get; set; } = Services.UrlOpener.Open;
 
     private void ShowDocumentation()
     {
@@ -3304,26 +3329,9 @@ public partial class MainWindowViewModel : ViewModelBase
         {
             var readmePath = System.IO.Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "README.md");
 
-            if (System.IO.File.Exists(readmePath))
-            {
-                // Open README.md with default application
-                var psi = new System.Diagnostics.ProcessStartInfo
-                {
-                    FileName = readmePath,
-                    UseShellExecute = true
-                };
-                System.Diagnostics.Process.Start(psi);
-            }
-            else
-            {
-                // Fallback to GitHub repository
-                var psi = new System.Diagnostics.ProcessStartInfo
-                {
-                    FileName = "https://github.com/marctjones/excise",
-                    UseShellExecute = true
-                };
-                System.Diagnostics.Process.Start(psi);
-            }
+            DocumentationOpener(System.IO.File.Exists(readmePath)
+                ? readmePath
+                : "https://github.com/marctjones/excise");
         }
         catch (Exception ex)
         {
@@ -3331,13 +3339,32 @@ public partial class MainWindowViewModel : ViewModelBase
         }
     }
 
-    private global::Avalonia.Controls.Window? GetMainWindow()
+    /// <summary>
+    /// Seam for #816: dialog commands (Security/Preferences/About/…) resolve
+    /// their owner window through this, normally reading
+    /// <c>Application.Current.ApplicationLifetime</c>. Avalonia allows
+    /// <c>ApplicationLifetime</c> to be set exactly once — a headless test
+    /// cannot stand up a desktop lifetime after <c>SetupWithoutStarting</c>
+    /// has already initialized the app (attempting it throws
+    /// <see cref="InvalidOperationException"/>) — so without this seam the
+    /// real owner-window path is unreachable from a test and these
+    /// commands' dialogs go untested (see <see cref="GetMainWindow"/>'s
+    /// previous no-desktop-lifetime-in-headless-tests comment history).
+    /// Test-settable so the real command can be executed and the real
+    /// dialog window observed. Defaults to the real lookup so production
+    /// behaviour is unchanged.
+    /// </summary>
+    internal Func<global::Avalonia.Controls.Window?> MainWindowResolver { get; set; } = DefaultMainWindowResolver;
+
+    private static global::Avalonia.Controls.Window? DefaultMainWindowResolver()
     {
         var lifetime = global::Avalonia.Application.Current?.ApplicationLifetime
             as IClassicDesktopStyleApplicationLifetime;
 
         return lifetime?.MainWindow;
     }
+
+    private global::Avalonia.Controls.Window? GetMainWindow() => MainWindowResolver();
 
     private IStorageProvider? GetStorageProvider()
     {

--- a/Excise.App/ViewModels/MainWindowViewModel.cs
+++ b/Excise.App/ViewModels/MainWindowViewModel.cs
@@ -1333,40 +1333,14 @@ public partial class MainWindowViewModel : ViewModelBase
             return;
         }
 
-        var storageProvider = GetStorageProvider();
-        if (storageProvider == null)
-        {
-            _logger.LogWarning("Storage provider unavailable, cannot show Add Pages dialog");
-            return;
-        }
-
-        var files = await storageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
-        {
-            Title = "Select PDF to Add Pages From",
-            AllowMultiple = false,
-            FileTypeFilter = new[]
-            {
-                new FilePickerFileType("PDF Files")
-                {
-                    Patterns = new[] { "*.pdf" }
-                }
-            }
-        });
-
+        var files = await PickPdfFilesAsync("Select PDF to Add Pages From", allowMultiple: false);
         if (files.Count == 0)
         {
             _logger.LogInformation("Add pages dialog cancelled");
             return;
         }
 
-        var filePath = files[0].Path.LocalPath;
-        if (string.IsNullOrWhiteSpace(filePath))
-        {
-            _logger.LogWarning("Selected file has no local path");
-            return;
-        }
-
-        await AddPagesFromFileAsync(filePath);
+        await AddPagesFromFileAsync(files[0]);
     }
 
     public async Task AddPagesFromFileAsync(string sourcePdfPath)
@@ -1416,61 +1390,14 @@ public partial class MainWindowViewModel : ViewModelBase
     {
         _logger.LogInformation("Combine documents command triggered");
 
-        var storageProvider = GetStorageProvider();
-        if (storageProvider == null)
-        {
-            _logger.LogWarning("Storage provider unavailable, cannot show Combine Documents dialog");
-            return;
-        }
-
-        var files = await storageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
-        {
-            Title = "Select PDFs to Combine",
-            AllowMultiple = true,
-            FileTypeFilter = new[]
-            {
-                new FilePickerFileType("PDF Files")
-                {
-                    Patterns = new[] { "*.pdf" }
-                }
-            }
-        });
-
-        if (files.Count == 0)
+        var sourcePaths = await PickPdfFilesAsync("Select PDFs to Combine", allowMultiple: true);
+        if (sourcePaths.Count == 0)
         {
             _logger.LogInformation("Combine Documents dialog cancelled");
             return;
         }
 
-        var sourcePaths = files
-            .Select(f => f.Path.LocalPath)
-            .Where(p => !string.IsNullOrWhiteSpace(p))
-            .ToList();
-
-        if (sourcePaths.Count == 0)
-        {
-            _logger.LogWarning("No selected files have a local path");
-            return;
-        }
-
-        var outputFile = await storageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
-        {
-            Title = "Save Combined PDF",
-            DefaultExtension = "pdf",
-            SuggestedFileName = "combined.pdf",
-            FileTypeChoices = new[]
-            {
-                new FilePickerFileType("PDF Files")
-                {
-                    Patterns = new[] { "*.pdf" }
-                }
-            }
-        });
-
-        if (outputFile == null)
-            return;
-
-        var outputPath = outputFile.Path.LocalPath;
+        var outputPath = await PickSavePdfPathAsync("Save Combined PDF", "combined.pdf");
         if (string.IsNullOrWhiteSpace(outputPath))
             return;
 
@@ -1493,13 +1420,6 @@ public partial class MainWindowViewModel : ViewModelBase
         if (!_documentService.IsDocumentLoaded)
         {
             _logger.LogWarning("Cannot split: No document loaded");
-            return;
-        }
-
-        var storageProvider = GetStorageProvider();
-        if (storageProvider == null)
-        {
-            _logger.LogWarning("Storage provider unavailable, cannot show Split Document dialog");
             return;
         }
 
@@ -1557,22 +1477,10 @@ public partial class MainWindowViewModel : ViewModelBase
             return;
         }
 
-        var folder = await storageProvider.OpenFolderPickerAsync(new FolderPickerOpenOptions
-        {
-            Title = "Select Folder for Split PDFs",
-            AllowMultiple = false
-        });
-
-        if (folder.Count == 0)
-        {
-            _logger.LogInformation("Split Document dialog cancelled");
-            return;
-        }
-
-        var folderPath = folder[0].Path.LocalPath;
+        var folderPath = await PickFolderAsync("Select Folder for Split PDFs");
         if (string.IsNullOrWhiteSpace(folderPath))
         {
-            _logger.LogWarning("Split target folder has no local path");
+            _logger.LogInformation("Split Document dialog cancelled");
             return;
         }
 
@@ -1593,35 +1501,11 @@ public partial class MainWindowViewModel : ViewModelBase
         if (!_documentService.IsDocumentLoaded)
             return;
 
-        var storageProvider = GetStorageProvider();
-        if (storageProvider == null)
-        {
-            _logger.LogWarning("Storage provider unavailable, cannot show Extract Page dialog");
-            return;
-        }
-
         var suggestedName = string.IsNullOrWhiteSpace(DocumentName)
             ? $"page-{DisplayPageNumber}.pdf"
             : $"{Path.GetFileNameWithoutExtension(DocumentName)}_page{DisplayPageNumber}.pdf";
 
-        var file = await storageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
-        {
-            Title = "Extract Current Page",
-            DefaultExtension = "pdf",
-            SuggestedFileName = suggestedName,
-            FileTypeChoices = new[]
-            {
-                new FilePickerFileType("PDF Files")
-                {
-                    Patterns = new[] { "*.pdf" }
-                }
-            }
-        });
-
-        if (file == null)
-            return;
-
-        var path = file.Path.LocalPath;
+        var path = await PickSavePdfPathAsync("Extract Current Page", suggestedName);
         if (!string.IsNullOrWhiteSpace(path))
             await ExtractPagesToFileAsync(path, new[] { CurrentPageIndex });
     }
@@ -1649,35 +1533,11 @@ public partial class MainWindowViewModel : ViewModelBase
         if (!_documentService.IsDocumentLoaded || selected.Count == 0)
             return;
 
-        var storageProvider = GetStorageProvider();
-        if (storageProvider == null)
-        {
-            _logger.LogWarning("Storage provider unavailable, cannot show Extract Selected Pages dialog");
-            return;
-        }
-
         var suggestedName = string.IsNullOrWhiteSpace(DocumentName)
             ? "selected-pages.pdf"
             : $"{Path.GetFileNameWithoutExtension(DocumentName)}_selected_pages.pdf";
 
-        var file = await storageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
-        {
-            Title = "Extract Selected Pages",
-            DefaultExtension = "pdf",
-            SuggestedFileName = suggestedName,
-            FileTypeChoices = new[]
-            {
-                new FilePickerFileType("PDF Files")
-                {
-                    Patterns = new[] { "*.pdf" }
-                }
-            }
-        });
-
-        if (file == null)
-            return;
-
-        var path = file.Path.LocalPath;
+        var path = await PickSavePdfPathAsync("Extract Selected Pages", suggestedName);
         if (!string.IsNullOrWhiteSpace(path))
             await ExtractPagesToFileAsync(path, selected);
     }
@@ -1806,27 +1666,8 @@ public partial class MainWindowViewModel : ViewModelBase
 
     private async Task<string?> PickPdfForPageInsertionAsync(string title)
     {
-        var storageProvider = GetStorageProvider();
-        if (storageProvider == null)
-        {
-            _logger.LogWarning("Storage provider unavailable, cannot show page insertion dialog");
-            return null;
-        }
-
-        var files = await storageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
-        {
-            Title = title,
-            AllowMultiple = false,
-            FileTypeFilter = new[]
-            {
-                new FilePickerFileType("PDF Files")
-                {
-                    Patterns = new[] { "*.pdf" }
-                }
-            }
-        });
-
-        return files.Count == 0 ? null : files[0].Path.LocalPath;
+        var files = await PickPdfFilesAsync(title, allowMultiple: false);
+        return files.Count == 0 ? null : files[0];
     }
 
     private void MarkPageOrganizationChanged(bool removedPage = false, int removedPageCount = 1)
@@ -3342,6 +3183,118 @@ public partial class MainWindowViewModel : ViewModelBase
     private IStorageProvider? GetStorageProvider()
     {
         return GetMainWindow()?.StorageProvider;
+    }
+
+    // ── Test seams for the file/folder-picker page-organization commands (#816).
+    //    Headless tests have no desktop ApplicationLifetime (GetMainWindow →
+    //    null) AND Avalonia's IStorageProvider/IStorageFile are sealed against
+    //    user implementation, so a fake provider is impossible. Instead these
+    //    delegates intercept at the picked-PATH boundary: when set, the picker
+    //    helpers below return the injected paths and skip the real dialog,
+    //    letting a test drive the actual COMMAND end-to-end. All null in
+    //    production — the real storage provider is always used. ────────────────
+    internal Func<bool, Task<IReadOnlyList<string>>>? PickPdfFilesOverride { get; set; }
+    internal Func<Task<string?>>? PickSavePdfPathOverride { get; set; }
+    internal Func<Task<string?>>? PickFolderOverride { get; set; }
+
+    /// <summary>
+    /// Shows the "open PDF(s)" picker and returns the selected local paths, or
+    /// an empty list if cancelled / unavailable. Honors
+    /// <see cref="PickPdfFilesOverride"/> in tests.
+    /// </summary>
+    private async Task<IReadOnlyList<string>> PickPdfFilesAsync(string title, bool allowMultiple)
+    {
+        if (PickPdfFilesOverride != null)
+            return await PickPdfFilesOverride(allowMultiple);
+
+        var storageProvider = GetStorageProvider();
+        if (storageProvider == null)
+        {
+            _logger.LogWarning("Storage provider unavailable, cannot show open-PDF dialog");
+            return Array.Empty<string>();
+        }
+
+        var files = await storageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
+        {
+            Title = title,
+            AllowMultiple = allowMultiple,
+            FileTypeFilter = new[]
+            {
+                new FilePickerFileType("PDF Files")
+                {
+                    Patterns = new[] { "*.pdf" }
+                }
+            }
+        });
+
+        return files
+            .Select(f => f.Path.LocalPath)
+            .Where(p => !string.IsNullOrWhiteSpace(p))
+            .ToList();
+    }
+
+    /// <summary>
+    /// Shows the "save PDF as" picker and returns the chosen local path, or
+    /// null if cancelled / unavailable. Honors
+    /// <see cref="PickSavePdfPathOverride"/> in tests.
+    /// </summary>
+    private async Task<string?> PickSavePdfPathAsync(string title, string suggestedName)
+    {
+        if (PickSavePdfPathOverride != null)
+            return await PickSavePdfPathOverride();
+
+        var storageProvider = GetStorageProvider();
+        if (storageProvider == null)
+        {
+            _logger.LogWarning("Storage provider unavailable, cannot show save-PDF dialog");
+            return null;
+        }
+
+        var file = await storageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
+        {
+            Title = title,
+            DefaultExtension = "pdf",
+            SuggestedFileName = suggestedName,
+            FileTypeChoices = new[]
+            {
+                new FilePickerFileType("PDF Files")
+                {
+                    Patterns = new[] { "*.pdf" }
+                }
+            }
+        });
+
+        var path = file?.Path.LocalPath;
+        return string.IsNullOrWhiteSpace(path) ? null : path;
+    }
+
+    /// <summary>
+    /// Shows the folder picker and returns the chosen local path, or null if
+    /// cancelled / unavailable. Honors <see cref="PickFolderOverride"/> in tests.
+    /// </summary>
+    private async Task<string?> PickFolderAsync(string title)
+    {
+        if (PickFolderOverride != null)
+            return await PickFolderOverride();
+
+        var storageProvider = GetStorageProvider();
+        if (storageProvider == null)
+        {
+            _logger.LogWarning("Storage provider unavailable, cannot show folder dialog");
+            return null;
+        }
+
+        var folder = await storageProvider.OpenFolderPickerAsync(new FolderPickerOpenOptions
+        {
+            Title = title,
+            AllowMultiple = false
+        });
+
+        if (folder.Count == 0)
+            return null;
+
+        var path = folder[0].Path.LocalPath;
+        return string.IsNullOrWhiteSpace(path) ? null : path;
     }
 
     private async Task<IStorageFile?> ShowSaveRedactedFileDialog(global::Avalonia.Controls.Window mainWindow, string suggestedPath)

--- a/tests/skip-allowlist/Excise.App.Tests.txt
+++ b/tests/skip-allowlist/Excise.App.Tests.txt
@@ -51,5 +51,6 @@ Excise.App.Tests.Unit.SignatureApplicationServiceTests.SignDocument_ExternalOrac
 # Independent-oracle GUI tests gated on mutool (absent on Linux CI); they run on macOS.
 Excise.App.Tests.UI.TypewriterWorkflowTests.SaveFileAsAsync_TypedText_IsReadBackByAnIndependentExtractor
 Excise.App.Tests.Unit.SignatureApplicationServiceTests.SignDocument_VisibleRect_IndependentRendererShowsInkInSignatureRect_AndStillVerifies
+Excise.App.Tests.UI.RedactionAndSearchCommandTests.ApplyAllRedactionsCommand_RedactedSecret_NotReadableByIndependentExtractor   # #816: mutool independent-extractor oracle for ApplyAllRedactionsCommand. The always-on SavedBytesOracle sibling test (carrier-agnostic byte scan + in-file negative control) still runs on CI, so removal is still independently verified without mutool.
 # Permission-gated test needing a restricted fixture absent on Linux CI.
 Excise.App.Tests.UI.TypewriterWorkflowTests.OnTypewriterTextCreated_ModifyForbidden_AddsNothing


### PR DESCRIPTION
Integration of the four #816 GUI-coverage batches (#818/#819/#820/#821) into one CI cycle. Each adds execute-the-real-command-and-assert-the-effect headless-Avalonia tests (not the underlying method):
- **Batch 1** page-org (Combine/Split/Insert/Extract/Move/Remove/RotateLeft/180)
- **Batch 2** file ops (Open/Recent/Save/SaveAs/Flatten/Export/Print) + StorageProviderOverride seam
- **Batch 3** redaction-button (Apply/ApplyAll/Clear/RemovePending — independent saved-bytes+mutool oracles, mutation-tested) + search-bar (Find/Next/Prev/Jump/Close)
- **Batch 4** annotate/style (Highlight/StickyNote/SetColor) + dialogs (Verify/Security/Prefs/About/Shortcuts/Docs) + ZoomFitPage (fixed vacuous assertion) + GoToPage

No mis-wired commands found across all four; one dead-code finding (ApplyRedactionAsync legacy branch). Test seams added are null-by-default (production unchanged). One merge conflict resolved in MainWindowViewModel.cs (kept both StorageProviderOverride + GetMainWindow=>MainWindowResolver). Closes the false-coverage class that hid #815.

Supersedes PRs #818/#819/#820/#821.