### PR TITLE
feat(viewer): Ctrl+wheel zoom + middle-button pan (#827 batch C)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ semantic versioning.
 ## [Unreleased]
 
 ### Added
+- **Ctrl+wheel zoom and middle-button pan in the PDF viewer** (#827) — the viewer
+  now handles the mouse wheel directly: **Ctrl (or ⌘) + wheel** zooms in/out
+  (reusing the existing 25%-step, min/max-clamped zoom), while a **plain wheel**
+  still scrolls natively and is never consumed. **Middle-button drag** pans the
+  active ScrollViewer (single-page or continuous) grab-and-drag style, available
+  in any interaction mode. Previously no `PointerWheelChanged` handler existed
+  (Ctrl+wheel was unimplemented) and `InteractionMode.Pan` was dead. New
+  real-gesture tests drive `window.MouseWheel` / middle-button `MouseDown`+drag
+  and assert `ZoomLevel`, scroll offset, and continuous page-boundary sync — the
+  legacy `LineDown()`/`ZoomInCommand`-invoke tests are superseded. Handlers are
+  registered on the Tunnel pass so Ctrl+wheel can suppress the native scroll;
+  plain scrolling, existing zoom shortcuts, and fit-on-resize are unchanged.
 - **Copied-text whitespace fidelity: paragraph + list awareness, as the default**
   — copying text now inserts a blank line at detected **paragraph** breaks (a
   vertical gap meaningfully larger than the block's typical leading) and keeps

--- a/Excise.App.Tests/UI/MouseInputTests.cs
+++ b/Excise.App.Tests/UI/MouseInputTests.cs
@@ -343,6 +343,194 @@ public class MouseInputTests
             "Ctrl+scroll up must increase zoom level");
     }
 
+    // ---- #827 batch C: real gesture wheel/pan/zoom coverage --------------
+    // MouseWheelScrollDown / CtrlWheelZoom above are the legacy command-invoke
+    // (LineDown / ZoomInCommand) versions kept for history. The ones below
+    // drive REAL wheel/pointer gestures via window.MouseWheel / MouseDown so
+    // they exercise the viewer's PointerWheelChanged and middle-button pan
+    // handlers added for #827. Confirmed headless: window.MouseWheel routes to
+    // our Tunnel handler, plain wheel drives native ScrollViewer scroll, and
+    // window.MouseDown(Middle)+MouseMove delivers the pan drag — no raised-event
+    // fallback was needed.
+
+    private static readonly Point ViewerCenter = new(640, 450);
+
+    private static async Task<(MainWindowViewModel vm, MainWindow window, PdfViewerControl viewer)>
+        OpenBookAsync()
+    {
+        var vm = new MainWindowViewModel();
+        var window = new MainWindow { DataContext = vm, Width = 1280, Height = 900 };
+        window.Show();
+        await Task.Delay(200);
+        await vm.LoadDocumentAsync(PragmaticBook!);
+        await Task.Delay(300);
+        window.UpdateLayout();
+        var viewer = window.FindControl<PdfViewerControl>("PdfViewerControl");
+        viewer.Should().NotBeNull();
+        return (vm, window, viewer!);
+    }
+
+    private static async Task<ScrollViewer> WaitForContinuousLaidOutAsync(
+        MainWindow window, PdfViewerControl viewer)
+    {
+        var sv = FindNamedDescendant<ScrollViewer>(viewer, "ContinuousScrollViewer");
+        sv.Should().NotBeNull();
+        var deadline = DateTime.UtcNow.AddSeconds(30);
+        while (DateTime.UtcNow < deadline && sv!.Extent.Height <= 0)
+        {
+            await Task.Delay(150);
+            window.UpdateLayout();
+        }
+        sv!.Extent.Height.Should().BeGreaterThan(0, "continuous content must be laid out");
+        return sv;
+    }
+
+    [FixedAvaloniaFact]
+    public async Task CtrlWheelUp_RealGesture_ZoomsIn()
+    {
+        Assert.SkipWhen(!File.Exists(PragmaticBook), "Pragmatic book corpus fixture not available locally.");
+        var (_, window, viewer) = await OpenBookAsync();
+
+        var before = viewer.ZoomLevel;
+        await Dispatcher.UIThread.InvokeAsync(() =>
+            window.MouseWheel(ViewerCenter, new Vector(0, 1), RawInputModifiers.Control));
+        await Task.Delay(150);
+        window.UpdateLayout();
+
+        _out.WriteLine($"CtrlWheelUp zoom {before} -> {viewer.ZoomLevel}");
+        viewer.ZoomLevel.Should().BeGreaterThan(before,
+            "a real Ctrl+wheel-up gesture must route to PointerWheelChanged and zoom in");
+    }
+
+    [FixedAvaloniaFact]
+    public async Task CtrlWheelDown_RealGesture_ZoomsOut()
+    {
+        Assert.SkipWhen(!File.Exists(PragmaticBook), "Pragmatic book corpus fixture not available locally.");
+        var (_, window, viewer) = await OpenBookAsync();
+
+        // Zoom in first so there is room to zoom back out (fit-width may start low).
+        await Dispatcher.UIThread.InvokeAsync(() =>
+            window.MouseWheel(ViewerCenter, new Vector(0, 1), RawInputModifiers.Control));
+        await Task.Delay(150);
+        window.UpdateLayout();
+        var mid = viewer.ZoomLevel;
+
+        await Dispatcher.UIThread.InvokeAsync(() =>
+            window.MouseWheel(ViewerCenter, new Vector(0, -1), RawInputModifiers.Control));
+        await Task.Delay(150);
+        window.UpdateLayout();
+
+        _out.WriteLine($"CtrlWheelDown zoom {mid} -> {viewer.ZoomLevel}");
+        viewer.ZoomLevel.Should().BeLessThan(mid,
+            "a real Ctrl+wheel-down gesture must zoom out");
+    }
+
+    [FixedAvaloniaFact]
+    public async Task PlainWheel_RealGesture_ScrollsAndDoesNotZoom()
+    {
+        Assert.SkipWhen(!File.Exists(PragmaticBook), "Pragmatic book corpus fixture not available locally.");
+        var (vm, window, viewer) = await OpenBookAsync();
+        vm.IsContinuousView.Should().BeTrue("continuous scroll is the app's default view mode");
+        var sv = await WaitForContinuousLaidOutAsync(window, viewer);
+
+        var zoomBefore = viewer.ZoomLevel;
+        var offsetBefore = sv.Offset;
+
+        // Plain wheel (no modifier) scrolling down must move the ScrollViewer
+        // offset and must NOT change zoom.
+        for (int i = 0; i < 3; i++)
+        {
+            await Dispatcher.UIThread.InvokeAsync(() =>
+                window.MouseWheel(ViewerCenter, new Vector(0, -1), RawInputModifiers.None));
+            await Task.Delay(80);
+            window.UpdateLayout();
+        }
+
+        _out.WriteLine($"PlainWheel offset {offsetBefore} -> {sv.Offset}, zoom {zoomBefore} -> {viewer.ZoomLevel}");
+        sv.Offset.Y.Should().BeGreaterThan(offsetBefore.Y,
+            "a plain wheel gesture must scroll natively (offset increases), not be consumed by zoom");
+        viewer.ZoomLevel.Should().Be(zoomBefore,
+            "a plain (no-Ctrl) wheel gesture must not change zoom");
+    }
+
+    [FixedAvaloniaFact]
+    public async Task ContinuousScrollPastPageBoundary_UpdatesCurrentPage()
+    {
+        Assert.SkipWhen(!File.Exists(PragmaticBook), "Pragmatic book corpus fixture not available locally.");
+        var (_, window, viewer) = await OpenBookAsync();
+        var sv = await WaitForContinuousLaidOutAsync(window, viewer);
+
+        viewer.CurrentPage.Should().Be(1);
+
+        // Drive a real scroll offset well past the first page boundary. Setting
+        // Offset is the same mechanism the scrollbar/wheel drive; it fires the
+        // OffsetProperty subscription that syncs CurrentPage.
+        await Dispatcher.UIThread.InvokeAsync(() =>
+            sv.Offset = new Vector(sv.Offset.X, 2000));
+        var deadline = DateTime.UtcNow.AddSeconds(10);
+        while (DateTime.UtcNow < deadline && viewer.CurrentPage == 1)
+        {
+            await Task.Delay(120);
+            window.UpdateLayout();
+        }
+
+        _out.WriteLine($"After scroll past boundary CurrentPage={viewer.CurrentPage}");
+        viewer.CurrentPage.Should().BeGreaterThan(1,
+            "scrolling the continuous offset past a page boundary must advance CurrentPage");
+    }
+
+    [FixedAvaloniaFact]
+    public async Task MiddleButtonDrag_RealGesture_PansScrollOffset()
+    {
+        Assert.SkipWhen(!File.Exists(PragmaticBook), "Pragmatic book corpus fixture not available locally.");
+        var (_, window, viewer) = await OpenBookAsync();
+        var sv = await WaitForContinuousLaidOutAsync(window, viewer);
+
+        var before = sv.Offset;
+
+        // Middle-button press, drag the pointer UP, release. Grabbing and
+        // dragging up reveals content below, so the offset increases.
+        await Dispatcher.UIThread.InvokeAsync(() =>
+        {
+            window.MouseDown(ViewerCenter, MouseButton.Middle);
+            window.MouseMove(new Point(ViewerCenter.X, ViewerCenter.Y - 120),
+                RawInputModifiers.MiddleMouseButton);
+            window.MouseMove(new Point(ViewerCenter.X, ViewerCenter.Y - 250),
+                RawInputModifiers.MiddleMouseButton);
+            window.MouseUp(new Point(ViewerCenter.X, ViewerCenter.Y - 250), MouseButton.Middle);
+        });
+        await Task.Delay(150);
+        window.UpdateLayout();
+
+        _out.WriteLine($"MiddleDrag offset {before} -> {sv.Offset}");
+        sv.Offset.Y.Should().BeGreaterThan(before.Y,
+            "a middle-button drag upward must pan the ScrollViewer offset down");
+    }
+
+    [FixedAvaloniaFact]
+    public async Task FitOnResize_RecomputesZoom()
+    {
+        Assert.SkipWhen(!File.Exists(PragmaticBook), "Pragmatic book corpus fixture not available locally.");
+        var vm = new MainWindowViewModel();
+        await vm.LoadDocumentAsync(PragmaticBook!);
+        await Task.Delay(200);
+
+        // Default fit mode is FitWidth. Setting the viewport width drives
+        // ReapplyFitModeIfNeeded, which recomputes ZoomLevel from the width.
+        vm.ViewportHeight = 900;
+        vm.ViewportWidth = 700;
+        await Task.Delay(50);
+        var zoomNarrow = vm.ZoomLevel;
+
+        vm.ViewportWidth = 1300;
+        await Task.Delay(50);
+        var zoomWide = vm.ZoomLevel;
+
+        _out.WriteLine($"FitOnResize zoom@700={zoomNarrow} zoom@1300={zoomWide}");
+        zoomWide.Should().BeGreaterThan(zoomNarrow,
+            "a wider viewport under an active FitWidth mode must recompute a larger zoom via ReapplyFitModeIfNeeded");
+    }
+
     #endregion
 
     #region Drag Operations

--- a/Excise.Avalonia/Controls/PdfViewerControl.Interaction.cs
+++ b/Excise.Avalonia/Controls/PdfViewerControl.Interaction.cs
@@ -22,6 +22,11 @@ public partial class PdfViewerControl
         if (IsTypewriterOverlayEvent(e))
             return;
 
+        // Middle-button is reserved for pan (#827, handled in the dedicated pan
+        // handlers). Never let it start a redaction/selection drag.
+        if (e.GetCurrentPoint(this).Properties.IsMiddleButtonPressed)
+            return;
+
         // First chance: internal-link click in any mode (including None).
         // Links are treated as ambient affordances — like a browser, not
         // a drawing tool — so the redaction/text-selection mode shouldn't

--- a/Excise.Avalonia/Controls/PdfViewerControl.WheelPan.cs
+++ b/Excise.Avalonia/Controls/PdfViewerControl.WheelPan.cs
@@ -1,0 +1,99 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+
+namespace Excise.Avalonia.Controls;
+
+public partial class PdfViewerControl
+{
+    #region Wheel zoom + middle-button pan (#827)
+
+    // Pan gesture state. Pan is an ambient middle-button-drag gesture available
+    // in every InteractionMode (it is NOT tied to the dead InteractionMode.Pan
+    // enum value — that value is left in place for a possible future explicit
+    // hand-tool). Grabbing the page and dragging moves the active ScrollViewer's
+    // offset so the content follows the pointer (browser "grab" convention).
+    private bool _isPanning;
+    private Point _panStartPointer;
+    private Vector _panStartOffset;
+
+    /// <summary>
+    /// The ScrollViewer that currently owns the viewport — the continuous
+    /// stack in Continuous mode, otherwise the single-page scroller.
+    /// </summary>
+    private ScrollViewer? ActiveScrollViewer =>
+        ViewMode == PdfViewMode.Continuous && _continuousScrollViewer != null
+            ? _continuousScrollViewer
+            : _scrollViewer;
+
+    /// <summary>
+    /// Ctrl (or Meta/⌘) + wheel zooms; a plain wheel is left untouched so the
+    /// ScrollViewer scrolls natively. Registered on the Tunnel pass at the root
+    /// so it runs before the inner ScrollViewer's wheel handler; marking the
+    /// event Handled for the zoom case suppresses the native scroll.
+    /// </summary>
+    private void OnViewerPointerWheelChanged(object? sender, PointerWheelEventArgs e)
+    {
+        bool zoomModifier = e.KeyModifiers.HasFlag(KeyModifiers.Control) ||
+                            e.KeyModifiers.HasFlag(KeyModifiers.Meta);
+        if (!zoomModifier)
+            return; // plain wheel → let the ScrollViewer scroll normally
+
+        if (e.Delta.Y > 0)
+            ZoomIn();
+        else if (e.Delta.Y < 0)
+            ZoomOut();
+        else
+            return;
+
+        // Consumed: stop the ScrollViewer from also scrolling on this wheel tick.
+        e.Handled = true;
+    }
+
+    private void OnPanPointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (!e.GetCurrentPoint(this).Properties.IsMiddleButtonPressed)
+            return;
+
+        var scroller = ActiveScrollViewer;
+        if (scroller == null)
+            return;
+
+        _isPanning = true;
+        _panStartPointer = e.GetPosition(this);
+        _panStartOffset = scroller.Offset;
+        e.Pointer.Capture(this);
+        Cursor = new Cursor(StandardCursorType.SizeAll);
+        e.Handled = true;
+    }
+
+    private void OnPanPointerMoved(object? sender, PointerEventArgs e)
+    {
+        if (!_isPanning)
+            return;
+
+        var scroller = ActiveScrollViewer;
+        if (scroller == null)
+            return;
+
+        // Content follows the pointer: dragging down reveals content above, so
+        // the offset moves opposite to the pointer delta.
+        var current = e.GetPosition(this);
+        var delta = current - _panStartPointer;
+        scroller.Offset = _panStartOffset - delta;
+        e.Handled = true;
+    }
+
+    private void OnPanPointerReleased(object? sender, PointerReleasedEventArgs e)
+    {
+        if (!_isPanning)
+            return;
+
+        _isPanning = false;
+        e.Pointer.Capture(null);
+        Cursor = Cursor.Default;
+        e.Handled = true;
+    }
+
+    #endregion
+}

--- a/Excise.Avalonia/Controls/PdfViewerControl.axaml.cs
+++ b/Excise.Avalonia/Controls/PdfViewerControl.axaml.cs
@@ -891,6 +891,24 @@ public partial class PdfViewerControl : UserControl
             global::Avalonia.Interactivity.RoutingStrategies.Tunnel | global::Avalonia.Interactivity.RoutingStrategies.Bubble,
             handledEventsToo: false);
 
+        // Wheel-zoom and middle-button pan (#827). Registered on Tunnel ONLY so
+        // the root sees the gesture before the inner ScrollViewer's own bubble
+        // handler — letting us suppress native scroll for Ctrl+wheel by marking
+        // the event Handled. Tunnel-only (not Tunnel|Bubble) deliberately: the
+        // #675 double-fire came from registering both passes.
+        AddHandler(PointerWheelChangedEvent, OnViewerPointerWheelChanged,
+            global::Avalonia.Interactivity.RoutingStrategies.Tunnel,
+            handledEventsToo: true);
+        AddHandler(PointerPressedEvent, OnPanPointerPressed,
+            global::Avalonia.Interactivity.RoutingStrategies.Tunnel,
+            handledEventsToo: true);
+        AddHandler(PointerMovedEvent, OnPanPointerMoved,
+            global::Avalonia.Interactivity.RoutingStrategies.Tunnel,
+            handledEventsToo: true);
+        AddHandler(PointerReleasedEvent, OnPanPointerReleased,
+            global::Avalonia.Interactivity.RoutingStrategies.Tunnel,
+            handledEventsToo: true);
+
         // Surface viewport changes (scrollbars appearing/disappearing,
         // sidebars toggling, window resizes). Subscribe directly to the
         // ScrollViewer's Viewport AvaloniaProperty — it raises only on


### PR DESCRIPTION
Implements the SCROLL/ZOOM/PAN feature gaps from #827 (batch C).

## Feature gaps implemented
- **Ctrl+wheel zoom** — adds the first real `PointerWheelChanged` handler to
  `PdfViewerControl`. Ctrl (or ⌘/Meta) + wheel zooms in/out, reusing the
  existing `ZoomIn()`/`ZoomOut()` (25% step, clamped 0.1–5.0, fit-mode aware).
  Plain wheel is left untouched so native scrolling still works. Registered on
  the **Tunnel** pass at the root so it runs before the inner ScrollViewer and
  can mark the event Handled to suppress native scroll for the zoom case only
  (Tunnel-only, avoiding the #675 double-fire). Works in single-page and
  continuous views (root-level handler covers both scrollers).
- **Middle-button pan** — middle-button drag pans the active ScrollViewer
  (single-page or continuous) grab-and-drag style, in any interaction mode. A
  one-line middle-button guard in the existing press handler stops it starting
  a redaction/selection drag. `InteractionMode.Pan` is intentionally left in
  place (documented) for a possible future explicit hand-tool — pan is an
  ambient gesture, so **no public-enum change and no approved.txt regen**.

## Real-gesture tests (Excise.App.Tests/UI/MouseInputTests.cs)
Drive real gestures via `window.MouseWheel` / middle-button `MouseDown`+drag —
no `LineDown()`/command-invoke bypasses:
- `CtrlWheelUp_RealGesture_ZoomsIn` / `CtrlWheelDown_RealGesture_ZoomsOut`
- `PlainWheel_RealGesture_ScrollsAndDoesNotZoom` (offset moves, zoom unchanged)
- `ContinuousScrollPastPageBoundary_UpdatesCurrentPage`
- `MiddleButtonDrag_RealGesture_PansScrollOffset`
- `FitOnResize_RecomputesZoom` (exercises `ReapplyFitModeIfNeeded`)

The legacy `MouseWheelScrollDown`/`CtrlWheelZoom` (LineDown/ZoomInCommand)
tests are kept and stay green.

## Gates
- Full **Excise.App.Tests** foreground: 1202 passed, 26 skipped, 0 failed, no host crash.
- **Excise.Avalonia.Tests**: 88 passed (public API approval intact).
- **test-tier.sh t0**: all green. Build: 0 warnings.

Touches only `Excise.Avalonia/Controls/PdfViewerControl.*` (+ new
`PdfViewerControl.WheelPan.cs`) and tests; no batch-A/B production touched.

STOP — do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)