### PR TITLE
feat(about): complete third-party license coverage + completeness gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ semantic versioning.
 ## [Unreleased]
 
 ### Added
+- **About dialog now carries a completeness-gated third-party license
+  manifest** — the About dialog already listed every shipped NuGet package
+  (name, version, SPDX id, copyright, verbatim license text) from the embedded
+  `Excise.App/Assets/third-party-licenses.json`, but nothing guaranteed the
+  list stayed complete. A new compliance gate
+  (`Excise.App.Tests/Unit/ThirdPartyLicenseCompletenessTests.cs`) enumerates
+  the actual restored package closure via
+  `dotnet list package --include-transitive` — an independent source, so the
+  manifest cannot vouch for its own completeness — and fails the build if any
+  shipped package is missing an attribution or carries an unresolved license.
+  Two previously-unresolved licenses were filled: `BitMiracle.LibJpeg.NET`
+  (BSD-3-Clause, from its bundled `license.txt`) and `CSJ2K` (BSD, with the
+  JJ2000 copyright notice embedded verbatim). Two reference-only packages that
+  ship no runtime DLL (`Microsoft.NETCore.Platforms`, `NETStandard.Library`)
+  are excluded as non-redistributed, in both the generator and the gate. The
+  headless About-window test now also asserts the verbatim license text is
+  reachable in the dialog, not just present in the ViewModel.
 - **Interactive GUI tests for file-ops toolbar/menu commands** (#816 batch 2)
   — `Excise.App.Tests/UI/FileOpsCommandTests.cs` executes the real
   `ReactiveCommand` behind Save/SaveAs/SaveFlattenedFormCopy/Open/LoadRecent/

--- a/Excise.App.Tests/UI/AboutWindowTests.cs
+++ b/Excise.App.Tests/UI/AboutWindowTests.cs
@@ -62,6 +62,23 @@ public class AboutWindowTests
         detail!.Children.Count.Should().BeGreaterThan(1,
             "selecting a package must repaint the detail pane (header + license text at minimum)");
 
+        // Compliance needs the verbatim license TEXT reachable in the dialog,
+        // not merely present in the ViewModel. Select a package that bundles
+        // license text and assert the detail pane surfaces it in a (copyable)
+        // TextBox.
+        var vm = (AboutWindowViewModel)window.DataContext!;
+        var withText = vm.Packages.FirstOrDefault(p => !string.IsNullOrWhiteSpace(p.LicenseText));
+        withText.Should().NotBeNull(
+            "at least one shipped package must carry embedded verbatim license text");
+
+        list.SelectedItem = withText;
+        var licenseBox = detail.Children.OfType<TextBox>().LastOrDefault();
+        licenseBox.Should().NotBeNull("the detail pane must render the license text in a TextBox");
+        licenseBox!.Text.Should().Be(withText!.LicenseText,
+            "the rendered license text must be the package's verbatim notice");
+        licenseBox.Text!.Length.Should().BeGreaterThan(100,
+            "a bundled license notice is substantial text, not a stub");
+
         window.Close();
     }
 }

--- a/Excise.App.Tests/Unit/ThirdPartyLicenseCompletenessTests.cs
+++ b/Excise.App.Tests/Unit/ThirdPartyLicenseCompletenessTests.cs
@@ -1,0 +1,162 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using AwesomeAssertions;
+using Excise.App.ViewModels;
+using Xunit;
+
+namespace Excise.App.Tests.Unit;
+
+/// <summary>
+/// Open-source license COMPLIANCE GATE.
+///
+/// Every third-party NuGet package that Excise.App actually ships must have a
+/// resolved license entry in the embedded <c>third-party-licenses.json</c>
+/// manifest that the About dialog surfaces. This test is the guarantee that a
+/// future dependency cannot be added — directly or transitively — without its
+/// attribution appearing in the About dialog.
+///
+/// It enumerates the ACTUAL restored package closure via
+/// <c>dotnet list package --include-transitive</c> — an independent source, so
+/// the manifest is not permitted to vouch for its own completeness — and fails
+/// if any shipped package is missing from the manifest or carries an
+/// unresolved license.
+///
+/// The exclude set below MUST mirror the one in
+/// <c>scripts/generate-license-manifest.sh</c>. Both list only build-time
+/// tooling and reference-only packages that carry no runtime DLL and are
+/// therefore not redistributed with the app.
+/// </summary>
+public class ThirdPartyLicenseCompletenessTests
+{
+    private static readonly HashSet<string> ExcludedPackages = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "Avalonia.Diagnostics",
+        "Microsoft.CodeAnalysis.Analyzers",
+        "Avalonia.BuildServices",
+        "Fody",
+        "Microsoft.NETCore.Platforms",
+        "NETStandard.Library",
+    };
+
+    [Fact]
+    public void EveryShippedPackage_HasResolvedLicenseEntry()
+    {
+        var closure = ResolvePackageClosure();
+        closure.Should().NotBeEmpty(
+            "dotnet list package must report the Excise.App dependency closure");
+
+        var vm = new AboutWindowViewModel();
+        vm.Packages.Should().NotBeEmpty("the embedded license manifest must load");
+
+        var resolvedIds = vm.Packages
+            .Where(p => !string.IsNullOrEmpty(p.Id) && HasResolvedLicense(p))
+            .Select(p => p.Id!)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var missing = closure
+            .Where(id => !ExcludedPackages.Contains(id))
+            .Where(id => !resolvedIds.Contains(id))
+            .OrderBy(id => id, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        missing.Should().BeEmpty(
+            "every shipped package must appear in Excise.App/Assets/third-party-licenses.json with a " +
+            "resolved license — regenerate via scripts/generate-license-manifest.sh (add a LICENSE_OVERRIDES " +
+            "entry if the license cannot be auto-detected). Packages missing an attribution: {0}",
+            string.Join(", ", missing));
+    }
+
+    [Fact]
+    public void NoManifestEntry_HasUnresolvedLicense()
+    {
+        var vm = new AboutWindowViewModel();
+        vm.Packages.Should().NotBeEmpty();
+
+        var unresolved = vm.Packages
+            .Where(p => !HasResolvedLicense(p))
+            .Select(p => $"{p.Id} {p.Version}")
+            .ToList();
+
+        unresolved.Should().BeEmpty(
+            "every manifest entry must carry a resolved license identity (an SPDX id or a real license " +
+            "name — not the '(see licenseUrl)' placeholder). Unresolved: {0}",
+            string.Join(", ", unresolved));
+    }
+
+    /// <summary>
+    /// A license is "resolved" when the entry names a license the user can
+    /// act on: an SPDX id, or a human-readable license name that is not the
+    /// generator's "(see licenseUrl)" placeholder. A bare URL is not an
+    /// attribution and does not count.
+    /// </summary>
+    private static bool HasResolvedLicense(ThirdPartyPackage p)
+    {
+        if (!string.IsNullOrWhiteSpace(p.Spdx)) return true;
+        if (string.IsNullOrWhiteSpace(p.LicenseName)) return false;
+        return !p.LicenseName!.Trim().Equals("(see licenseUrl)", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static List<string> ResolvePackageClosure()
+    {
+        var csproj = Path.Combine(FindRepoRoot(), "Excise.App", "Excise.App.csproj");
+        File.Exists(csproj).Should().BeTrue($"expected the GUI project at {csproj}");
+
+        var psi = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        psi.ArgumentList.Add("list");
+        psi.ArgumentList.Add(csproj);
+        psi.ArgumentList.Add("package");
+        psi.ArgumentList.Add("--include-transitive");
+        psi.ArgumentList.Add("--format");
+        psi.ArgumentList.Add("json");
+
+        using var proc = Process.Start(psi)
+            ?? throw new InvalidOperationException("Failed to start 'dotnet list package'");
+        var stdout = proc.StandardOutput.ReadToEnd();
+        var stderr = proc.StandardError.ReadToEnd();
+        proc.WaitForExit(120_000).Should().BeTrue("dotnet list package should finish promptly");
+        proc.ExitCode.Should().Be(0, $"dotnet list package failed: {stderr}");
+
+        var ids = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        using var json = JsonDocument.Parse(stdout);
+        foreach (var project in json.RootElement.GetProperty("projects").EnumerateArray())
+        {
+            if (!project.TryGetProperty("frameworks", out var fws) || fws.ValueKind != JsonValueKind.Array)
+                continue;
+            foreach (var fw in fws.EnumerateArray())
+            {
+                foreach (var kind in new[] { "topLevelPackages", "transitivePackages" })
+                {
+                    if (!fw.TryGetProperty(kind, out var arr) || arr.ValueKind != JsonValueKind.Array)
+                        continue;
+                    foreach (var pkg in arr.EnumerateArray())
+                    {
+                        if (pkg.TryGetProperty("id", out var idEl) && idEl.GetString() is { } id)
+                            ids.Add(id);
+                    }
+                }
+            }
+        }
+        return ids.ToList();
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "excise.sln")))
+                return dir.FullName;
+            dir = dir.Parent;
+        }
+        throw new DirectoryNotFoundException("Could not find repository root from test base directory.");
+    }
+}

--- a/Excise.App/Assets/third-party-licenses.json
+++ b/Excise.App/Assets/third-party-licenses.json
@@ -1,10 +1,10 @@
 {
-  "generatedAt": "2026-07-04T08:38:11.783700Z",
+  "generatedAt": "2026-07-27T21:31:13.406266Z",
   "project": "Excise.App/Excise.App.csproj",
   "packages": [
     {
       "id": "Avalonia",
-      "version": "12.0.4",
+      "version": "12.0.5",
       "authors": "Avalonia Team",
       "copyright": "Copyright 2013-2026 \u00a9 The AvaloniaUI Project",
       "projectUrl": "https://avaloniaui.net/?utm_source=nuget&utm_medium=referral&utm_content=project_homepage_link",
@@ -14,7 +14,7 @@
       "licenseValue": "MIT",
       "licenseUrl": "https://licenses.nuget.org/MIT",
       "nugetId": "Avalonia",
-      "nugetVersion": "12.0.4",
+      "nugetVersion": "12.0.5",
       "spdx": "MIT",
       "licenseName": "MIT License",
       "licenseSpdxUrl": "https://spdx.org/licenses/MIT.html"
@@ -73,7 +73,7 @@
     },
     {
       "id": "Avalonia.Desktop",
-      "version": "12.0.4",
+      "version": "12.0.5",
       "authors": "Avalonia Team",
       "copyright": "Copyright 2013-2026 \u00a9 The AvaloniaUI Project",
       "projectUrl": "https://avaloniaui.net/?utm_source=nuget&utm_medium=referral&utm_content=project_homepage_link",
@@ -83,14 +83,14 @@
       "licenseValue": "MIT",
       "licenseUrl": "https://licenses.nuget.org/MIT",
       "nugetId": "Avalonia.Desktop",
-      "nugetVersion": "12.0.4",
+      "nugetVersion": "12.0.5",
       "spdx": "MIT",
       "licenseName": "MIT License",
       "licenseSpdxUrl": "https://spdx.org/licenses/MIT.html"
     },
     {
       "id": "Avalonia.Fonts.Inter",
-      "version": "12.0.4",
+      "version": "12.0.5",
       "authors": "Avalonia Team",
       "copyright": "Copyright 2013-2026 \u00a9 The AvaloniaUI Project",
       "projectUrl": "https://avaloniaui.net/?utm_source=nuget&utm_medium=referral&utm_content=project_homepage_link",
@@ -100,14 +100,14 @@
       "licenseValue": "MIT",
       "licenseUrl": "https://licenses.nuget.org/MIT",
       "nugetId": "Avalonia.Fonts.Inter",
-      "nugetVersion": "12.0.4",
+      "nugetVersion": "12.0.5",
       "spdx": "MIT",
       "licenseName": "MIT License",
       "licenseSpdxUrl": "https://spdx.org/licenses/MIT.html"
     },
     {
       "id": "Avalonia.FreeDesktop",
-      "version": "12.0.4",
+      "version": "12.0.5",
       "authors": "Avalonia Team",
       "copyright": "Copyright 2013-2026 \u00a9 The AvaloniaUI Project",
       "projectUrl": "https://avaloniaui.net/?utm_source=nuget&utm_medium=referral&utm_content=project_homepage_link",
@@ -117,14 +117,14 @@
       "licenseValue": "MIT",
       "licenseUrl": "https://licenses.nuget.org/MIT",
       "nugetId": "Avalonia.FreeDesktop",
-      "nugetVersion": "12.0.4",
+      "nugetVersion": "12.0.5",
       "spdx": "MIT",
       "licenseName": "MIT License",
       "licenseSpdxUrl": "https://spdx.org/licenses/MIT.html"
     },
     {
       "id": "Avalonia.FreeDesktop.AtSpi",
-      "version": "12.0.4",
+      "version": "12.0.5",
       "authors": "Avalonia Team",
       "copyright": "Copyright 2013-2026 \u00a9 The AvaloniaUI Project",
       "projectUrl": "https://avaloniaui.net/?utm_source=nuget&utm_medium=referral&utm_content=project_homepage_link",
@@ -134,14 +134,14 @@
       "licenseValue": "MIT",
       "licenseUrl": "https://licenses.nuget.org/MIT",
       "nugetId": "Avalonia.FreeDesktop.AtSpi",
-      "nugetVersion": "12.0.4",
+      "nugetVersion": "12.0.5",
       "spdx": "MIT",
       "licenseName": "MIT License",
       "licenseSpdxUrl": "https://spdx.org/licenses/MIT.html"
     },
     {
       "id": "Avalonia.HarfBuzz",
-      "version": "12.0.4",
+      "version": "12.0.5",
       "authors": "Avalonia Team",
       "copyright": "Copyright 2013-2026 \u00a9 The AvaloniaUI Project",
       "projectUrl": "https://avaloniaui.net/?utm_source=nuget&utm_medium=referral&utm_content=project_homepage_link",
@@ -151,14 +151,14 @@
       "licenseValue": "MIT",
       "licenseUrl": "https://licenses.nuget.org/MIT",
       "nugetId": "Avalonia.HarfBuzz",
-      "nugetVersion": "12.0.4",
+      "nugetVersion": "12.0.5",
       "spdx": "MIT",
       "licenseName": "MIT License",
       "licenseSpdxUrl": "https://spdx.org/licenses/MIT.html"
     },
     {
       "id": "Avalonia.Native",
-      "version": "12.0.4",
+      "version": "12.0.5",
       "authors": "Avalonia Team",
       "copyright": "Copyright 2013-2026 \u00a9 The AvaloniaUI Project",
       "projectUrl": "https://avaloniaui.net/?utm_source=nuget&utm_medium=referral&utm_content=project_homepage_link",
@@ -168,14 +168,14 @@
       "licenseValue": "MIT",
       "licenseUrl": "https://licenses.nuget.org/MIT",
       "nugetId": "Avalonia.Native",
-      "nugetVersion": "12.0.4",
+      "nugetVersion": "12.0.5",
       "spdx": "MIT",
       "licenseName": "MIT License",
       "licenseSpdxUrl": "https://spdx.org/licenses/MIT.html"
     },
     {
       "id": "Avalonia.Remote.Protocol",
-      "version": "12.0.4",
+      "version": "12.0.5",
       "authors": "Avalonia Team",
       "copyright": "Copyright 2013-2026 \u00a9 The AvaloniaUI Project",
       "projectUrl": "https://avaloniaui.net/?utm_source=nuget&utm_medium=referral&utm_content=project_homepage_link",
@@ -185,14 +185,14 @@
       "licenseValue": "MIT",
       "licenseUrl": "https://licenses.nuget.org/MIT",
       "nugetId": "Avalonia.Remote.Protocol",
-      "nugetVersion": "12.0.4",
+      "nugetVersion": "12.0.5",
       "spdx": "MIT",
       "licenseName": "MIT License",
       "licenseSpdxUrl": "https://spdx.org/licenses/MIT.html"
     },
     {
       "id": "Avalonia.Skia",
-      "version": "12.0.4",
+      "version": "12.0.5",
       "authors": "Avalonia Team",
       "copyright": "Copyright 2013-2026 \u00a9 The AvaloniaUI Project",
       "projectUrl": "https://avaloniaui.net/?utm_source=nuget&utm_medium=referral&utm_content=project_homepage_link",
@@ -202,14 +202,14 @@
       "licenseValue": "MIT",
       "licenseUrl": "https://licenses.nuget.org/MIT",
       "nugetId": "Avalonia.Skia",
-      "nugetVersion": "12.0.4",
+      "nugetVersion": "12.0.5",
       "spdx": "MIT",
       "licenseName": "MIT License",
       "licenseSpdxUrl": "https://spdx.org/licenses/MIT.html"
     },
     {
       "id": "Avalonia.Themes.Fluent",
-      "version": "12.0.4",
+      "version": "12.0.5",
       "authors": "Avalonia Team",
       "copyright": "Copyright 2013-2026 \u00a9 The AvaloniaUI Project",
       "projectUrl": "https://avaloniaui.net/?utm_source=nuget&utm_medium=referral&utm_content=project_homepage_link",
@@ -219,14 +219,14 @@
       "licenseValue": "MIT",
       "licenseUrl": "https://licenses.nuget.org/MIT",
       "nugetId": "Avalonia.Themes.Fluent",
-      "nugetVersion": "12.0.4",
+      "nugetVersion": "12.0.5",
       "spdx": "MIT",
       "licenseName": "MIT License",
       "licenseSpdxUrl": "https://spdx.org/licenses/MIT.html"
     },
     {
       "id": "Avalonia.Win32",
-      "version": "12.0.4",
+      "version": "12.0.5",
       "authors": "Avalonia Team",
       "copyright": "Copyright 2013-2026 \u00a9 The AvaloniaUI Project",
       "projectUrl": "https://avaloniaui.net/?utm_source=nuget&utm_medium=referral&utm_content=project_homepage_link",
@@ -236,14 +236,14 @@
       "licenseValue": "MIT",
       "licenseUrl": "https://licenses.nuget.org/MIT",
       "nugetId": "Avalonia.Win32",
-      "nugetVersion": "12.0.4",
+      "nugetVersion": "12.0.5",
       "spdx": "MIT",
       "licenseName": "MIT License",
       "licenseSpdxUrl": "https://spdx.org/licenses/MIT.html"
     },
     {
       "id": "Avalonia.X11",
-      "version": "12.0.4",
+      "version": "12.0.5",
       "authors": "Avalonia Team",
       "copyright": "Copyright 2013-2026 \u00a9 The AvaloniaUI Project",
       "projectUrl": "https://avaloniaui.net/?utm_source=nuget&utm_medium=referral&utm_content=project_homepage_link",
@@ -253,7 +253,7 @@
       "licenseValue": "MIT",
       "licenseUrl": "https://licenses.nuget.org/MIT",
       "nugetId": "Avalonia.X11",
-      "nugetVersion": "12.0.4",
+      "nugetVersion": "12.0.5",
       "spdx": "MIT",
       "licenseName": "MIT License",
       "licenseSpdxUrl": "https://spdx.org/licenses/MIT.html"
@@ -274,7 +274,9 @@
       "licenseFileName": "LICENSE.txt",
       "licenseFileSha1": "7dd2a42ee1d6593623b9e7ffadb48b7b9aabd9c5",
       "licenseText": "**LibJpeg.Net**\n\nCopyright (c) 2008-2020, Bit Miracle\n\nAll rights reserved.\n\nRedistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: \n\n* Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. \n* Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution. \n* Neither the name of the Bit Miracle nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission. \n\nTHIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS \"AS IS\" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BIT MIRACLE BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. \n\n---\n**NOTE**\n\nThis software is based in part on the\n\nThe Independent JPEG Group's JPEG software\n\nhttp://www.ijg.org/\n\nCopyright (C) 1991-1998, Thomas G. Lane.\n\n---",
-      "licenseName": "(see licenseUrl)"
+      "licenseName": "BSD 3-Clause License",
+      "spdx": "BSD-3-Clause",
+      "licenseSpdxUrl": "https://spdx.org/licenses/BSD-3-Clause.html"
     },
     {
       "id": "BouncyCastle.Cryptography",
@@ -309,7 +311,8 @@
       "licenseUrl": "http://www.opensource.org/licenses/bsd-license.php",
       "nugetId": "CSJ2K",
       "nugetVersion": "3.0.0",
-      "licenseName": "(see licenseUrl)"
+      "licenseName": "BSD License (CSJ2K / JJ2000)",
+      "licenseText": "CSJ2K is licensed under the BSD License.\n\nCopyright (c) 1999-2000 JJ2000 Partners; original C# port (c) 2007-2012\nJason S. Clary; C# encoding and adaptation to Portable Class Library with\nplatform specific support (c) 2013-2018 Anders Gustafsson, Cureos AB.\n\nLicensed and distributable under the terms of the BSD license:\nhttp://www.opensource.org/licenses/bsd-license.php\n\n----------------------------------------------------------------------\nThe JPEG 2000 core (JJ2000) carries the following copyright notice, which\nmust be included in all copies or derivative works of this software module:\n\nCOPYRIGHT:\n\nThis software module was originally developed by Rapha\u00ebl Grosbois and\nDiego Santa Cruz (Swiss Federal Institute of Technology-EPFL); Joel\nAskel\u00f6f (Ericsson Radio Systems AB); and Bertrand Berthelot, David\nBouchard, F\u00e9lix Henry, Gerard Mozelle and Patrice Onno (Canon Research\nCentre France S.A) in the course of development of the JPEG2000 standard\nas specified by ISO/IEC 15444 (JPEG 2000 Standard). This software module\nis an implementation of a part of the JPEG 2000 Standard. Swiss Federal\nInstitute of Technology-EPFL, Ericsson Radio Systems AB and Canon Research\nCentre France S.A (collectively JJ2000 Partners) agree not to assert\nagainst ISO/IEC and users of the JPEG 2000 Standard (Users) any of their\nrights under the copyright, not including other intellectual property\nrights, for this software module with respect to the usage by ISO/IEC and\nUsers of this software module or modifications thereof for use in hardware\nor software products claiming conformance to the JPEG 2000 Standard. Those\nintending to use this software module in hardware or software products are\nadvised that their use may infringe existing patents. The original\ndevelopers of this software module, JJ2000 Partners and ISO/IEC assume no\nliability for use of this software module or modifications thereof. No\nlicense or right to this software module is granted for non JPEG 2000\nStandard conforming products. JJ2000 Partners have full right to use this\nsoftware module for his/her own purpose, assign or donate this software\nmodule to any third party and to inhibit third parties from using this\nsoftware module for non JPEG 2000 Standard conforming products. This\ncopyright notice must be included in all copies or derivative works of\nthis software module.\n\nCopyright (c) 1999/2000 JJ2000 Partners."
     },
     {
       "id": "DynamicData",
@@ -752,36 +755,6 @@
       "licenseSpdxUrl": "https://spdx.org/licenses/MIT.html"
     },
     {
-      "id": "Microsoft.NETCore.Platforms",
-      "version": "1.1.0",
-      "authors": "Microsoft",
-      "copyright": "\u00a9 Microsoft Corporation.  All rights reserved.",
-      "projectUrl": "https://dot.net/",
-      "repositoryUrl": null,
-      "description": "Provides runtime information required to resolve target framework, platform, and runtime specific implementations of .NETCore packages. \nWhen using NuGet 3.x this package requires at least version 3.4.",
-      "licenseKind": null,
-      "licenseValue": null,
-      "licenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
-      "nugetId": "Microsoft.NETCore.Platforms",
-      "nugetVersion": "1.1.0",
-      "licenseName": "(see licenseUrl)"
-    },
-    {
-      "id": "NETStandard.Library",
-      "version": "1.6.1",
-      "authors": "Microsoft",
-      "copyright": "\u00a9 Microsoft Corporation.  All rights reserved.",
-      "projectUrl": "https://dot.net/",
-      "repositoryUrl": null,
-      "description": "A set of standard .NET APIs that are prescribed to be used and supported together. This includes all of the APIs in the NETStandard.Platform package plus additional libraries that are core to .NET but built on top of NETStandard.Platform. \nWhen using NuGet 3.x this package requires at least version 3.4.",
-      "licenseKind": null,
-      "licenseValue": null,
-      "licenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
-      "nugetId": "NETStandard.Library",
-      "nugetVersion": "1.6.1",
-      "licenseName": "(see licenseUrl)"
-    },
-    {
       "id": "ReactiveUI",
       "version": "23.2.28",
       "authors": ".NET Foundation and Contributors",
@@ -794,23 +767,6 @@
       "licenseUrl": "https://licenses.nuget.org/MIT",
       "nugetId": "ReactiveUI",
       "nugetVersion": "23.2.28",
-      "spdx": "MIT",
-      "licenseName": "MIT License",
-      "licenseSpdxUrl": "https://spdx.org/licenses/MIT.html"
-    },
-    {
-      "id": "ReactiveUI.Avalonia",
-      "version": "12.0.3",
-      "authors": "ReactiveUI and Avalonia Teams, and Contributors",
-      "copyright": "Copyright (c) 2019-2026 ReactiveUI and Avalonia Teams, and Contributors",
-      "projectUrl": "https://reactiveui.net/",
-      "repositoryUrl": "https://github.com/reactiveui/reactiveui",
-      "description": "Contains the ReactiveUI platform specific extensions for Avalonia",
-      "licenseKind": "expression",
-      "licenseValue": "MIT",
-      "licenseUrl": "https://licenses.nuget.org/MIT",
-      "nugetId": "ReactiveUI.Avalonia",
-      "nugetVersion": "12.0.3",
       "spdx": "MIT",
       "licenseName": "MIT License",
       "licenseSpdxUrl": "https://spdx.org/licenses/MIT.html"

--- a/LICENSES.md
+++ b/LICENSES.md
@@ -16,6 +16,17 @@ is available three ways:
 All runtime dependencies use **permissive** licenses (MIT, Apache-2.0,
 BSD-3-Clause, OFL-1.1). No copyleft (GPL/LGPL/AGPL).
 
+Completeness is enforced in CI:
+`Excise.App.Tests/Unit/ThirdPartyLicenseCompletenessTests.cs` re-enumerates the
+actual restored package closure (`dotnet list package --include-transitive`)
+and fails the build if any shipped package is missing an attribution or carries
+an unresolved license — so a new dependency cannot ship without appearing in the
+About dialog. Build-time tooling and reference-only packages that carry no
+runtime DLL (`Microsoft.NETCore.Platforms`, `NETStandard.Library`,
+`Avalonia.Diagnostics`, `Microsoft.CodeAnalysis.Analyzers`,
+`Avalonia.BuildServices`, `Fody`) are excluded as non-redistributed, in both
+the generator and the completeness gate.
+
 The script `scripts/generate-license-manifest.sh --scancode` cross-checks
 each package against [scancode-toolkit](https://scancode-toolkit.readthedocs.io/)
 to verify that the license declared in the package metadata matches the
@@ -55,7 +66,7 @@ scripts/generate-license-manifest.sh
 
 # Verified: also runs scancode-toolkit to cross-check the declared
 # license against the actual license text in each package. Slower
-# (~10 minutes for 54 packages) but produces evidence-backed results.
+# (~10 minutes for the full package set) but produces evidence-backed results.
 scripts/generate-license-manifest.sh --scancode
 
 # Both write to:

--- a/scripts/generate-license-manifest.sh
+++ b/scripts/generate-license-manifest.sh
@@ -82,6 +82,8 @@ EXCLUDE_PATTERNS=(
     'Microsoft.CodeAnalysis.Analyzers'   # build-time analyzer
     'Avalonia.BuildServices'              # build-time
     'Fody'                                # build-time weaver
+    'Microsoft.NETCore.Platforms'         # reference-only: ships runtime.json, no runtime DLL
+    'NETStandard.Library'                 # reference-only meta-package, no runtime DLL
 )
 
 echo "▶ Building manifest"
@@ -99,6 +101,13 @@ exclude = set([
     "Microsoft.CodeAnalysis.Analyzers",
     "Avalonia.BuildServices",
     "Fody",
+    # Reference-only packages that carry no runtime DLL and are therefore
+    # not redistributed in the app. NETStandard.Library is a meta-package;
+    # Microsoft.NETCore.Platforms ships only runtime.json. Excluding them
+    # also sidesteps their legacy .NET Library EULA licenseUrl (LinkId=329770),
+    # which is not an SPDX-resolvable license for attribution purposes.
+    "Microsoft.NETCore.Platforms",
+    "NETStandard.Library",
 ])
 
 # A few packages don't ship a LICENSE file but use SPDX-only metadata;
@@ -121,6 +130,54 @@ SCANCODE_FALSE_POSITIVES = {
     "Portable.BouncyCastle": ["LicenseRef-scancode-proprietary-license"],
 }
 
+# CSJ2K's NuGet package ships no LICENSE file — only a licenseUrl pointing
+# at the generic OSI BSD page. The wrapper is BSD-licensed and the JPEG 2000
+# core (JJ2000) carries a specific copyright notice that BSD-style
+# redistribution requires we reproduce. Both are embedded here verbatim so
+# the About dialog can satisfy the attribution obligation offline.
+CSJ2K_LICENSE_TEXT = '''CSJ2K is licensed under the BSD License.
+
+Copyright (c) 1999-2000 JJ2000 Partners; original C# port (c) 2007-2012
+Jason S. Clary; C# encoding and adaptation to Portable Class Library with
+platform specific support (c) 2013-2018 Anders Gustafsson, Cureos AB.
+
+Licensed and distributable under the terms of the BSD license:
+http://www.opensource.org/licenses/bsd-license.php
+
+----------------------------------------------------------------------
+The JPEG 2000 core (JJ2000) carries the following copyright notice, which
+must be included in all copies or derivative works of this software module:
+
+COPYRIGHT:
+
+This software module was originally developed by Raphaël Grosbois and
+Diego Santa Cruz (Swiss Federal Institute of Technology-EPFL); Joel
+Askelöf (Ericsson Radio Systems AB); and Bertrand Berthelot, David
+Bouchard, Félix Henry, Gerard Mozelle and Patrice Onno (Canon Research
+Centre France S.A) in the course of development of the JPEG2000 standard
+as specified by ISO/IEC 15444 (JPEG 2000 Standard). This software module
+is an implementation of a part of the JPEG 2000 Standard. Swiss Federal
+Institute of Technology-EPFL, Ericsson Radio Systems AB and Canon Research
+Centre France S.A (collectively JJ2000 Partners) agree not to assert
+against ISO/IEC and users of the JPEG 2000 Standard (Users) any of their
+rights under the copyright, not including other intellectual property
+rights, for this software module with respect to the usage by ISO/IEC and
+Users of this software module or modifications thereof for use in hardware
+or software products claiming conformance to the JPEG 2000 Standard. Those
+intending to use this software module in hardware or software products are
+advised that their use may infringe existing patents. The original
+developers of this software module, JJ2000 Partners and ISO/IEC assume no
+liability for use of this software module or modifications thereof. No
+license or right to this software module is granted for non JPEG 2000
+Standard conforming products. JJ2000 Partners have full right to use this
+software module for his/her own purpose, assign or donate this software
+module to any third party and to inhibit third parties from using this
+software module for non JPEG 2000 Standard conforming products. This
+copyright notice must be included in all copies or derivative works of
+this software module.
+
+Copyright (c) 1999/2000 JJ2000 Partners.'''
+
 # Manual license-name overrides — packages whose .nuspec lacks an SPDX
 # expression but whose actual license is known and stable. Keyed by
 # package id.
@@ -132,6 +189,19 @@ LICENSE_OVERRIDES = {
         "licenseName": "MIT License (BouncyCastle)",
         "spdx": "MIT",
         "licenseSpdxUrl": "https://www.bouncycastle.org/csharp/licence.html",
+    },
+    # BitMiracle.LibJpeg.NET bundles a verbatim 3-clause BSD license.txt
+    # (captured as licenseText) but declares only a legacy licenseUrl, so
+    # the SPDX id has to be set explicitly.
+    "BitMiracle.LibJpeg.NET": {
+        "licenseName": "BSD 3-Clause License",
+        "spdx": "BSD-3-Clause",
+        "licenseSpdxUrl": "https://spdx.org/licenses/BSD-3-Clause.html",
+    },
+    # CSJ2K ships no LICENSE file; embed the BSD notice + JJ2000 copyright.
+    "CSJ2K": {
+        "licenseName": "BSD License (CSJ2K / JJ2000)",
+        "licenseText": CSJ2K_LICENSE_TEXT,
     },
 }
 


### PR DESCRIPTION
## Summary

Makes the About dialog's third-party-license reporting **complete and self-guarding** for every bundled library, and adds a compliance gate so it can't silently regress.

The manifest/dialog infrastructure **already existed on develop** (embedded `Excise.App/Assets/third-party-licenses.json`, `AboutWindowViewModel`, master/detail `AboutWindow`, and `scripts/generate-license-manifest.sh`). What was missing was the guarantee of completeness and two unresolved licenses. This PR adds the delta.

## How the manifest is enumerated + bundled

`scripts/generate-license-manifest.sh` resolves the GUI's full package closure via `dotnet list package --include-transitive`, reads each package's `.nuspec` (SPDX / copyright / URL) and bundled `LICENSE*` file text from the NuGet cache, and writes `Excise.App/Assets/third-party-licenses.json`. That JSON is an `<EmbeddedResource>` the About dialog loads at runtime and renders name / version / SPDX / copyright / **verbatim license text** (in a copyable TextBox) per package. Auto-generated over a hand-list so a new dependency shows up automatically.

## Completeness test (the compliance guarantee)

`Excise.App.Tests/Unit/ThirdPartyLicenseCompletenessTests.cs`:
- Re-enumerates the **actual restored closure** with `dotnet list package --include-transitive` — an **independent source**, so the manifest cannot vouch for its own completeness.
- **Fails** if any shipped package (matched by ID) is absent from the manifest, or if any entry has an **unresolved** license (`spdx == null` and `licenseName` null or the `(see licenseUrl)` placeholder — a bare URL is not an attribution).
- Excludes only build-time tooling + reference-only packages (mirrored with the generator).
- Verified it *bites*: run against develop's stale manifest it fails, flagging exactly `BitMiracle.LibJpeg.NET` and `CSJ2K`.

The headless `AboutWindowTests` now also asserts the verbatim license text is reachable in the dialog, not merely in the ViewModel.

## Libraries covered

All 55 shipped packages: Avalonia (+ Controls.DataGrid/ColorPicker/Desktop/Fonts.Inter/Themes.Fluent/native assets), FluentAvaloniaUI, ReactiveUI/DynamicData/Splat/System.Reactive, SkiaSharp (+ natives), HarfBuzzSharp (+ natives), BouncyCastle.Cryptography, BitMiracle.LibJpeg.NET, CSJ2K, Microsoft.CodeAnalysis.CSharp.Scripting, Microsoft.Extensions.*, MicroCom, Tmds.DBus.

## Gap-fills

- **BitMiracle.LibJpeg.NET** → BSD-3-Clause (from its bundled `license.txt`; SPDX set via override).
- **CSJ2K** → BSD; embedded the JJ2000 copyright notice verbatim. **`spdx` left null on purpose**: the package's only pointer is the OSI `bsd-license.php` URL, ambiguous between BSD-2/BSD-3, so the verbatim text is authoritative rather than a guessed token.
- **Microsoft.NETCore.Platforms** and **NETStandard.Library** → excluded as reference-only (no runtime DLL; also sidesteps their legacy .NET Library EULA `licenseUrl`).

## Note on the manifest diff

Regenerating also corrected a **stale Avalonia 12.0.4 → 12.0.5** drift across ~12 packages — develop's committed manifest predated the csproj bump to 12.0.5, so the dialog was misreporting the shipped version. This is a correction, not a dependency change.

## Unresolvable licenses

None. Every shipped package resolves to a license identity + attribution. (CSJ2K carries a real license name + embedded text but no clean SPDX token, by the decision above.)

## Testing
- Full `Excise.App.Tests` (foreground, serial): **1161 passed, 0 failed, 26 skipped**, no host crash.
- `scripts/test-tier.sh t0`: all green (build, core/cli/avalonia tests, doc-claims, gate-asymmetry, redaction-architecture, testdata-sync, skip-budget).
- Build: 0 warnings, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)